### PR TITLE
fix(autofix): Use dict instead of model_dump when fetching state

### DIFF
--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -34,8 +34,7 @@ class ContinuationState(LocalMemoryState[AutofixContinuation]):
             # )
             # TODO: This is only temp, remove this
             group_state = AutofixGroupState(status=AutofixStatus.PROCESSING)
-            logger.info(f"Loaded group_state: {group_state!r}")
-            self.val = self.val.model_copy(update=group_state.model_dump())
+            self.val = self.val.model_copy(update=dict(group_state))
             return True
         except HTTPError as e:
             if e.response.status_code == 404:

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -34,6 +34,7 @@ class ContinuationState(LocalMemoryState[AutofixContinuation]):
             # )
             # TODO: This is only temp, remove this
             group_state = AutofixGroupState(status=AutofixStatus.PROCESSING)
+            logger.info(f"Loaded group_state: {group_state!r}")
             self.val = self.val.model_copy(update=dict(group_state))
             return True
         except HTTPError as e:


### PR DESCRIPTION
`model_dump` will serialize the sub fields which we don't want here, use `dict(model)` instead to pass the fields without serializing them: https://docs.pydantic.dev/latest/concepts/serialization/#dictmodel-and-iteration

`model_copy(update=...` does not validate/re-instantiate the fields passed to it