### PR TITLE
feat(autofix): Include stacktrace frame variables

### DIFF
--- a/src/seer/automation/autofix/autofix.py
+++ b/src/seer/automation/autofix/autofix.py
@@ -68,7 +68,6 @@ class Autofix(Pipeline):
                 autofix_logger.info(f"Problem is not actionable")
                 return
 
-            print("request.repos", request.repos)
             for repo in request.repos:
                 self.context.event_manager.send_codebase_indexing_repo_check_message(repo.full_name)
                 if self.context.has_codebase_index(repo):

--- a/src/seer/automation/autofix/components/assessment/component.py
+++ b/src/seer/automation/autofix/components/assessment/component.py
@@ -18,7 +18,7 @@ class ProblemDiscoveryComponent(BaseComponent[ProblemDiscoveryRequest, ProblemDi
     def __init__(self, context: AutofixContext):
         super().__init__(context)
 
-    @traceable(name="Problem Discovery", run_type="llm", tags=["problem_discovery:v1.1"])
+    @traceable(name="Problem Discovery", run_type="llm", tags=["problem_discovery:v1.2"])
     def invoke(self, request: ProblemDiscoveryRequest) -> ProblemDiscoveryOutput | None:
         with self.context.state.update() as cur:
             gpt_client = GptClient()

--- a/src/seer/automation/autofix/components/assessment/component.py
+++ b/src/seer/automation/autofix/components/assessment/component.py
@@ -42,8 +42,6 @@ class ProblemDiscoveryComponent(BaseComponent[ProblemDiscoveryRequest, ProblemDi
                 ],
             )
 
-            print("cur", cur)
-
             cur.usage += usage
 
             if data is None:

--- a/src/seer/automation/autofix/components/assessment/component.py
+++ b/src/seer/automation/autofix/components/assessment/component.py
@@ -42,6 +42,8 @@ class ProblemDiscoveryComponent(BaseComponent[ProblemDiscoveryRequest, ProblemDi
                 ],
             )
 
+            print("cur", cur)
+
             cur.usage += usage
 
             if data is None:

--- a/src/seer/automation/autofix/components/executor/component.py
+++ b/src/seer/automation/autofix/components/executor/component.py
@@ -15,7 +15,7 @@ class ExecutorComponent(BaseComponent[ExecutorRequest, ExecutorOutput]):
     def __init__(self, context: AutofixContext):
         super().__init__(context)
 
-    @traceable(name="Executor", run_type="llm", tags=["executor:v1.1"])
+    @traceable(name="Executor", run_type="llm", tags=["executor:v1.2"])
     def invoke(self, request: ExecutorRequest) -> None:
         with self.context.state.update() as cur:
             code_action_tools = CodeActionTools(self.context)

--- a/src/seer/automation/autofix/components/planner/component.py
+++ b/src/seer/automation/autofix/components/planner/component.py
@@ -78,7 +78,7 @@ class PlanningComponent(BaseComponent[PlanningRequest, PlanningOutput]):
             )
             return None
 
-    @traceable(name="Planning", run_type="llm", tags=["planning:v1.1"])
+    @traceable(name="Planning", run_type="llm", tags=["planning:v1.2"])
     def invoke(self, request: PlanningRequest) -> PlanningOutput | None:
         with self.context.state.update() as cur:
             planning_agent_tools = BaseTools(self.context)

--- a/tests/automation/autofix/test_models.py
+++ b/tests/automation/autofix/test_models.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 
 from pydantic import ValidationError
@@ -189,3 +190,15 @@ def test_event_get_stacktrace_invalid_entry(
     assert (
         StacktraceFrame.model_validate(valid_frame) in event_details.exceptions[0].stacktrace.frames
     )
+
+
+@parameterize
+def test_stacktrace_frame_vars_stringify(stacktrace: Stacktrace):
+    stack_str = stacktrace.to_str()
+
+    for frame in stacktrace.frames:
+        if frame.vars:
+            vars_str = json.dumps(frame.vars, indent=2)
+            assert vars_str in stack_str
+        else:
+            assert "---\nvariables" not in stack_str


### PR DESCRIPTION
Includes the variables from the stacktrace frame in the components:
- Preliminary Assessment
- Planning
- Executor

This would allow autofix to create fixes with much better understanding of the data flowing through when the error occurred.

Also updates the versioning of the components affected by the new stackframe vars to v1.2

[Example langsmith run with these changes](https://smith.langchain.com/public/f246289e-f305-4c05-b545-beeb8bd14ad5/r)