### PR TITLE
fix(autofix): Fix replacements introducing newlines

### DIFF
--- a/src/seer/automation/autofix/tools.py
+++ b/src/seer/automation/autofix/tools.py
@@ -152,7 +152,7 @@ class CodeActionTools(BaseTools):
                 len(lines), snippet_end_line + self.chunk_padding
             )
         ]
-        chunk = "\n".join(chunk_lines).strip("\n") + "\n"  # Keep a newline at the end
+        chunk = "\n".join(chunk_lines).strip("\n")
 
         if not original_snippet:
             raise Exception("Reference snippet not found. Try again with an exact match.")
@@ -169,13 +169,20 @@ class CodeActionTools(BaseTools):
         if not output:
             raise Exception("Snippet replacement failed.")
 
+        # Add a trailing newline in the reference snippet, this is because we stripped all newlines from the chunk originally, we should add the trailing one back in.
+        reference_snippet = chunk + "\n"
+        new_snippet = output.snippet
+        # Add a trailing snippet to the new snippet to match the reference snippet if there isn't already one.
+        if not new_snippet.endswith("\n"):
+            new_snippet += "\n"
+
         self.store_file_change(
             codebase,
             FileChange(
                 change_type="edit",
                 path=file_path,
-                reference_snippet=chunk,
-                new_snippet=output.snippet,
+                reference_snippet=reference_snippet,
+                new_snippet=new_snippet,
                 description=commit_message,
             ),
         )

--- a/tests/automation/autofix/test_autofix_tools.py
+++ b/tests/automation/autofix/test_autofix_tools.py
@@ -55,3 +55,69 @@ class TestReplaceSnippetWith(unittest.TestCase):
                 description="message",
             )
         )
+
+    @patch("seer.automation.autofix.components.snippet_replacement.GptClient")
+    def test_replace_snippet_with_chunk_newlines(self, mock_gpt_client):
+        mock_context = MagicMock()
+        mock_gpt_client = mock_gpt_client
+        code_action_tools = CodeActionTools(context=mock_context)
+
+        # Setup
+        original_snippet = "print('Hello, world!')"
+        replacement_snippet = "print('Goodbye, world!')"
+        file_path = "test_file.py"
+        mock_document = MagicMock()
+        mock_document.text = textwrap.dedent(
+            """\
+
+            def foo():
+                print('Hello, world!')
+                return True
+
+
+            """
+        )
+        mock_codebase = MagicMock()
+        mock_context.get_document_and_codebase.return_value = (mock_codebase, mock_document)
+
+        completion_with_parser = MagicMock()
+        code = textwrap.dedent(
+            """\
+            def foo():
+                print('Goodbye, world!')
+                return True"""
+        )
+        completion_with_parser.return_value = ({"code": code}, MagicMock(), MagicMock())
+        mock_gpt_client.return_value.json_completion = completion_with_parser
+
+        result = code_action_tools.replace_snippet_with(
+            file_path, "repo", original_snippet, replacement_snippet, "message"
+        )
+
+        # Assert
+        self.assertTrue(result)
+        self.assertEquals(result, f"success: Resulting code after replacement:\n```\n{code}\n```\n")
+        mock_codebase.store_file_change.assert_called_once_with(
+            FileChange(
+                change_type="edit",
+                path=file_path,
+                reference_snippet=mock_document.text.strip("\n") + "\n",
+                new_snippet=code + "\n",
+                description="message",
+            )
+        )
+
+        expected_final_document_content = textwrap.dedent(
+            """\
+
+            def foo():
+                print('Goodbye, world!')
+                return True
+
+
+            """
+        )
+        assert (
+            mock_codebase.store_file_change.call_args[0][0].apply(mock_document.text)
+            == expected_final_document_content
+        )


### PR DESCRIPTION
Tried on 2 issues locally, no more unexpected newlines introduced:

https://github.com/getsentry/seer/pull/418/files

https://github.com/getsentry/seer/pull/416/files

Issue was caused by the LLM getting confused with the extra newline in the XML tag contents, so it often added one. This fix ensures that there is no newline padding in the input to the LLM and only adds the newline after and ensures both the reference and replacement snippet end in a newline.