### PR TITLE
feat(autofix): Introduce retrieval reranker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -96,3 +96,4 @@ pytest-asyncio==0.23.5
 aiohttp==3.9.3
 types-python-dateutil==2.8.19.20240106
 johen==0.1.3
+pydantic-xml==2.9.0

--- a/src/seer/automation/agent/agent.py
+++ b/src/seer/automation/agent/agent.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from abc import ABC, abstractmethod
 from typing import Any

--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -41,7 +41,6 @@ class GptClient(LlmClient):
             model=self.model,
             messages=messages,  # type: ignore
             temperature=0.0,
-            seed=42,
             **chat_completion_kwargs,
         )
 

--- a/src/seer/automation/autofix/autofix.py
+++ b/src/seer/automation/autofix/autofix.py
@@ -2,7 +2,7 @@ import textwrap
 from typing import Any
 
 import sentry_sdk
-from langsmith import RunTree, traceable
+from langsmith import traceable
 
 from celery_app.models import UpdateCodebaseTaskRequest
 from seer.automation.autofix.autofix_context import AutofixContext
@@ -350,7 +350,9 @@ class Autofix(Pipeline):
         executor.invoke(
             ExecutorRequest(
                 event_details=event_details,
-                retriever_dump=retriever_output.content if retriever_output else None,
+                retriever_dump=(
+                    retriever_output.to_xml().to_prompt_str() if retriever_output else None
+                ),
                 task=step.text,
             )
         )

--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -78,7 +78,6 @@ class AutofixContext(PipelineContext):
         repo_name: str | None = None,
         repo_id: int | None = None,
         top_k: int = 8,
-        expand=False,
     ) -> list[StoredDocumentChunkWithRepoName]:
         if repo_name:
             repo_id = next(
@@ -114,9 +113,7 @@ class AutofixContext(PipelineContext):
             populated_chunks: list[StoredDocumentChunkWithRepoName] = []
             for _repo_id, db_chunks_for_codebase in chunks_by_repo_id.items():
                 codebase = self.get_codebase(_repo_id)
-                populated_chunks.extend(
-                    codebase._populate_chunks(db_chunks_for_codebase, expand=expand)
-                )
+                populated_chunks.extend(codebase._populate_chunks(db_chunks_for_codebase))
 
             # Re-sort populated_chunks based on their original order in db_chunks
             db_chunk_order = {db_chunk.id: index for index, db_chunk in enumerate(db_chunks)}

--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -10,7 +10,7 @@ from seer.automation.autofix.models import (
     Stacktrace,
 )
 from seer.automation.codebase.codebase_index import CodebaseIndex
-from seer.automation.codebase.models import StoredDocumentChunk
+from seer.automation.codebase.models import StoredDocumentChunk, StoredDocumentChunkWithRepoName
 from seer.automation.pipeline import PipelineContext
 from seer.automation.state import State
 from seer.automation.utils import get_embedding_model
@@ -73,8 +73,13 @@ class AutofixContext(PipelineContext):
         return codebase
 
     def query(
-        self, query: str, repo_name: str | None = None, repo_id: int | None = None, top_k: int = 8
-    ):
+        self,
+        query: str,
+        repo_name: str | None = None,
+        repo_id: int | None = None,
+        top_k: int = 8,
+        expand=False,
+    ) -> list[StoredDocumentChunkWithRepoName]:
         if repo_name:
             repo_id = next(
                 (
@@ -106,10 +111,12 @@ class AutofixContext(PipelineContext):
             for db_chunk in db_chunks:
                 chunks_by_repo_id.setdefault(db_chunk.repo_id, []).append(db_chunk)
 
-            populated_chunks: list[StoredDocumentChunk] = []
+            populated_chunks: list[StoredDocumentChunkWithRepoName] = []
             for _repo_id, db_chunks_for_codebase in chunks_by_repo_id.items():
                 codebase = self.get_codebase(_repo_id)
-                populated_chunks.extend(codebase._populate_chunks(db_chunks_for_codebase))
+                populated_chunks.extend(
+                    codebase._populate_chunks(db_chunks_for_codebase, expand=expand)
+                )
 
             # Re-sort populated_chunks based on their original order in db_chunks
             db_chunk_order = {db_chunk.id: index for index, db_chunk in enumerate(db_chunks)}

--- a/src/seer/automation/autofix/components/assessment/component.py
+++ b/src/seer/automation/autofix/components/assessment/component.py
@@ -15,9 +15,6 @@ from seer.automation.component import BaseComponent
 class ProblemDiscoveryComponent(BaseComponent[ProblemDiscoveryRequest, ProblemDiscoveryOutput]):
     context: AutofixContext
 
-    def __init__(self, context: AutofixContext):
-        super().__init__(context)
-
     @traceable(name="Problem Discovery", run_type="llm", tags=["problem_discovery:v1.2"])
     def invoke(self, request: ProblemDiscoveryRequest) -> ProblemDiscoveryOutput | None:
         with self.context.state.update() as cur:

--- a/src/seer/automation/autofix/components/reranker/component.py
+++ b/src/seer/automation/autofix/components/reranker/component.py
@@ -1,3 +1,4 @@
+import sentry_sdk
 from langsmith import traceable
 
 from seer.automation.agent.client import GptClient
@@ -40,6 +41,11 @@ class RerankerComponent(BaseComponent[RerankerRequest, RerankerOutput]):
             snippet_ids = RawRerankerResult.from_xml(
                 f"<research_result>{completion_result.content}</research_result>"
             ).snippet_ids
+
+            # Sanity log if we ever get a hash collision
+            all_snippet_ids = [chunk.get_short_hash() for chunk in request.chunks]
+            if len(all_snippet_ids) != len(set(all_snippet_ids)):
+                sentry_sdk.capture_message(f"Hash collision in reranker: {all_snippet_ids}")
 
             relevant_chunks = []
             for short_snippet_hash in snippet_ids:

--- a/src/seer/automation/autofix/components/reranker/component.py
+++ b/src/seer/automation/autofix/components/reranker/component.py
@@ -1,0 +1,63 @@
+from langsmith import traceable
+
+from seer.automation.agent.client import GptClient
+from seer.automation.agent.models import Message
+from seer.automation.autofix.autofix_context import AutofixContext
+from seer.automation.autofix.components.reranker.models import (
+    RawRerankerResult,
+    RerankerOutput,
+    RerankerRequest,
+)
+from seer.automation.autofix.components.reranker.prompts import RerankerPrompts
+from seer.automation.autofix.utils import autofix_logger
+from seer.automation.component import BaseComponent
+
+
+class RerankerComponent(BaseComponent[RerankerRequest, RerankerOutput]):
+    context: AutofixContext
+
+    @traceable(name="Reranker", run_type="llm", tags=["reranker:v1"])
+    def invoke(self, request: RerankerRequest) -> RerankerOutput:
+        with self.context.state.update() as cur:
+            gpt_client = GptClient()
+
+            code_dump = "\n".join(
+                [chunk.get_dump_for_llm(include_short_hash_as_id=True) for chunk in request.chunks]
+            )
+
+            completion_result, usage = gpt_client.completion(
+                [
+                    Message(role="system", content=RerankerPrompts.format_system_msg()),
+                    Message(
+                        role="user",
+                        content=RerankerPrompts.format_default_msg(request.query, code_dump),
+                    ),
+                ]
+            )
+
+            cur.usage += usage
+
+            snippet_ids = RawRerankerResult.from_xml(
+                f"<research_result>{completion_result.content}</research_result>"
+            ).snippet_ids
+
+            relevant_chunks = []
+            for short_snippet_hash in snippet_ids:
+                chunk = next(
+                    chunk
+                    for chunk in request.chunks
+                    if chunk.matches_short_hash(short_snippet_hash)
+                )
+
+                if not chunk:
+                    # Go forward, but we should log this.
+                    autofix_logger.exception(
+                        ValueError(
+                            f"Snippet with hash {short_snippet_hash} not found in the input chunks"
+                        )
+                    )
+                    continue
+
+                relevant_chunks.append(chunk)
+
+            return RerankerOutput(chunks=relevant_chunks)

--- a/src/seer/automation/autofix/components/reranker/models.py
+++ b/src/seer/automation/autofix/components/reranker/models.py
@@ -1,0 +1,26 @@
+import json
+import textwrap
+
+from pydantic import BaseModel
+from pydantic_xml import element
+
+from seer.automation.codebase.models import StoredDocumentChunkWithRepoName
+from seer.automation.component import BaseComponentOutput, BaseComponentRequest
+from seer.automation.models import PromptXmlModel
+
+
+class RerankerRequest(BaseComponentRequest):
+    query: str
+    chunks: list[StoredDocumentChunkWithRepoName]
+
+
+class RawRerankerResult(PromptXmlModel, tag="research_result"):
+    raw_snippet_ids: str = element(tag="code_snippet_ids")
+
+    @property
+    def snippet_ids(self) -> list[str]:
+        return json.loads(self.raw_snippet_ids)
+
+
+class RerankerOutput(BaseComponentOutput):
+    chunks: list[StoredDocumentChunkWithRepoName]

--- a/src/seer/automation/autofix/components/reranker/prompts.py
+++ b/src/seer/automation/autofix/components/reranker/prompts.py
@@ -1,0 +1,42 @@
+import textwrap
+
+
+class RerankerPrompts:
+    @staticmethod
+    def format_system_msg():
+        return textwrap.dedent(
+            """\
+            You are exceptional at gathering information.
+            - Given a task, you must return the list of code snippet ids that are relevant to the task.
+
+            Code snippets will be given to you in the format:
+            <chunk id="3232" path="file/path.ext" repo_name="repo/name">
+            def foo():
+                return "bar"
+            </chunk>
+
+            You must output the relevant ids to the task as a list of code snippet ids in JSON array format inside a <code_snippet_ids> tag:
+            <code_snippet_ids>
+            ["3232", "3233", "3234"]
+            </code_snippet_ids>"""
+        )
+
+    @staticmethod
+    def format_default_msg(task_instruction: str, code_dump: str):
+        return textwrap.dedent(
+            """\
+            <code_snippets>
+            {code_dump}
+            </code_snippets>
+
+            Given the task:
+            <task>
+            {task_instruction}
+            </task>
+            you must return all relevant code snippet ids in order of relevance.
+
+            Think out loud step-by-step then output all relevant code snippet IDs in the JSON."""
+        ).format(
+            code_dump=code_dump,
+            task_instruction=task_instruction,
+        )

--- a/src/seer/automation/autofix/components/retriever.py
+++ b/src/seer/automation/autofix/components/retriever.py
@@ -6,16 +6,26 @@ from seer.automation.agent.client import GptClient
 from seer.automation.agent.models import Message
 from seer.automation.autofix.autofix_context import AutofixContext
 from seer.automation.autofix.utils import autofix_logger
-from seer.automation.codebase.models import StoredDocumentChunk
+from seer.automation.codebase.models import DocumentChunkPromptXml, StoredDocumentChunkWithRepoName
 from seer.automation.component import BaseComponent, BaseComponentOutput, BaseComponentRequest
+from seer.automation.models import PromptXmlModel
 
 
 class RetrieverRequest(BaseComponentRequest):
     text: str
+    repo_top_k: int = 4
+    include_short_hash_as_id: bool = False
+
+
+class RetrieverOutputPromptXml(PromptXmlModel, tag="chunks"):
+    chunks: list[DocumentChunkPromptXml]
 
 
 class RetrieverOutput(BaseComponentOutput):
-    content: str
+    chunks: list[StoredDocumentChunkWithRepoName]
+
+    def to_xml(self) -> RetrieverOutputPromptXml:
+        return RetrieverOutputPromptXml(chunks=[chunk.get_prompt_xml() for chunk in self.chunks])
 
 
 class RetrieverPrompts:
@@ -87,9 +97,9 @@ class RetrieverComponent(BaseComponent[RetrieverRequest, RetrieverOutput]):
             autofix_logger.debug(f"Search queries: {queries}")
 
             context_dump = ""
-            unique_chunks: dict[str, StoredDocumentChunk] = {}
+            unique_chunks: dict[str, StoredDocumentChunkWithRepoName] = {}
             for query in queries:
-                retrived_chunks = self.context.query(query, top_k=4)
+                retrived_chunks = self.context.query(query, top_k=request.repo_top_k)
                 for chunk in retrived_chunks:
                     unique_chunks[chunk.hash] = chunk
             chunks = list(unique_chunks.values())
@@ -97,6 +107,6 @@ class RetrieverComponent(BaseComponent[RetrieverRequest, RetrieverOutput]):
             autofix_logger.debug(f"Retrieved {len(chunks)} unique chunks.")
 
             for chunk in chunks:
-                context_dump += f"\n\n{chunk.get_dump_for_llm(self.context.get_codebase(chunk.repo_id).repo_info.external_slug)}"
+                context_dump += f"\n\n{chunk.get_dump_for_llm(include_short_hash_as_id=request.include_short_hash_as_id)}"
 
-            return RetrieverOutput(content=context_dump)
+            return RetrieverOutput(chunks=chunks)

--- a/src/seer/automation/autofix/components/retriever_with_reranker.py
+++ b/src/seer/automation/autofix/components/retriever_with_reranker.py
@@ -1,0 +1,34 @@
+from langsmith import traceable
+
+from seer.automation.autofix.autofix_context import AutofixContext
+from seer.automation.autofix.components.reranker.component import RerankerComponent
+from seer.automation.autofix.components.reranker.models import RerankerRequest
+from seer.automation.autofix.components.retriever import (
+    RetrieverComponent,
+    RetrieverOutput,
+    RetrieverRequest,
+)
+from seer.automation.component import BaseComponent
+
+
+class RetrieverWithRerankerComponent(BaseComponent[RetrieverRequest, RetrieverOutput]):
+    context: AutofixContext
+
+    @traceable(name="Retriever With Reranker", run_type="chain", tags=["retriever-reranker:v1"])
+    def invoke(self, request: RetrieverRequest) -> RetrieverOutput | None:
+        retriever = RetrieverComponent(self.context)
+
+        retriever_output = retriever.invoke(
+            request.model_copy(update=dict(include_short_hash_as_id=True))
+        )
+
+        if retriever_output is None:
+            return None
+
+        reranker = RerankerComponent(self.context)
+
+        reranker_output = reranker.invoke(
+            RerankerRequest(query=request.text, chunks=retriever_output.chunks)
+        )
+
+        return RetrieverOutput(chunks=reranker_output.chunks)

--- a/src/seer/automation/codebase/codebase_index.py
+++ b/src/seer/automation/codebase/codebase_index.py
@@ -504,7 +504,7 @@ class CodebaseIndex:
                             break
 
     def _populate_chunks(
-        self, chunks: list[DbDocumentChunk], expand=False
+        self, chunks: list[DbDocumentChunk]
     ) -> list[StoredDocumentChunkWithRepoName]:
         ### This seems awfully wasteful to chunk and hash a document for each returned chunk but I guess we are offloading the work to when it's needed?
         assert self.repo_info is not None, "Repository info is not set"
@@ -546,13 +546,6 @@ class CodebaseIndex:
                 language=chunk.language,
                 repo_name=self.repo_info.external_slug,
             )
-            if expand:
-                if chunk.index > 0:
-                    prev_neighbor = doc_chunks[chunk.index - 1]
-                    populated_chunk.content = prev_neighbor.content + "\n" + populated_chunk.content
-                if chunk.index < len(doc_chunks) - 1:
-                    next_neighbor = doc_chunks[chunk.index + 1]
-                    populated_chunk.content = populated_chunk.content + "\n" + next_neighbor.content
 
             matched_chunks.append(populated_chunk)
 

--- a/src/seer/automation/codebase/codebase_index.py
+++ b/src/seer/automation/codebase/codebase_index.py
@@ -25,6 +25,7 @@ from seer.automation.codebase.models import (
     EmbeddedDocumentChunk,
     RepositoryInfo,
     StoredDocumentChunk,
+    StoredDocumentChunkWithRepoName,
 )
 from seer.automation.codebase.parser import DocumentParser
 from seer.automation.codebase.repo_client import RepoClient
@@ -502,13 +503,15 @@ class CodebaseIndex:
                             frame.filename = valid_path
                             break
 
-    def _populate_chunks(self, chunks: list[DbDocumentChunk]) -> list[StoredDocumentChunk]:
+    def _populate_chunks(
+        self, chunks: list[DbDocumentChunk], expand=False
+    ) -> list[StoredDocumentChunkWithRepoName]:
         ### This seems awfully wasteful to chunk and hash a document for each returned chunk but I guess we are offloading the work to when it's needed?
         assert self.repo_info is not None, "Repository info is not set"
 
         doc_parser = DocumentParser(self.embedding_model)
 
-        matched_chunks: list[StoredDocumentChunk] = []
+        matched_chunks: list[StoredDocumentChunkWithRepoName] = []
         for chunk in chunks:
             content = self._get_file_content_with_cache(chunk.path, self.repo_info.sha)
 
@@ -530,20 +533,28 @@ class CodebaseIndex:
                 logger.warning(f"Failed to match chunk with hash {chunk.hash}")
                 continue
 
-            matched_chunks.append(
-                StoredDocumentChunk(
-                    id=chunk.id,
-                    path=chunk.path,
-                    index=chunk.index,
-                    hash=chunk.hash,
-                    token_count=chunk.token_count,
-                    embedding=np.array(chunk.embedding),
-                    content=matched_chunk.content,
-                    context=matched_chunk.context,
-                    repo_id=chunk.repo_id,
-                    language=chunk.language,
-                )
+            populated_chunk = StoredDocumentChunkWithRepoName(
+                id=chunk.id,
+                path=chunk.path,
+                index=chunk.index,
+                hash=chunk.hash,
+                token_count=chunk.token_count,
+                embedding=np.array(chunk.embedding),
+                content=matched_chunk.content,
+                context=matched_chunk.context,
+                repo_id=chunk.repo_id,
+                language=chunk.language,
+                repo_name=self.repo_info.external_slug,
             )
+            if expand:
+                if chunk.index > 0:
+                    prev_neighbor = doc_chunks[chunk.index - 1]
+                    populated_chunk.content = prev_neighbor.content + "\n" + populated_chunk.content
+                if chunk.index < len(doc_chunks) - 1:
+                    next_neighbor = doc_chunks[chunk.index + 1]
+                    populated_chunk.content = populated_chunk.content + "\n" + next_neighbor.content
+
+            matched_chunks.append(populated_chunk)
 
         return matched_chunks
 

--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -51,19 +51,18 @@ class BaseDocumentChunk(BaseModel):
             content=self.content,
         )
 
-    def get_dump_for_llm(self, repo_name: str, include_short_hash_as_id: bool = False):
-        xml_chunk = self._get_prompt_xml(repo_name, include_short_hash_as_id)
+    def get_dump_for_llm(
+        self, repo_name: str | None = None, include_short_hash_as_id: bool = False
+    ):
+        xml_chunk = self.get_prompt_xml(repo_name or "", include_short_hash_as_id)
 
         return xml_chunk.to_prompt_str()
 
-    def get_prompt_xml(self, repo_name: str, include_short_hash_as_id: bool = False):
-        return self._get_prompt_xml(repo_name, include_short_hash_as_id)
-
-    def _get_prompt_xml(self, repo_name: str, include_short_hash_as_id: bool = False):
+    def get_prompt_xml(self, repo_name: str | None = None, include_short_hash_as_id: bool = False):
         return DocumentChunkPromptXml(
             id=self.hash[:SHORT_HASH_LENGTH] if include_short_hash_as_id else None,
             path=self.path,
-            repo=repo_name,
+            repo=repo_name or "",
             content=(self.context if self.context else "") + self.content,
         )
 
@@ -117,14 +116,16 @@ class StoredDocumentChunk(EmbeddedDocumentChunk):
 class StoredDocumentChunkWithRepoName(StoredDocumentChunk):
     repo_name: str
 
-    def get_dump_for_llm(self, include_short_hash_as_id: bool = False):
+    def get_dump_for_llm(
+        self, repo_name: str | None = None, include_short_hash_as_id: bool = False
+    ):
         return super().get_dump_for_llm(
-            self.repo_name, include_short_hash_as_id=include_short_hash_as_id
+            repo_name or self.repo_name, include_short_hash_as_id=include_short_hash_as_id
         )
 
-    def get_prompt_xml(self, include_short_hash_as_id: bool = False):
-        return self._get_prompt_xml(
-            self.repo_name, include_short_hash_as_id=include_short_hash_as_id
+    def get_prompt_xml(self, repo_name: str | None = None, include_short_hash_as_id: bool = False):
+        return self.get_prompt_xml(
+            repo_name or self.repo_name, include_short_hash_as_id=include_short_hash_as_id
         )
 
 

--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -124,7 +124,7 @@ class StoredDocumentChunkWithRepoName(StoredDocumentChunk):
         )
 
     def get_prompt_xml(self, repo_name: str | None = None, include_short_hash_as_id: bool = False):
-        return self.get_prompt_xml(
+        return super().get_prompt_xml(
             repo_name or self.repo_name, include_short_hash_as_id=include_short_hash_as_id
         )
 

--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -42,8 +42,11 @@ class BaseDocumentChunk(BaseModel):
     index: int
     token_count: int
 
+    def get_short_hash(self) -> str:
+        return self.hash[:SHORT_HASH_LENGTH]
+
     def matches_short_hash(self, short_hash: str) -> bool:
-        return self.hash[:SHORT_HASH_LENGTH] == short_hash
+        return self.get_short_hash() == short_hash
 
     def get_dump_for_embedding(self):
         return """{context}{content}""".format(

--- a/src/seer/automation/component.py
+++ b/src/seer/automation/component.py
@@ -3,6 +3,7 @@ from typing import Generic, TypeVar
 
 from pydantic import BaseModel
 
+from seer.automation.models import PromptXmlModel
 from seer.automation.pipeline import PipelineContext
 from seer.automation.state import State
 
@@ -11,12 +12,16 @@ class BaseComponentRequest(BaseModel):
     pass
 
 
+class BaseComponentXmlOutput(PromptXmlModel):
+    pass
+
+
 class BaseComponentOutput(BaseModel):
     pass
 
 
 BCR = TypeVar("BCR", bound=BaseComponentRequest)
-BCO = TypeVar("BCO", bound=BaseComponentOutput)
+BCO = TypeVar("BCO", bound=BaseComponentOutput | BaseComponentXmlOutput)
 
 
 class BaseComponent(abc.ABC, Generic[BCR, BCO]):

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -1,12 +1,36 @@
 from typing import List, Literal, Optional
+from xml.etree import ElementTree as ET
 
 from pydantic import BaseModel
+from pydantic_xml import BaseXmlModel
 
 from seer.automation.agent.models import Usage
 
 
 class InitializationError(Exception):
     pass
+
+
+class PromptXmlModel(BaseXmlModel):
+    def _pad_with_newlines(self, tree: ET.Element) -> None:
+        for elem in tree.iter():
+            if elem.text:
+                stripped = elem.text.strip("\n")
+                if stripped:
+                    elem.text = "\n" + stripped + "\n"
+            if elem.tail:
+                stripped = elem.tail.strip("\n")
+                if stripped:
+                    elem.tail = "\n" + stripped + "\n"
+
+    def to_prompt_str(self) -> str:
+        tree: ET.Element = self.to_xml_tree()
+
+        ET.indent(tree, space="", level=0)
+
+        self._pad_with_newlines(tree)
+
+        return ET.tostring(tree, encoding="unicode")
 
 
 class Line(BaseModel):


### PR DESCRIPTION
Introduces an LLM reranker step to our semantic codebase search.

It's also the first usage of `pydantic-xml` which allows us to easily parse from and convert to the XML format we use in our prompts.

![image](https://github.com/getsentry/seer/assets/30991498/bb3888aa-2911-4086-8293-2b7d1def7f03)
