### PR TITLE
chore(dev): Stop calling `deactivate` in `.envrc`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,5 @@
 venv_name="${PWD}/.venv"
 
-deactivate 2>/dev/null || true
 expected_python_version=$(cat .python-version)
 python_version=$(python3 -V 2>&1 | awk '{print $2}')
 if  [ $python_version != $expected_python_version ]; then


### PR DESCRIPTION
This removes the `deactivate` call from `.envrc`, similar to what was done in https://github.com/getsentry/sentry/pull/67827. Two reasons for this:

- In VSCode it can cause an infinite loop, where `direnv` calls our `.envrc`, our `.envrc` calls `deactivate`, that call gets routed to the VSCode Python extension's `deactivate` script, that script runs the normal `deactivate` stuff but then also cals `zsh`, which loads your `.zshrc`, which includes the code activating `direnv`, which then causes it to call our `.envrc`, which calls `deactivate`... You get the idea. Nothing good comes of it.
- The `deactivate` code (a non-`zsh`-calling copy of it which lives in the standard virtual env `activate` script) is called as the first act of `activate` in any case, so our call to it is redundant. (Said script is included below for reference.)

    <details>
    <summary>The standard `activate` script</summary>

    ```shell
    # This file must be used with "source bin/activate" *from bash*
    # you cannot run it directly

    deactivate () {
        # reset old environment variables
        if [ -n "${_OLD_VIRTUAL_PATH:-}" ] ; then
            PATH="${_OLD_VIRTUAL_PATH:-}"
            export PATH
            unset _OLD_VIRTUAL_PATH
        fi
        if [ -n "${_OLD_VIRTUAL_PYTHONHOME:-}" ] ; then
            PYTHONHOME="${_OLD_VIRTUAL_PYTHONHOME:-}"
            export PYTHONHOME
            unset _OLD_VIRTUAL_PYTHONHOME
        fi

        # Call hash to forget past commands. Without forgetting
        # past commands the $PATH changes we made may not be respected
        hash -r 2> /dev/null

        if [ -n "${_OLD_VIRTUAL_PS1:-}" ] ; then
            PS1="${_OLD_VIRTUAL_PS1:-}"
            export PS1
            unset _OLD_VIRTUAL_PS1
        fi

        unset VIRTUAL_ENV
        unset VIRTUAL_ENV_PROMPT
        if [ ! "${1:-}" = "nondestructive" ] ; then
        # Self destruct!
            unset -f deactivate
        fi
    }

    # unset irrelevant variables
    deactivate nondestructive

    VIRTUAL_ENV="/Users/Katie/Documents/Sentry/seer/.venv"
    export VIRTUAL_ENV

    _OLD_VIRTUAL_PATH="$PATH"
    PATH="$VIRTUAL_ENV/bin:$PATH"
    export PATH

    # unset PYTHONHOME if set
    # this will fail if PYTHONHOME is set to the empty string (which is bad anyway)
    # could use `if (set -u; : $PYTHONHOME) ;` in bash
    if [ -n "${PYTHONHOME:-}" ] ; then
        _OLD_VIRTUAL_PYTHONHOME="${PYTHONHOME:-}"
        unset PYTHONHOME
    fi

    if [ -z "${VIRTUAL_ENV_DISABLE_PROMPT:-}" ] ; then
        _OLD_VIRTUAL_PS1="${PS1:-}"
        PS1="(.venv) ${PS1:-}"
        export PS1
        VIRTUAL_ENV_PROMPT="(.venv) "
        export VIRTUAL_ENV_PROMPT
    fi

    # Call hash to forget past commands. Without forgetting
    # past commands the $PATH changes we made may not be respected
    hash -r 2> /dev/null
    ```


    </details>