### PR TITLE
chore: Use all CUDA devices

### DIFF
--- a/celeryworker.sh
+++ b/celeryworker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$CELERY_WORKER_ENABLE" = "true" ]; then
-    exec celery -A src.celery_app.tasks worker --loglevel=info -c 4 # 4 workers for now
+    exec celery -A src.celery_app.tasks worker --loglevel=info -c 4 # Use 4 processes with one GPU per process
 else
     echo "Celery worker is disabled via environment variable CELERY_WORKER_ENABLE"
     exit 0

--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -94,6 +94,8 @@ class AutofixContext(PipelineContext):
 
         repo_ids = [repo_id] if repo_id is not None else list(self.codebases.keys())
 
+        # By defaut the returned embeddings are numpy arrays stored on CPU memory. If we want
+        # them to be loaded in the GPU memory then pass appropriate parameters to encode.
         embedding = self.embedding_model.encode(query)
 
         with Session() as session:

--- a/src/seer/automation/utils.py
+++ b/src/seer/automation/utils.py
@@ -1,26 +1,58 @@
 import functools
+import logging
 import os
 from typing import Any
 
+import billiard  # type: ignore[import-untyped]
 import torch
 from sentence_transformers import SentenceTransformer
 
+# ALERT: Using magic number four. This is temporary code that ensures that AutopFix uses all 4
+# cuda devices available. This "4" should match the number of celery sub-processes configured in celeryworker.sh.
+EXPECTED_CUDA_DEVICES = 4
+logger = logging.getLogger("autofix")
 
-def get_torch_device():
+
+def _get_torch_device_name():
+    device: str = "cpu"
     if torch.cuda.is_available():
-        return torch.device("cuda")
+        if torch.cuda.device_count() >= EXPECTED_CUDA_DEVICES:
+            try:
+                index: int = billiard.process.current_process().index
+                if index < 0 or index >= EXPECTED_CUDA_DEVICES:
+                    logger.warn(
+                        f"CUDA device selection: invalid process index {index}. Defaulting to active GPU."
+                    )
+                    device = "cuda"
+                else:
+                    device = f"cuda:{index}"
+            except Exception as e:
+                logger.warn(
+                    "CUDA device selection: unable to look up celery process index. Defaulting to active GPU.",
+                    exc_info=e,
+                )
+                device = "cuda"
+        else:
+            logger.info(
+                f"CUDA device selection: found {torch.cuda.device_count()} CUDA devices which is less than the required {EXPECTED_CUDA_DEVICES}. Defaulting to active GPU"
+            )
+            device = "cuda"
     elif torch.backends.mps.is_available():
-        return torch.device("mps")
-    return torch.device("cpu")
+        device = "mps"
+    logger.info(f"Using {device} device for embedding model")
+    return device
 
 
 @functools.cache
-def get_embedding_model():
+def _get_embedding_model_on(device_name: str):
+    device = torch.device(device_name)
     model = SentenceTransformer(
         os.path.join("./", "models", "autofix_embeddings_v0"),
         trust_remote_code=True,
-    ).to(get_torch_device())
-
+    ).to(device=device)
     model.max_seq_length = 4096
-
     return model
+
+
+def get_embedding_model():
+    return _get_embedding_model_on(_get_torch_device_name())

--- a/src/seer/grouping/grouping.py
+++ b/src/seer/grouping/grouping.py
@@ -81,6 +81,7 @@ class GroupingLookup:
         :param model_path: Path to the sentence transformer model.
         """
         model_device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+        logger.info(f"Loading transformer model to device {model_device}")
         self.model = SentenceTransformer(
             model_path,
             trust_remote_code=True,


### PR DESCRIPTION
Assign one Cuda device to one celery process. Tested on I4 VM. Below are screen shots of memory and GPU usage when I submitted 100 autofix requests to Seer.
>Baseline - Memory and CPU before submitting 100 requests
![Before Starting - baseline](https://github.com/getsentry/seer/assets/21250923/e0be0125-6b08-42fc-b2e4-48a5270b6df1)

>Snapshot 1 during processing
![During - 1](https://github.com/getsentry/seer/assets/21250923/5a85847c-b5e9-441f-95b4-f3184664b727)

>Snapshot 2 during processing
![During - 2](https://github.com/getsentry/seer/assets/21250923/ba6d537c-d856-4037-812c-054639865ddf)

>Snapshot 3 during processing (memory drops after completion of a batch)
![During - 3 - shows memory going back to baseline](https://github.com/getsentry/seer/assets/21250923/cec0929e-9c7a-4fce-ad2a-dca504f50176)

>After 100 requests -  memory back to baseline
![After 100 requests - memory back to baseline](https://github.com/getsentry/seer/assets/21250923/150a1d56-7318-44f7-aeee-03319620d9a5)
