### PR TITLE
Models are loaded in a thread

### DIFF
--- a/src/seer/bootup.py
+++ b/src/seer/bootup.py
@@ -33,7 +33,7 @@ def bootup(
     init_migrations=False,
     init_db=True,
     with_async=False,
-    eager_load_inference_models=False,
+    async_load_models=False,
 ) -> Flask:
     from seer.grouping.grouping import logger as grouping_logger
 
@@ -52,7 +52,7 @@ def bootup(
     app.config["SQLALCHEMY_DATABASE_URI"] = uri
     app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {"connect_args": {"prepare_threshold": None}}
 
-    from seer.inference_models import cached
+    from seer.inference_models import start_loading
 
     if init_db:
         db.init_app(app)
@@ -67,10 +67,7 @@ def bootup(
                     )
                 )
 
-    if eager_load_inference_models:
-        for item in cached:
-            # Preload model
-            item()
+    start_loading(async_load_models)
 
     return app
 

--- a/src/seer/inference_models.py
+++ b/src/seer/inference_models.py
@@ -1,6 +1,10 @@
+import contextlib
 import functools
 import os
-from typing import Any, Callable
+import threading
+from typing import Any, Callable, Literal, TypeVar
+
+import sentry_sdk
 
 from seer.grouping.grouping import GroupingLookup
 from seer.severity.severity_inference import SeverityInference
@@ -12,14 +16,30 @@ def model_path(subpath: str) -> str:
     return os.path.join(root, "models", subpath)
 
 
-@functools.cache
+_A = TypeVar("_A")
+_deferred: list[Callable[[], Any]] = []
+
+
+def deferred_loading(env_var_required: str) -> Callable[[Callable[[], _A]], Callable[[], _A]]:
+    def decorator(func: Callable[[], _A]) -> Callable[[], Any]:
+        if os.environ.get(env_var_required, "").lower() not in ("true", "t", "1"):
+            return func
+        # python functools is thread safe: https://docs.python.org/3/library/functools.html
+        wrapped = functools.cache(func)
+        _deferred.append(wrapped)
+        return wrapped
+
+    return decorator
+
+
+@deferred_loading("SEVERITY_ENABLED")
 def embeddings_model() -> SeverityInference:
     return SeverityInference(
         model_path("issue_severity_v0/embeddings"), model_path("issue_severity_v0/classifier")
     )
 
 
-@functools.cache
+@deferred_loading("GROUPING_ENABLED")
 def grouping_lookup() -> GroupingLookup:
     return GroupingLookup(
         model_path=model_path("issue_grouping_v0/embeddings"),
@@ -27,14 +47,65 @@ def grouping_lookup() -> GroupingLookup:
     )
 
 
-function_env_config = {
-    "embeddings_model": "SEVERITY_ENABLED",
-    "grouping_lookup": "GROUPING_ENABLED",
-}
+LoadingResult = Literal["pending"] | Literal["loading"] | Literal["done"] | Literal["failed"]
 
-cached: list[Callable[..., Any]] = [
-    globals()[function_name]
-    for function_name, env_var in function_env_config.items()
-    if os.environ.get(env_var, "").lower() in ("true", "1", "t")
-    if hasattr(globals()[function_name], "cache_info")
-]
+_loading_lock: threading.Lock = threading.RLock()
+_loading_thread: threading.Thread | None = None
+_loading_result: LoadingResult = "pending"
+
+
+def models_loading_status() -> LoadingResult:
+    global _loading_result
+    return _loading_result
+
+
+def start_loading(load_async: bool):
+    global _loading_result
+
+    with _loading_lock:
+        if _loading_result != "pending":
+            return
+        _loading_result = "loading"
+
+    def load():
+        global _loading_result
+        try:
+            for item in _deferred:
+                item()
+            with _loading_lock:
+                _loading_result = "done"
+        except Exception:
+            sentry_sdk.capture_exception()
+            with _loading_lock:
+                _loading_result = "failed"
+
+    thread = threading.Thread(target=load)
+    thread.start()
+
+    if not load_async:
+        thread.join(timeout=5)
+
+
+def reset_loading_state(state: LoadingResult = "pending"):
+    global _loading_thread, _deferred, _loading_result
+
+    with _loading_lock:
+        if _loading_thread:
+            _loading_thread.join()
+        _loading_thread = None
+        _loading_result = state
+
+    for f in _deferred:
+        if hasattr(f, "cache_clear"):
+            f.cache_clear()
+
+
+@contextlib.contextmanager
+def dummy_deferred(c: Callable):
+    global _deferred
+    old = _deferred[:]
+    try:
+        _deferred = [c]
+        yield
+    finally:
+        _deferred = old

--- a/src/seer/inference_models.py
+++ b/src/seer/inference_models.py
@@ -64,7 +64,9 @@ def start_loading(load_async: bool):
 
     with _loading_lock:
         if _loading_result != "pending":
-            return
+            raise RuntimeError(
+                "start_loading invoked, but loading already started.  call reset_loading_state"
+            )
         _loading_result = "loading"
 
     def load():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 from seer.bootup import CELERY_CONFIG, bootup
 from seer.db import Session, db
+from seer.inference_models import reset_loading_state
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -18,8 +19,9 @@ def configure_environment():
 
 
 @pytest.fixture(autouse=True)
-def manage_db():
+def setup_app():
     # Forces the initialization of the database
+    reset_loading_state()
     app = bootup(
         __name__,
         init_db=True,


### PR DESCRIPTION
When starting the web server, load models in a thread rather than blocking, and have the liveness and readiness checks report that back.

1.  When models fail to load, live will return 500 and we'll have the pods restart, along with sentry errors.
2.  When models are slow to reload, live returns 200 but ready immediately returns 503, ensuring k8s does not restart the pods directly, but merely waits until the ready hits 200.
3.  Tested.