### PR TITLE
ref(dev): Migrate to new `docker compose` syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,26 +16,26 @@ pip: # Runs pip install with the requirements.txt file
 
 .PHONY: shell
 shell: .env # Opens a bash shell in the context of the project
-	docker-compose run app bash
+	docker compose run app bash
 
 .PHONY: update
-update: .env # Updates the project's docker-compose image.
-	docker-compose build
-	docker-compose run app flask db upgrade
+update: .env # Updates the project's docker compose image.
+	docker compose build
+	docker compose run app flask db upgrade
 
 .PHONY: dev
 dev: .env # Starts the webserver based on the current src on port 9091
-	docker-compose up --build
+	docker compose up --build
 
 .PHONY: dev-cuda
 dev-cuda: .env # Starts the webserver based on the current src on port 9091 with cuda enabled
-	docker-compose -f docker-compose.yml -f docker-compose.cuda.yml up --build
+	docker compose -f docker-compose.yml -f docker-compose.cuda.yml up --build
 
 .PHONY: test
 test: # Executes all tests in the baked image file.  Requires models/
-	docker-compose up -d test-db
-	docker-compose run app mypy
-	docker-compose run app pytest
+	docker compose up -d test-db
+	docker compose run app mypy
+	docker compose run app pytest
 
 .PHONY: mypy
 mypy: # Runs mypy type checking
@@ -44,7 +44,7 @@ mypy: # Runs mypy type checking
 .PHONY: schemas
 schemas: # Generates json files
 	#docker run --rm -v ./src/seer/schemas:/app/src/seer/schemas $(project_name):latest python src/seer/generate_schemas.py
-	docker-compose run app python src/seer/generate_schemas.py
+	docker compose run app python src/seer/generate_schemas.py
 	git clone --depth 1 https://github.com/getsentry/sentry-data-schemas.git $(tmpdir)
 	docker run --rm -t \
 	  -v $(tmpdir):/sentry-data-schemas:ro \
@@ -53,11 +53,11 @@ schemas: # Generates json files
 
 .PHONY: migration
 migration: .env
-	docker-compose run app flask db migrate -m 'Migration'
+	docker compose run app flask db migrate -m 'Migration'
 
 .PHONY: merge-migrations
 merge-migrations: .env
-	docker-compose run app flask db merge heads
+	docker compose run app flask db merge heads
 
 .env:
 	cp .env.example .env

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ gsutil cp -r gs://sentry-ml/seer/models ./models
 To run for development locally in one ago including building the docker image and rabbitmq container:
 
 ```bash
-make dev # runs docker-compose up --build
+make dev # runs docker compose up --build
 ```
 
 Port `9091` will be exposed which is what the local sentry application will look for to connect to the service.
@@ -77,6 +77,6 @@ make shell
 If you run into any data issue or connection issue and want to start from scratch, run the following set of commands from the command shell inside the seer repo:
 
 ```
-docker-compose down --volumes
+docker compose down --volumes
 make update && make dev
 ```


### PR DESCRIPTION
This switches all of our `docker-compose` calls to `docker compose` calls, as per [the V1 -> V2 migration guide](https://docs.docker.com/compose/migrate/) in the docker docs. 

I'm doing this not just because it's nice to be up to date with stuff, but also because GH actions will eventually stop recognizing the old syntax. (They briefly turned it off [two weeks ago](https://github.com/actions/runner-images/issues/9557), everyone freaked out, and they [pushed the date back to July](https://github.com/actions/runner-images/issues/9557#issuecomment-2052607340). Still it's coming.)