### PR TITLE
chore(dev): Fix Python version in black config in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 [tool.black]
     # File filtering is taken care of in pre-commit.
     line-length = 100
-    target-version = ['py38']
+    target-version = ['py311']
 
 [tool.isort]
     profile = "black"


### PR DESCRIPTION
This brings us up to 3.11, which is what we're using elsewhere in the repo.