### PR TITLE
fix(dev): Fix main branch name and excludes in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,9 +57,5 @@ repos:
       - id: check-symlinks
       - id: check-yaml
       - id: end-of-file-fixer
-        exclude_types: [svg]
-        exclude: ^fixtures/
       - id: trailing-whitespace
-        exclude_types: [svg]
-        exclude: ^(fixtures/|scripts/patches/)
       - id: debug-statements

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,9 +41,9 @@ repos:
         files: requirements-.*\.txt$
         additional_dependencies: [packaging==21.3]
       - id: prevent-push
-        name: prevent pushing master
+        name: prevent pushing to main
         stages: [push]
-        entry: bash -c 'test "$PRE_COMMIT_REMOTE_BRANCH" != "refs/heads/master"'
+        entry: bash -c 'test "$PRE_COMMIT_REMOTE_BRANCH" != "refs/heads/main"'
         always_run: true
         pass_filenames: false
         language: system


### PR DESCRIPTION
I think our pre-commit config was probably copied from the `sentry` repo, but that means we have a few things there which don't apply to this repo. 

Changes:

- Fix main branch name, from `master` to `main`.
- Remove exclusion of a directory (`fixtures`)  and a file type (SVG) that this repo doesn't have.