### PR TITLE
fix(linting): Vaguely substantive linter fixes

### DIFF
--- a/src/seer/automation/agent/agent.py
+++ b/src/seer/automation/agent/agent.py
@@ -107,13 +107,13 @@ class GptAgent(LlmAgent):
         tools: list[FunctionTool] | None = None,
         memory: list[Message] | None = None,
         name="GptAgent",
-        chat_completion_kwargs={},
+        chat_completion_kwargs=None,
         stop_message: str | None = None,
     ):
         super().__init__(tools, memory, name=name, stop_message=stop_message)
         self.client = GptClient(model=self.model)
 
-        self.chat_completion_kwargs = chat_completion_kwargs
+        self.chat_completion_kwargs = chat_completion_kwargs or {}
 
     def run_iteration(self):
         logger.debug(f"----[{self.name}] Running Iteration {self.iterations}----")

--- a/src/seer/automation/agent/utils.py
+++ b/src/seer/automation/agent/utils.py
@@ -7,7 +7,7 @@ import tree_sitter_languages
 
 def replace_newlines_not_in_quotes(value):
     # Split the string by both single and double quotes, replace \n outside quotes, and reassemble
-    parts = re.split(r'(["\'].*?["\'])', value)
+    parts = re.split(r'(["\'][^"\']*["\'])', value)
     for i, part in enumerate(parts):
         if i % 2 == 0:  # Not inside quotes
             part = part.replace("\\n", "\n")

--- a/src/seer/automation/codebase/parser.py
+++ b/src/seer/automation/codebase/parser.py
@@ -90,7 +90,7 @@ class DocumentParser:
         self,
         node: Node,
         language: str,
-        parent_declarations: list[AstDeclaration] = [],
+        parent_declarations: list[AstDeclaration] | None = None,
         root_node: Node | None = None,
         last_end_byte=0,
     ) -> list[TempChunk]:
@@ -105,6 +105,9 @@ class DocumentParser:
         Returns:
         List[List[Node]]: A list of lists, where each sublist contains touching nodes.
         """
+        if parent_declarations is None:
+            parent_declarations = []
+
         children = node.children
         root_node = root_node or node
 

--- a/src/seer/db.py
+++ b/src/seer/db.py
@@ -84,7 +84,7 @@ class ProcessRequest(Base):
         name: str,
         payload: dict | str | bytes | BaseModel,
         when: datetime.datetime,
-        expected_duration: datetime.timedelta = datetime.timedelta(seconds=0),
+        expected_duration: datetime.timedelta = datetime.timedelta(seconds=0),  # noqa
     ) -> sqlalchemy.UpdateBase:
         scheduled_from = scheduled_for = when
         # This increases last_delay.  When the item is scheduled, the 'next' schedule will be double this.

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -66,7 +66,7 @@ class UpdatedWork:
     def save(
         self,
         now: datetime.datetime,
-        expected_duration: datetime.timedelta = datetime.timedelta(seconds=0),
+        expected_duration: datetime.timedelta = datetime.timedelta(seconds=0),  # noqa
     ) -> Self:
         self.scheduled_work.save()
         with Session() as session:


### PR DESCRIPTION
Episode 4 of Man, This Linter Has A Lot Of Opinions: Two changes which _aren't_ behavior changes, but which take at least a little thinking to review before mashing approve, and which are therefore separated into their own PR. 

Changes:

- Use a more efficient regex in `replace_newlines_not_in_quotes` helper. A fuller explanation can be found [here](https://rules.sonarsource.com/python/RSPEC-5857/), but TL;DR `.*?` can require backtracking, whereas just excluding particular characters makes it so the regex engine only has to consider each character in that part of the pattern once. 
- Stop using mutable values as defaults for function parameters, because they are bound when the function is defined, not when it's called, and therefore every call of the function which uses the default uses the exact same instance of the mutable data structure - so any mutations made in the function end up all getting crammed together in that same list/dictionary/whatever.