### PR TITLE
feat(linting): Add flake8 config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,20 @@
+[flake8]
+# File filtering is taken care of in pre-commit.
+
+# B error codes come from flake8-bugbear, which we should start using. List of codes: https://github.com/PyCQA/flake8-bugbear#list-of-warnings
+# E error codes come from pycodestyle. List of codes: https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
+# F error codes come from flake8. List of codes: https://flake8.pycqa.org/en/latest/user/error-codes.html
+# LOG error codes come from flake8-logging, which is included in the VSCode Python extension. List of codes: https://github.com/adamchainz/flake8-logging#rules
+# S error codes come from sentry-flake8, if we ever start using that. List of codes: https://github.com/getsentry/sentry/blob/master/tools/flake8_plugin.py
+
+# For reference, here are the ones the `sentry` repo ignores (at least as of April 2024). Including these here as a sanity check on future additions to the ignores here:
+# extend-ignore = E203,E501,E402,E731,B007,B009,B010,B011,B020,B023,B024,B026,B027
+
+# E203 - Whitespace before `:`, but it's a false positive. See https://github.com/PyCQA/pycodestyle/issues/373
+# E501 - Line too long
+# E731 - Don't assign a lambda
+# LOG005 - Use exception() within an exception handler
+# LOG010 - exception() does not take an exception
+# LOG011 - Avoid pre-formatting log messages
+
+extend-ignore = E203, E501, E731, LOG005, LOG010, LOG011


### PR DESCRIPTION
This adds config for `flake8`, specifically a handful of rule ignores. With this and all of my recent linter fixes, we can _almost_ turn `flake8` back on in our pre-commit hook.