### PR TITLE
fix(autofix): Fix similarity tool low line similarity case

### DIFF
--- a/src/seer/automation/autofix/components/retriever.py
+++ b/src/seer/automation/autofix/components/retriever.py
@@ -69,7 +69,7 @@ class RetrieverComponent(BaseComponent[RetrieverRequest, RetrieverOutput]):
     def __init__(self, context: AutofixContext):
         super().__init__(context)
 
-    @traceable(name="Retriever", run_type="retriever", tags=["retriever:v1.1"])
+    @traceable(name="Retriever", run_type="retriever", tags=["retriever:v1.2"])
     def invoke(self, request: RetrieverRequest) -> RetrieverOutput | None:
         with self.context.state.update() as cur:
             # Identify good search queries for the plan item

--- a/src/seer/automation/autofix/utils.py
+++ b/src/seer/automation/autofix/utils.py
@@ -120,11 +120,12 @@ def find_original_snippet(
         if ellipsis_found and similarity < threshold:
             file_line_index += 1
         else:
-            if similarity < threshold:
-                return None
             ellipsis_found = False
-            snippet_index += 1
-            file_line_index += 1
+            if similarity < threshold:
+                file_line_index += 1
+            else:
+                snippet_index += 1
+                file_line_index += 1
     final_file_snippet = "\n".join(file_lines[snippet_start:file_line_index])
 
     # Ensure the last line of the file is at least `threshold` similar to the last line of the snippet


### PR DESCRIPTION
Found a bug where on lower similarity thresholds if it partially (some lines) match with something that isn't the snippet we're looking for, when it gets to a line below that threshold it would return None instead of moving on to subsequent lines.

Also bumps retriever version to v1.2