### PR TITLE
feat(autofix): Call create codebase index if any repos are missing from a run

### DIFF
--- a/src/seer/automation/autofix/components/retriever.py
+++ b/src/seer/automation/autofix/components/retriever.py
@@ -93,7 +93,7 @@ class RetrieverComponent(BaseComponent[RetrieverRequest, RetrieverOutput]):
 
         queries = data["queries"]
         autofix_logger.debug(f"Search queries: {queries}")
-        self.context.event_manager.log_tool_use(f"Searching with queries: {queries}")
+        self.context.event_manager.add_log(f"Searching with queries: {queries}")
 
         unique_chunks: dict[str, QueryResultDocumentChunk] = {}
         for query in queries:

--- a/src/seer/automation/autofix/components/retriever_with_reranker.py
+++ b/src/seer/automation/autofix/components/retriever_with_reranker.py
@@ -34,6 +34,6 @@ class RetrieverWithRerankerComponent(BaseComponent[RetrieverRequest, RetrieverOu
         file_names = set()
         for chunk in reranker_output.chunks:
             file_names.add(chunk.path)
-        self.context.event_manager.log_tool_use(f"Retrieved code from files: {file_names}")
+        self.context.event_manager.add_log(f"Retrieved code from files: {file_names}")
 
         return RetrieverOutput(chunks=reranker_output.chunks)

--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -71,6 +71,7 @@ class AutofixEventManager:
         with self.state.update() as cur:
             root_cause_step = cur.find_or_add(self.root_cause_analysis_processing_step)
             root_cause_step.status = AutofixStatus.PROCESSING
+            cur.make_step_latest(root_cause_step)
 
             cur.status = AutofixStatus.PROCESSING
 

--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -88,32 +88,10 @@ class AutofixEventManager:
                 root_cause_step.status = AutofixStatus.ERROR
                 cur.status = AutofixStatus.ERROR
 
-    def send_codebase_indexing_start_for_repo(self, repo_name: str):
+    def send_codebase_indexing_start(self):
         with self.state.update() as cur:
             indexing_step = cur.find_or_add(self.indexing_step)
             indexing_step.status = AutofixStatus.PROCESSING
-            indexing_step.title = f"Codebase Indexing"
-            indexing_step.progress.append(
-                ProgressItem(
-                    message=f"Updating codebase index for {repo_name}",
-                    type=ProgressType.INFO,
-                )
-            )
-
-            cur.status = AutofixStatus.PROCESSING
-
-    def send_codebase_indexing_complete_for_repo(self, repo_name: str):
-        with self.state.update() as cur:
-            indexing_step = cur.find_or_add(self.indexing_step)
-            indexing_step.status = AutofixStatus.COMPLETED
-            indexing_step.title = f"Codebase Indexing"
-
-            indexing_step.progress.append(
-                ProgressItem(
-                    message=f"Successfully updated codebase index for {repo_name}",
-                    type=ProgressType.INFO,
-                )
-            )
 
             cur.status = AutofixStatus.PROCESSING
 
@@ -208,7 +186,7 @@ class AutofixEventManager:
             changes_step.status = AutofixStatus.COMPLETED
             cur.status = AutofixStatus.COMPLETED
 
-    def log_tool_use(self, message: str):
+    def add_log(self, message: str):
         with self.state.update() as cur:
             step = cur.steps[-1]
             if step.status == AutofixStatus.PROCESSING:

--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -276,6 +276,11 @@ class AutofixContinuation(AutofixGroupState):
         self.steps.append(base_step)
         return base_step
 
+    def make_step_latest(self, step: Step):
+        if step in self.steps:
+            self.steps.remove(step)
+            self.steps.append(step)
+
     def mark_all_steps_completed(self):
         for step in self.steps:
             step.status = AutofixStatus.COMPLETED

--- a/src/seer/automation/autofix/pipelines.py
+++ b/src/seer/automation/autofix/pipelines.py
@@ -132,8 +132,9 @@ class AutofixRootCause(Pipeline):
 
     @traceable(name="Root Cause", tags=["autofix:v2"])
     def invoke(self):
-        self.context.event_manager.send_root_cause_analysis_start()
         self.invoke_side_effects()
+
+        self.context.event_manager.send_root_cause_analysis_start()
 
         if self.context.has_missing_codebase_indexes():
             raise ValueError("Codebase indexes must be created before root cause analysis")
@@ -166,8 +167,9 @@ class AutofixExecution(Pipeline):
 
     @traceable(name="Execution", tags=["autofix:v2"])
     def invoke(self):
-        self.context.event_manager.send_planning_start()
         self.invoke_side_effects()
+
+        self.context.event_manager.send_planning_start()
 
         if self.context.has_missing_codebase_indexes():
             raise ValueError("Codebase indexes must be created before planning")

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -48,7 +48,7 @@ def get_autofix_state(group_id: int) -> AutofixContinuation | None:
         return continuation.get()
 
 
-@celery_app.task(time_limit=60 * 15)  # 15 minute task timeout
+@celery_app.task(time_limit=60 * 30)  # 30 minute task timeout
 def run_autofix_root_cause(
     request_data: dict[str, Any],
     autofix_group_state: dict[str, Any] | None = None,

--- a/src/seer/automation/autofix/tools.py
+++ b/src/seer/automation/autofix/tools.py
@@ -45,7 +45,7 @@ class BaseTools:
 
     @traceable(run_type="tool", name="Expand Document")
     def expand_document(self, input: str, repo_name: str | None = None):
-        self.context.event_manager.log_tool_use(
+        self.context.event_manager.add_log(
             f"Taking a look at the document at {input} in {repo_name}."
         )
 
@@ -110,7 +110,7 @@ class CodeActionTools(BaseTools):
             codebase.store_file_change(file_change)
             cur.codebases[codebase.repo_info.id].file_changes.append(file_change)
 
-        self.context.event_manager.log_tool_use(
+        self.context.event_manager.add_log(
             f"Made a code change in {file_change.path} in {codebase.repo_info.external_slug}."
         )
 

--- a/src/seer/automation/codebase/codebase_index.py
+++ b/src/seer/automation/codebase/codebase_index.py
@@ -78,17 +78,11 @@ class CodebaseIndex:
 
     @staticmethod
     def has_repo_been_indexed(organization: int, project: int, repo: RepoDefinition):
-        return (
-            Session()
-            .query(DbRepositoryInfo)
-            .filter(
-                DbRepositoryInfo.organization == organization,
-                DbRepositoryInfo.project == project,
-                DbRepositoryInfo.provider == repo.provider,
-                DbRepositoryInfo.external_slug == f"{repo.owner}/{repo.name}",
-            )
-            .count()
-            > 0
+        return CodebaseNamespaceManager.does_repo_exist(
+            organization=organization,
+            project=project,
+            provider=repo.provider,
+            external_slug=repo.full_name,
         )
 
     @classmethod
@@ -177,6 +171,8 @@ class CodebaseIndex:
         embedding_model: SentenceTransformer,
         tracking_branch: str | None = None,
         sha: str | None = None,
+        state: State | None = None,
+        state_manager_class: Type[CodebaseStateManager] | None = None,
     ):
         repo_client = RepoClient(repo.provider, repo.owner, repo.name)
 
@@ -228,7 +224,11 @@ class CodebaseIndex:
                 project,
                 repo_client,
                 workspace=workspace,
-                state_manager=DummyCodebaseStateManager(),
+                state_manager=(
+                    state_manager_class(repo_id=workspace.repo_info.id, state=state)
+                    if state and state_manager_class
+                    else DummyCodebaseStateManager()
+                ),
                 embedding_model=embedding_model,
             )
         finally:

--- a/src/seer/automation/codebase/namespace.py
+++ b/src/seer/automation/codebase/namespace.py
@@ -262,6 +262,21 @@ class CodebaseNamespaceManager:
 
         return cls(repo_info, namespace, storage_adapter)
 
+    @staticmethod
+    def does_repo_exist(organization: int, project: int, provider: str, external_slug: str):
+        with Session() as session:
+            return (
+                session.query(DbRepositoryInfo)
+                .filter(
+                    DbRepositoryInfo.organization == organization,
+                    DbRepositoryInfo.project == project,
+                    DbRepositoryInfo.provider == provider,
+                    DbRepositoryInfo.external_slug == external_slug,
+                )
+                .count()
+                > 0
+            )
+
     def chunk_hashes_exist(self, hashes: list[str]):
         if not hashes:
             return []

--- a/src/seer/automation/pipeline.py
+++ b/src/seer/automation/pipeline.py
@@ -12,8 +12,10 @@ class PipelineContext(abc.ABC):
 
 
 class PipelineSideEffect(abc.ABC):
+    context: PipelineContext
+
     @abc.abstractmethod
-    def invoke(self, context: PipelineContext):
+    def invoke(self):
         pass
 
 
@@ -26,7 +28,7 @@ class Pipeline(abc.ABC):
 
     def invoke_side_effects(self):
         for side_effect in self.side_effects:
-            side_effect.invoke(self.context)
+            side_effect.invoke()
 
     @abc.abstractmethod
     def invoke(self, request: Any) -> Any:


### PR DESCRIPTION
This adds a codebase indexing step in the root cause analysis until we separately call it from the frontend with the new onboarding.

Originally this was to be temporary but I realise having this check isn't too bad an idea