### PR TITLE
fix(autofix): Initialize a repoclient for creating PRs

### DIFF
--- a/src/seer/automation/codebase/codebase_index.py
+++ b/src/seer/automation/codebase/codebase_index.py
@@ -77,6 +77,12 @@ class CodebaseIndex:
         return self.workspace.namespace
 
     @staticmethod
+    def get_repo_info_from_db(repo_id: int):
+        db_repo_info = Session().get(DbRepositoryInfo, repo_id)
+
+        return RepositoryInfo.from_db(db_repo_info) if db_repo_info else None
+
+    @staticmethod
     def has_repo_been_indexed(organization: int, project: int, repo: RepoDefinition):
         return (
             Session()
@@ -140,12 +146,9 @@ class CodebaseIndex:
         state_manager_class: Type[CodebaseStateManager] | None = None,
         namespace_id: int | None = None,
     ):
-        db_repo_info = Session().get(DbRepositoryInfo, repo_id)
+        repo_info = cls.get_repo_info_from_db(repo_id)
 
-        if db_repo_info:
-            repo_info = RepositoryInfo.from_db(db_repo_info)
-            repo_owner, repo_name = db_repo_info.external_slug.split("/")
-
+        if repo_info:
             workspace = CodebaseNamespaceManager.load_workspace(
                 namespace_id=namespace_id or repo_info.default_namespace
             )
@@ -159,7 +162,7 @@ class CodebaseIndex:
                 return cls(
                     organization=repo_info.organization,
                     project=repo_info.project,
-                    repo_client=RepoClient(repo_info.provider, repo_owner, repo_name),
+                    repo_client=RepoClient.from_repo_info(repo_info),
                     workspace=workspace,
                     state_manager=state_manager,
                     embedding_model=embedding_model,

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -14,6 +14,7 @@ from github.Repository import Repository
 from unidiff import PatchSet
 
 from seer.automation.autofix.utils import generate_random_string, sanitize_branch_name
+from seer.automation.codebase.models import RepositoryInfo
 from seer.automation.models import FileChange, InitializationError
 from seer.utils import class_method_lru_cache
 
@@ -69,6 +70,11 @@ class RepoClient:
 
         self.repo_owner = repo_owner
         self.repo_name = repo_name
+
+    @classmethod
+    def from_repo_info(cls, repo_info: RepositoryInfo):
+        repo_owner, repo_name = repo_info.external_slug.split("/")
+        return cls(repo_provider=repo_info.provider, repo_owner=repo_owner, repo_name=repo_name)
 
     @property
     def repo_full_name(self):


### PR DESCRIPTION
Codebase index loading was skipped for PR creation, so we move the repo client initialization out because that's all we need for PR creation