### PR TITLE
fix(autofix): Default namespace is supposed to be nullable

### DIFF
--- a/src/seer/automation/codebase/codebase_index.py
+++ b/src/seer/automation/codebase/codebase_index.py
@@ -184,11 +184,13 @@ class CodebaseIndex:
 
         head_sha = sha
         branch = None
+        is_default_branch = False
 
         if tracking_branch:
             branch = tracking_branch
             head_sha = repo_client.get_branch_head_sha(branch)
         elif not head_sha:
+            is_default_branch = True
             branch = repo_client.get_default_branch()
             head_sha = repo_client.get_branch_head_sha(branch)
 
@@ -219,6 +221,7 @@ class CodebaseIndex:
                 external_slug=repo_client.repo.full_name,
                 head_sha=head_sha,
                 tracking_branch=branch,
+                should_set_as_default=is_default_branch,
             )
             workspace.insert_chunks(embedded_chunks)
             workspace.save()

--- a/src/seer/automation/codebase/codebase_index.py
+++ b/src/seer/automation/codebase/codebase_index.py
@@ -143,9 +143,12 @@ class CodebaseIndex:
         repo_info = cls.get_repo_info_from_db(repo_id)
 
         if repo_info:
-            workspace = CodebaseNamespaceManager.load_workspace(
-                namespace_id=namespace_id or repo_info.default_namespace
-            )
+            namespace_id = namespace_id or repo_info.default_namespace
+
+            if not namespace_id:
+                raise ValueError(f"Repository with id {repo_id} does not have a default namespace")
+
+            workspace = CodebaseNamespaceManager.load_workspace(namespace_id=namespace_id)
 
             if workspace:
                 state_manager = (

--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -141,7 +141,7 @@ class RepositoryInfo(BaseModel):
     project: int
     provider: str
     external_slug: str
-    default_namespace: int
+    default_namespace: Optional[int] = None
 
     @classmethod
     def from_db(cls, db_repo: DbRepositoryInfo) -> "RepositoryInfo":

--- a/src/seer/automation/codebase/namespace.py
+++ b/src/seer/automation/codebase/namespace.py
@@ -142,6 +142,7 @@ class CodebaseNamespaceManager:
         external_slug: str,
         head_sha: str,
         tracking_branch: str | None = None,
+        should_set_as_default: bool = False,
     ):
         with Session() as session:
             db_repo_info = DbRepositoryInfo(
@@ -162,7 +163,8 @@ class CodebaseNamespaceManager:
             session.add(db_namespace)
             session.flush()
 
-            db_repo_info.default_namespace = db_namespace.id
+            if should_set_as_default:
+                db_repo_info.default_namespace = db_namespace.id
 
             session.commit()
 
@@ -182,6 +184,7 @@ class CodebaseNamespaceManager:
         external_slug: str,
         head_sha: str,
         tracking_branch: str | None = None,
+        should_set_as_default: bool = False,
     ):
         with Session() as session:
             db_repo_info = (
@@ -203,12 +206,14 @@ class CodebaseNamespaceManager:
                     external_slug=external_slug,
                     head_sha=head_sha,
                     tracking_branch=tracking_branch,
+                    should_set_as_default=should_set_as_default,
                 )
 
             return cls.create_namespace_for_repo(
                 repo_id=db_repo_info.id,
                 sha=head_sha,
                 tracking_branch=tracking_branch,
+                should_set_as_default=should_set_as_default,
             )
 
     @classmethod
@@ -217,6 +222,7 @@ class CodebaseNamespaceManager:
         repo_id: int,
         sha: str,
         tracking_branch: str | None = None,
+        should_set_as_default: bool = False,
     ):
         with Session() as session:
             existing_namespace = None
@@ -257,7 +263,7 @@ class CodebaseNamespaceManager:
 
             repo_info = RepositoryInfo.from_db(db_repo_info)
 
-            if repo_info.default_namespace is None:
+            if should_set_as_default:
                 repo_info.default_namespace = db_namespace.id
 
             namespace = CodebaseNamespace.from_db(db_namespace)

--- a/src/seer/automation/codebase/namespace.py
+++ b/src/seer/automation/codebase/namespace.py
@@ -256,6 +256,10 @@ class CodebaseNamespaceManager:
             session.commit()
 
             repo_info = RepositoryInfo.from_db(db_repo_info)
+
+            if repo_info.default_namespace is None:
+                repo_info.default_namespace = db_namespace.id
+
             namespace = CodebaseNamespace.from_db(db_namespace)
 
         storage_adapter = get_storage_adapter_class()(repo_info.id, namespace.id, namespace.slug)

--- a/tests/automation/codebase/test_namespace.py
+++ b/tests/automation/codebase/test_namespace.py
@@ -23,7 +23,13 @@ class TestNamespaceManager(unittest.TestCase):
 
     def test_create_repo(self):
         namespace = CodebaseNamespaceManager.create_repo(
-            1, 1337, "github", "getsentry/seer", "sha", tracking_branch="main"
+            1,
+            1337,
+            "github",
+            "getsentry/seer",
+            "sha",
+            tracking_branch="main",
+            should_set_as_default=True,
         )
         namespace.save()
 
@@ -59,7 +65,10 @@ class TestNamespaceManager(unittest.TestCase):
     ):
         with Session() as session:
             db_repo_info = DbRepositoryInfo(
-                organization=1, project=1337, external_slug="getsentry/seer", provider="github"
+                organization=1,
+                project=1337,
+                external_slug="getsentry/seer",
+                provider="github",
             )
             session.add(db_repo_info)
             session.commit()
@@ -88,7 +97,13 @@ class TestNamespaceManager(unittest.TestCase):
 
     def test_insert_chunks(self):
         namespace = CodebaseNamespaceManager.create_repo(
-            1, 1337, "github", "getsentry/seer", "sha", tracking_branch="main"
+            1,
+            1337,
+            "github",
+            "getsentry/seer",
+            "sha",
+            tracking_branch="main",
+            should_set_as_default=True,
         )
 
         namespace.insert_chunks(
@@ -113,7 +128,13 @@ class TestNamespaceManager(unittest.TestCase):
 
     def test_query_chunks(self):
         namespace = CodebaseNamespaceManager.create_repo(
-            1, 1337, "github", "getsentry/seer", "sha", tracking_branch="main"
+            1,
+            1337,
+            "github",
+            "getsentry/seer",
+            "sha",
+            tracking_branch="main",
+            should_set_as_default=True,
         )
 
         namespace.insert_chunks(
@@ -149,7 +170,13 @@ class TestNamespaceManager(unittest.TestCase):
 
     def test_save(self):
         namespace = CodebaseNamespaceManager.create_repo(
-            1, 1337, "github", "getsentry/seer", "sha", tracking_branch="main"
+            1,
+            1337,
+            "github",
+            "getsentry/seer",
+            "sha",
+            tracking_branch="main",
+            should_set_as_default=True,
         )
 
         namespace.save()
@@ -191,38 +218,38 @@ class TestNamespaceManager(unittest.TestCase):
             self.assertEqual(chunks[0].hash, "chunk1hash")
             self.assertEqual(loaded_namespace.namespace.sha, "newsha")
 
-        def test_chunk_hashes_exist(self):
-            namespace = CodebaseNamespaceManager.create_repo(
-                1, 1337, "github", "getsentry/seer", "sha", tracking_branch="main"
-            )
+    def test_chunk_hashes_exist(self):
+        namespace = CodebaseNamespaceManager.create_repo(
+            1, 1337, "github", "getsentry/seer", "sha", tracking_branch="main"
+        )
 
-            namespace.insert_chunks(
-                [
-                    EmbeddedDocumentChunk(
-                        context="chunk1context",
-                        content="chunk1",
-                        hash="chunk1hash",
-                        path="path1",
-                        index=0,
-                        token_count=0,
-                        language="python",
-                        embedding=np.ones((768)),
-                    ),
-                    EmbeddedDocumentChunk(
-                        context="chunk2context",
-                        content="chunk2",
-                        hash="chunk2hash",
-                        path="path1",
-                        index=2,
-                        token_count=0,
-                        language="python",
-                        embedding=np.ones((768)),
-                    ),
-                ]
-            )
+        namespace.insert_chunks(
+            [
+                EmbeddedDocumentChunk(
+                    context="chunk1context",
+                    content="chunk1",
+                    hash="chunk1hash",
+                    path="path1",
+                    index=0,
+                    token_count=0,
+                    language="python",
+                    embedding=np.ones((768)),
+                ),
+                EmbeddedDocumentChunk(
+                    context="chunk2context",
+                    content="chunk2",
+                    hash="chunk2hash",
+                    path="path1",
+                    index=2,
+                    token_count=0,
+                    language="python",
+                    embedding=np.ones((768)),
+                ),
+            ]
+        )
 
-            chunk_hashes = namespace.chunk_hashes_exist(["path1"])
+        chunk_hashes = namespace.chunk_hashes_exist(["chunk1hash", "chunk2hash"])
 
-            self.assertEqual(len(chunk_hashes), 2)
-            self.assertTrue("chunk1hash" in chunk_hashes)
-            self.assertTrue("chunk2hash" in chunk_hashes)
+        self.assertEqual(len(chunk_hashes), 2)
+        self.assertTrue("chunk1hash" in chunk_hashes)
+        self.assertTrue("chunk2hash" in chunk_hashes)


### PR DESCRIPTION
The db model for default namespace field of repo info allows it to be nullable, but the pydantic model doesn't

We allow it to be nullable and also set a default namespace if `should_set_as_default` flag is true