### PR TITLE
fix(autofix): Bump root cause timeout to 1 hr

### DIFF
--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -48,7 +48,8 @@ def get_autofix_state(group_id: int) -> AutofixContinuation | None:
         return continuation.get()
 
 
-@celery_app.task(time_limit=60 * 30)  # 30 minute task timeout
+# TODO: This timeout probably should be dropped back down once we have onboarding call the separate create codebase task
+@celery_app.task(time_limit=60 * 60)  # 60 minute task timeout
 def run_autofix_root_cause(
     request_data: dict[str, Any],
     autofix_group_state: dict[str, Any] | None = None,


### PR DESCRIPTION
bump it up to make space for codebase indexing until onboarding calls it separately