### PR TITLE
fix(autofix): Change timeout logic to work with new stateful arch

### DIFF
--- a/src/seer/app.py
+++ b/src/seer/app.py
@@ -12,6 +12,7 @@ from seer.automation.autofix.models import (
     AutofixUpdateType,
 )
 from seer.automation.autofix.tasks import (
+    check_and_mark_if_timed_out,
     get_autofix_state,
     run_autofix_create_pr,
     run_autofix_execution,
@@ -114,8 +115,11 @@ def autofix_update_endpoint(
 def get_autofix_state_endpoint(data: AutofixStateRequest) -> AutofixStateResponse:
     state = get_autofix_state(data.group_id)
 
+    if state:
+        check_and_mark_if_timed_out(state)
+
     return AutofixStateResponse(
-        group_id=data.group_id, state=state.model_dump(mode="json") if state else None
+        group_id=data.group_id, state=state.get().model_dump(mode="json") if state else None
     )
 
 

--- a/src/seer/automation/autofix/config.py
+++ b/src/seer/automation/autofix/config.py
@@ -1,0 +1,5 @@
+AUTOFIX_ROOT_CAUSE_TIMEOUT_SECS = (
+    60 * 60
+)  # TODO: This timeout probably should be dropped back down once we have onboarding call the separate create codebase task
+AUTOFIX_EXECUTION_TIMEOUT_SECS = 60 * 15
+AUTOFIX_CREATE_PR_TIMEOUT_SECS = 60 * 5

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any, cast
 
 import sentry_sdk
+from pydantic import BaseModel
 
 from celery_app.app import app as celery_app
 from seer.automation.autofix.autofix_context import AutofixContext
@@ -34,7 +35,7 @@ logger = logging.getLogger("autofix")
 @dataclasses.dataclass
 class ContinuationState(DbState[AutofixContinuation]):
     @classmethod
-    def from_id(cls, id: int, model: type[AutofixContinuation]) -> "ContinuationState":
+    def from_id(cls, id: int, model: type[BaseModel]) -> "ContinuationState":
         return cast(ContinuationState, super().from_id(id, model))
 
     def set(self, state: AutofixContinuation):

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -6,6 +6,11 @@ import sentry_sdk
 
 from celery_app.app import app as celery_app
 from seer.automation.autofix.autofix_context import AutofixContext
+from seer.automation.autofix.config import (
+    AUTOFIX_CREATE_PR_TIMEOUT_SECS,
+    AUTOFIX_EXECUTION_TIMEOUT_SECS,
+    AUTOFIX_ROOT_CAUSE_TIMEOUT_SECS,
+)
 from seer.automation.autofix.event_manager import AutofixEventManager
 from seer.automation.autofix.models import (
     AutofixContinuation,
@@ -22,17 +27,22 @@ from seer.automation.autofix.utils import get_sentry_client
 from seer.automation.models import InitializationError
 from seer.automation.state import DbState
 from seer.db import DbRunState, Session
-from seer.rpc import RpcClient
 
 logger = logging.getLogger("autofix")
 
 
 @dataclasses.dataclass
 class ContinuationState(DbState[AutofixContinuation]):
-    pass
+    @classmethod
+    def from_id(cls, id: int, model: type[AutofixContinuation]) -> "ContinuationState":
+        return cast(ContinuationState, super().from_id(id, model))
+
+    def set(self, state: AutofixContinuation):
+        state.mark_updated()
+        super().set(state)
 
 
-def get_autofix_state(group_id: int) -> AutofixContinuation | None:
+def get_autofix_state(group_id: int) -> ContinuationState | None:
     with Session() as session:
         run_state = (
             session.query(DbRunState)
@@ -45,11 +55,17 @@ def get_autofix_state(group_id: int) -> AutofixContinuation | None:
 
         continuation = ContinuationState.from_id(run_state.id, AutofixContinuation)
 
-        return continuation.get()
+        return continuation
 
 
-# TODO: This timeout probably should be dropped back down once we have onboarding call the separate create codebase task
-@celery_app.task(time_limit=60 * 60)  # 60 minute task timeout
+def check_and_mark_if_timed_out(state: ContinuationState):
+    with state.update() as cur:
+        if cur.has_timed_out:
+            cur.mark_running_steps_errored()
+            cur.status = AutofixStatus.ERROR
+
+
+@celery_app.task(time_limit=AUTOFIX_ROOT_CAUSE_TIMEOUT_SECS)
 def run_autofix_root_cause(
     request_data: dict[str, Any],
     autofix_group_state: dict[str, Any] | None = None,
@@ -59,19 +75,20 @@ def run_autofix_root_cause(
         AutofixContinuation(request=request),
         group_id=request.issue.id,
     )
+
+    with state.update() as cur:
+        cur.run_timeout_secs = AUTOFIX_ROOT_CAUSE_TIMEOUT_SECS
+        cur.mark_triggered()
+    cur = state.get()
+
+    # Process has no further work.
+    if cur.status in AutofixStatus.terminal():
+        logger.warning(f"Ignoring job, state {cur.status}")
+        return
+
     event_manager = AutofixEventManager(state)
     event_manager.send_root_cause_analysis_pending()
     try:
-        cur = state.get()
-
-        # Process has no further work.
-        if cur.status in AutofixStatus.terminal():
-            logger.warning(f"Ignoring job, state {cur.status}")
-            return
-
-        if cur.request.has_timed_out:
-            raise InitializationError("Timeout while dealing with autofix request.")
-
         with sentry_sdk.start_span(
             op="seer.automation.autofix",
             description="Run autofix on an issue within celery task",
@@ -88,13 +105,18 @@ def run_autofix_root_cause(
         raise e
 
 
-@celery_app.task(time_limit=60 * 15)  # 15 minute task timeout
+@celery_app.task(time_limit=AUTOFIX_EXECUTION_TIMEOUT_SECS)
 def run_autofix_execution(
     request_data: dict[str, Any],
     autofix_group_state: dict[str, Any] | None = None,
 ):
     request = AutofixUpdateRequest.model_validate(request_data)
     state = ContinuationState.from_id(request.run_id, model=AutofixContinuation)
+
+    with state.update() as cur:
+        cur.run_timeout_secs = AUTOFIX_EXECUTION_TIMEOUT_SECS
+        cur.mark_triggered()
+
     event_manager = AutofixEventManager(state)
     event_manager.send_planning_pending()
 
@@ -123,9 +145,6 @@ def run_autofix_execution(
             logger.warning(f"Ignoring job, state {cur.status}")
             return
 
-        if cur.request.has_timed_out:
-            raise InitializationError("Timeout while dealing with autofix request.")
-
         with sentry_sdk.start_span(
             op="seer.automation.autofix_execution",
             description="Run autofix on an issue within celery task",
@@ -142,7 +161,7 @@ def run_autofix_execution(
         raise e
 
 
-@celery_app.task(time_limit=60 * 5)  # 5 minute task timeout
+@celery_app.task(time_limit=AUTOFIX_CREATE_PR_TIMEOUT_SECS)
 def run_autofix_create_pr(request_data: dict[str, Any]):
     request = AutofixUpdateRequest.model_validate(request_data)
 
@@ -150,6 +169,11 @@ def run_autofix_create_pr(request_data: dict[str, Any]):
         raise ValueError("Invalid payload type for create_pr")
 
     state = ContinuationState.from_id(request.run_id, model=AutofixContinuation)
+
+    with state.update() as cur:
+        cur.run_timeout_secs = AUTOFIX_CREATE_PR_TIMEOUT_SECS
+        cur.mark_triggered()
+
     event_manager = AutofixEventManager(state)
     context = AutofixContext(
         state=state,


### PR DESCRIPTION
Because we moved to a step-based stateful architecture where a subsequent steps can be run at any time after another step we need to change how our timeout logic works.

We remove the timeout values in the `AutofixRequest` and introduce new fields for the autofix state:
- `run_timeout_secs` Timeout sections for a current "run" set by the run
- `last_triggered_at` Timestamp for the last time a run was triggered
- `updated_at` Timestamp for the last time the state was updated, this is set by the `ContinuationState` automatically every time the state is set

Fixes a bug where the execution step won't run after the original 30 min timeout