### PR TITLE
fix(autofix): Link to gh repos with repo id instead of slug

### DIFF
--- a/notebooks/run_eval.ipynb
+++ b/notebooks/run_eval.ipynb
@@ -164,7 +164,7 @@
                 "    request = AutofixRequest(\n",
                 "        organization_id=1,\n",
                 "        project_id=1,\n",
-                "        repos=[RepoDefinition(provider=\"github\", owner=\"getsentry\", name=\"sentry\")],\n",
+                "        repos=[RepoDefinition(provider=\"github\", owner=\"getsentry\", name=\"sentry\", external_id='873328')],\n",
                 "        base_commit_sha=run_item.commit.parents[0].sha,\n",
                 "        issue=run_item.issue,\n",
                 "    )\n",

--- a/src/migrations/versions/5398765db926_migration.py
+++ b/src/migrations/versions/5398765db926_migration.py
@@ -1,0 +1,104 @@
+"""Drop and recreate the repositories table.
+
+Revision ID: 5398765db926
+Revises: d8b8874b594d
+Create Date: 2024-04-22 20:15:18.429995
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "5398765db926"
+down_revision = "d8b8874b594d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_table("codebase_namespaces")
+    op.drop_table("repositories")
+    op.create_table(
+        "repositories",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("organization", sa.BigInteger(), nullable=False),
+        sa.Column("project", sa.BigInteger(), nullable=False),
+        sa.Column("provider", sa.String(), nullable=False),
+        sa.Column("external_slug", sa.String(), nullable=False),
+        sa.Column("external_id", sa.String(), nullable=False),
+        sa.Column("default_namespace", sa.Integer(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("organization", "project", "provider", "external_id"),
+    )
+    with op.batch_alter_table("repositories", schema=None) as batch_op:
+        batch_op.create_index(
+            "ix_repository_organization_project_provider_slug",
+            ["organization", "project", "provider", "external_id"],
+            unique=False,
+        )
+    op.create_table(
+        "codebase_namespaces",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("repo_id", sa.Integer(), nullable=False),
+        sa.Column("sha", sa.String(length=40), nullable=False),
+        sa.Column("tracking_branch", sa.String(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("accessed_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["repo_id"],
+            ["repositories.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("repo_id", "sha"),
+        sa.UniqueConstraint("repo_id", "tracking_branch"),
+    )
+    with op.batch_alter_table("codebase_namespaces", schema=None) as batch_op:
+        batch_op.create_index("ix_codebase_namespace_repo_id_sha", ["repo_id", "sha"], unique=False)
+        batch_op.create_index(
+            "ix_codebase_namespace_repo_id_tracking_branch",
+            ["repo_id", "tracking_branch"],
+            unique=False,
+        )
+
+
+def downgrade():
+    op.drop_table("codebase_namespaces")
+    op.drop_table("repositories")
+    op.create_table(
+        "repositories",
+        sa.Column("id", sa.INTEGER(), autoincrement=True, nullable=False),
+        sa.Column("organization", sa.INTEGER(), nullable=False),
+        sa.Column("project", sa.INTEGER(), nullable=False),
+        sa.Column("provider", sa.VARCHAR(), nullable=False),
+        sa.Column("external_slug", sa.VARCHAR(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("organization", "project", "provider", "external_slug"),
+    )
+    op.create_table(
+        "codebase_namespaces",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("repo_id", sa.Integer(), nullable=False),
+        sa.Column("sha", sa.String(length=40), nullable=False),
+        sa.Column("tracking_branch", sa.String(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["repo_id"],
+            ["repositories.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("repo_id", "sha"),
+        sa.UniqueConstraint("repo_id", "tracking_branch"),
+    )
+    with op.batch_alter_table("repositories", schema=None) as batch_op:
+        batch_op.create_index(
+            "ix_repository_organization_project_provider_slug",
+            ["organization", "project", "provider", "external_slug"],
+            unique=False,
+        )
+    with op.batch_alter_table("codebase_namespaces", schema=None) as batch_op:
+        batch_op.create_index("ix_codebase_namespace_repo_id_sha", ["repo_id", "sha"], unique=False)
+        batch_op.create_index(
+            "ix_codebase_namespace_repo_id_tracking_branch",
+            ["repo_id", "tracking_branch"],
+            unique=False,
+        )

--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -90,7 +90,7 @@ class AutofixContext(PipelineContext):
 
     def has_codebase_index(self, repo: RepoDefinition) -> bool:
         for codebase in self.codebases.values():
-            if codebase.repo_info.external_slug == repo.full_name:
+            if codebase.repo_info.external_id == repo.external_id:
                 return True
 
         return False

--- a/src/seer/automation/codebase/codebase_index.py
+++ b/src/seer/automation/codebase/codebase_index.py
@@ -88,7 +88,7 @@ class CodebaseIndex:
             organization=organization,
             project=project,
             provider=repo.provider,
-            external_slug=repo.full_name,
+            external_id=repo.external_id,
         )
 
     @classmethod
@@ -119,7 +119,7 @@ class CodebaseIndex:
         )
 
         if workspace:
-            repo_client = RepoClient(repo.provider, repo.owner, repo.name)
+            repo_client = RepoClient(repo)
             return cls(
                 organization,
                 project,
@@ -180,7 +180,7 @@ class CodebaseIndex:
         state: State | None = None,
         state_manager_class: Type[CodebaseStateManager] | None = None,
     ):
-        repo_client = RepoClient(repo.provider, repo.owner, repo.name)
+        repo_client = RepoClient(repo)
 
         head_sha = sha
         branch = None
@@ -217,8 +217,7 @@ class CodebaseIndex:
             workspace = CodebaseNamespaceManager.create_namespace_with_new_or_existing_repo(
                 organization=organization,
                 project=project,
-                provider=repo.provider,
-                external_slug=repo_client.repo.full_name,
+                repo=repo,
                 head_sha=head_sha,
                 tracking_branch=branch,
                 should_set_as_default=is_default_branch,

--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -141,6 +141,7 @@ class RepositoryInfo(BaseModel):
     project: int
     provider: str
     external_slug: str
+    external_id: str
     default_namespace: Optional[int] = None
 
     @classmethod
@@ -151,6 +152,7 @@ class RepositoryInfo(BaseModel):
             project=db_repo.project,
             provider=db_repo.provider,
             external_slug=db_repo.external_slug,
+            external_id=db_repo.external_id,
             default_namespace=db_repo.default_namespace,
         )
 
@@ -161,7 +163,16 @@ class RepositoryInfo(BaseModel):
             project=self.project,
             provider=self.provider,
             external_slug=self.external_slug,
+            external_id=self.external_id,
             default_namespace=self.default_namespace,
+        )
+
+    def to_repo_definition(self) -> RepoDefinition:
+        return RepoDefinition(
+            provider=self.provider,
+            owner=self.external_slug.split("/")[0],
+            name=self.external_slug.split("/")[1],
+            external_id=self.external_id,
         )
 
 

--- a/src/seer/automation/codebase/namespace.py
+++ b/src/seer/automation/codebase/namespace.py
@@ -91,7 +91,7 @@ class CodebaseNamespaceManager:
                     DbRepositoryInfo.organization == organization,
                     DbRepositoryInfo.project == project,
                     DbRepositoryInfo.provider == repo.provider,
-                    DbRepositoryInfo.external_slug == repo.full_name,
+                    DbRepositoryInfo.external_id == repo.external_id,
                 )
                 .one_or_none()
             )
@@ -138,8 +138,7 @@ class CodebaseNamespaceManager:
         cls,
         organization: int,
         project: int,
-        provider: str,
-        external_slug: str,
+        repo: RepoDefinition,
         head_sha: str,
         tracking_branch: str | None = None,
         should_set_as_default: bool = False,
@@ -148,8 +147,9 @@ class CodebaseNamespaceManager:
             db_repo_info = DbRepositoryInfo(
                 organization=organization,
                 project=project,
-                provider=provider,
-                external_slug=external_slug,
+                provider=repo.provider,
+                external_slug=repo.full_name,
+                external_id=repo.external_id,
             )
             session.add(db_repo_info)
             session.flush()
@@ -180,8 +180,7 @@ class CodebaseNamespaceManager:
         cls,
         organization: int,
         project: int,
-        provider: str,
-        external_slug: str,
+        repo: RepoDefinition,
         head_sha: str,
         tracking_branch: str | None = None,
         should_set_as_default: bool = False,
@@ -192,8 +191,8 @@ class CodebaseNamespaceManager:
                 .filter(
                     DbRepositoryInfo.organization == organization,
                     DbRepositoryInfo.project == project,
-                    DbRepositoryInfo.provider == provider,
-                    DbRepositoryInfo.external_slug == external_slug,
+                    DbRepositoryInfo.provider == repo.provider,
+                    DbRepositoryInfo.external_id == repo.external_id,
                 )
                 .one_or_none()
             )
@@ -202,8 +201,7 @@ class CodebaseNamespaceManager:
                 return cls.create_repo(
                     organization=organization,
                     project=project,
-                    provider=provider,
-                    external_slug=external_slug,
+                    repo=repo,
                     head_sha=head_sha,
                     tracking_branch=tracking_branch,
                     should_set_as_default=should_set_as_default,
@@ -271,7 +269,7 @@ class CodebaseNamespaceManager:
         return cls(repo_info, namespace, storage_adapter)
 
     @staticmethod
-    def does_repo_exist(organization: int, project: int, provider: str, external_slug: str):
+    def does_repo_exist(organization: int, project: int, provider: str, external_id: str):
         with Session() as session:
             return (
                 session.query(DbRepositoryInfo)
@@ -279,7 +277,7 @@ class CodebaseNamespaceManager:
                     DbRepositoryInfo.organization == organization,
                     DbRepositoryInfo.project == project,
                     DbRepositoryInfo.provider == provider,
-                    DbRepositoryInfo.external_slug == external_slug,
+                    DbRepositoryInfo.external_id == external_id,
                 )
                 .count()
                 > 0

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -58,7 +58,11 @@ class RepoClient:
             )
 
         self.github = Github(auth=get_github_auth(repo_definition.owner, repo_definition.name))
-        self.repo = self.github.get_repo(int(repo_definition.external_id))
+        self.repo = self.github.get_repo(
+            int(repo_definition.external_id)
+            if repo_definition.external_id.isdigit()
+            else repo_definition.full_name
+        )
 
         self.provider = repo_definition.provider
         self.repo_owner = repo_definition.owner

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -3,8 +3,6 @@ import os
 import shutil
 import tarfile
 import tempfile
-import textwrap
-from typing import Optional, TypedDict
 
 import requests
 import sentry_sdk
@@ -41,13 +39,6 @@ def get_github_auth(repo_owner: str, repo_name: str):
         github_auth = app_auth.get_installation_auth(installation.id)
 
     return github_auth
-
-
-class RepoInitializer(TypedDict):
-    provider: str
-    owner: str
-    name: str
-    external_id: str
 
 
 class RepoClient:

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -203,7 +203,7 @@ class RepoDefinition(BaseModel):
         return cleaned_provider
 
     def __hash__(self):
-        return hash((self.provider, self.owner, self.name))
+        return hash((self.provider, self.owner, self.name, self.external_id))
 
 
 class InitializationError(Exception):

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -184,6 +184,7 @@ class RepoDefinition(BaseModel):
     provider: Annotated[str, Examples(("github", "integrations:github"))]
     owner: str
     name: str
+    external_id: Annotated[str, Examples(specialized.ascii_words)]
 
     @property
     def full_name(self):

--- a/src/seer/db.py
+++ b/src/seer/db.py
@@ -166,15 +166,16 @@ class DbRepositoryInfo(Base):
     project: Mapped[int] = mapped_column(BigInteger, nullable=False)
     provider: Mapped[str] = mapped_column(String, nullable=False)
     external_slug: Mapped[str] = mapped_column(String, nullable=False)
+    external_id: Mapped[str] = mapped_column(String, nullable=False)
     default_namespace: Mapped[int] = mapped_column(Integer, nullable=True)
     __table_args__ = (
-        UniqueConstraint("organization", "project", "provider", "external_slug"),
+        UniqueConstraint("organization", "project", "provider", "external_id"),
         Index(
             "ix_repository_organization_project_provider_slug",
             "organization",
             "project",
             "provider",
-            "external_slug",
+            "external_id",
         ),
     )
 

--- a/tests/automation/autofix/test_models.py
+++ b/tests/automation/autofix/test_models.py
@@ -78,30 +78,45 @@ class TestStacktraceHelpers(unittest.TestCase):
 
 class TestRepoDefinition(unittest.TestCase):
     def test_repo_definition_creation(self):
-        repo_def = RepoDefinition(provider="github", owner="seer", name="automation")
+        repo_def = RepoDefinition(
+            provider="github", owner="seer", name="automation", external_id="123"
+        )
         self.assertEqual(repo_def.provider, "github")
         self.assertEqual(repo_def.owner, "seer")
         self.assertEqual(repo_def.name, "automation")
+        self.assertEqual(repo_def.external_id, "123")
 
     def test_repo_definition_uniqueness(self):
-        repo_def1 = RepoDefinition(provider="github", owner="seer", name="automation")
-        repo_def2 = RepoDefinition(provider="github", owner="seer", name="automation")
+        repo_def1 = RepoDefinition(
+            provider="github", owner="seer", name="automation", external_id="123"
+        )
+        repo_def2 = RepoDefinition(
+            provider="github", owner="seer", name="automation", external_id="123"
+        )
         self.assertEqual(hash(repo_def1), hash(repo_def2))
 
     def test_multiple_repos(self):
-        repo_def1 = RepoDefinition(provider="github", owner="seer", name="automation")
-        repo_def2 = RepoDefinition(provider="github", owner="seer", name="automation-tools")
+        repo_def1 = RepoDefinition(
+            provider="github", owner="seer", name="automation", external_id="123"
+        )
+        repo_def2 = RepoDefinition(
+            provider="github", owner="seer", name="automation-tools", external_id="123"
+        )
         self.assertNotEqual(hash(repo_def1), hash(repo_def2))
 
     def test_repo_with_provider_processing(self):
-        repo_def = RepoDefinition(provider="integrations:github", owner="seer", name="automation")
+        repo_def = RepoDefinition(
+            provider="integrations:github", owner="seer", name="automation", external_id="123"
+        )
         self.assertEqual(repo_def.provider, "github")
         self.assertEqual(repo_def.owner, "seer")
         self.assertEqual(repo_def.name, "automation")
 
     def test_repo_with_invalid_provider(self):
         with self.assertRaises(ValidationError):
-            RepoDefinition(provider="invalid_provider", owner="seer", name="automation")
+            RepoDefinition(
+                provider="invalid_provider", owner="seer", name="automation", external_id="123"
+            )
 
     def test_repo_with_none_provider(self):
         repo_dict = {"provider": None, "owner": "seer", "name": "automation"}
@@ -111,7 +126,9 @@ class TestRepoDefinition(unittest.TestCase):
 
 class TestAutofixRequest(unittest.TestCase):
     def test_autofix_request_handler(self):
-        repo_def = RepoDefinition(provider="github", owner="seer", name="automation")
+        repo_def = RepoDefinition(
+            provider="github", owner="seer", name="automation", external_id="123"
+        )
         issue_details = IssueDetails(
             id=789, title="Test Issue", events=[SentryEventData(title="yes", entries=[])]
         )
@@ -128,8 +145,12 @@ class TestAutofixRequest(unittest.TestCase):
         self.assertEqual(autofix_request.issue.title, "Test Issue")
 
     def test_autofix_request_with_duplicate_repos(self):
-        repo_def1 = RepoDefinition(provider="github", owner="seer", name="automation")
-        repo_def2 = RepoDefinition(provider="github", owner="seer", name="automation")
+        repo_def1 = RepoDefinition(
+            provider="github", owner="seer", name="automation", external_id="123"
+        )
+        repo_def2 = RepoDefinition(
+            provider="github", owner="seer", name="automation", external_id="123"
+        )
         with self.assertRaises(ValidationError):
             AutofixRequest(
                 organization_id=123,
@@ -141,8 +162,12 @@ class TestAutofixRequest(unittest.TestCase):
             )
 
     def test_autofix_request_with_multiple_repos(self):
-        repo_def1 = RepoDefinition(provider="github", owner="seer", name="automation")
-        repo_def2 = RepoDefinition(provider="github", owner="seer", name="automation-tools")
+        repo_def1 = RepoDefinition(
+            provider="github", owner="seer", name="automation", external_id="123"
+        )
+        repo_def2 = RepoDefinition(
+            provider="github", owner="seer", name="automation-tools", external_id="123"
+        )
         issue_details = IssueDetails(
             id=789, title="Test Issue", events=[SentryEventData(title="yes", entries=[])]
         )

--- a/tests/automation/codebase/test_namespace.py
+++ b/tests/automation/codebase/test_namespace.py
@@ -7,6 +7,7 @@ import numpy as np
 from seer.automation.codebase.models import CodebaseNamespace, EmbeddedDocumentChunk
 from seer.automation.codebase.namespace import CodebaseNamespaceManager
 from seer.automation.codebase.storage_adapters import FilesystemStorageAdapter
+from seer.automation.models import RepoDefinition
 from seer.db import DbCodebaseNamespace, DbRepositoryInfo, Session
 
 
@@ -25,8 +26,7 @@ class TestNamespaceManager(unittest.TestCase):
         namespace = CodebaseNamespaceManager.create_repo(
             1,
             1337,
-            "github",
-            "getsentry/seer",
+            RepoDefinition(provider="github", owner="getsentry", name="seer", external_id="123"),
             "sha",
             tracking_branch="main",
             should_set_as_default=True,
@@ -70,6 +70,7 @@ class TestNamespaceManager(unittest.TestCase):
                 organization=1,
                 project=1337,
                 external_slug="getsentry/seer",
+                external_id="123",
                 provider="github",
             )
             session.add(db_repo_info)
@@ -80,7 +81,11 @@ class TestNamespaceManager(unittest.TestCase):
 
         CodebaseNamespaceManager.create_repo.assert_not_called()
         CodebaseNamespaceManager.create_namespace_with_new_or_existing_repo(
-            1, 1337, "github", "getsentry/seer", "sha", tracking_branch="main"
+            1,
+            1337,
+            RepoDefinition(provider="github", owner="getsentry", name="seer", external_id="123"),
+            "sha",
+            tracking_branch="main",
         )
 
         CodebaseNamespaceManager.create_or_get_namespace_for_repo.assert_called_once()
@@ -93,7 +98,11 @@ class TestNamespaceManager(unittest.TestCase):
         self, mock_create_namespace_for_repo, mock_create_repo
     ):
         CodebaseNamespaceManager.create_namespace_with_new_or_existing_repo(
-            1, 1337, "github", "getsentry/seer", "sha", tracking_branch="main"
+            1,
+            1337,
+            RepoDefinition(provider="github", owner="getsentry", name="seer", external_id="123"),
+            "sha",
+            tracking_branch="main",
         )
 
         CodebaseNamespaceManager.create_or_get_namespace_for_repo.assert_not_called()
@@ -103,8 +112,7 @@ class TestNamespaceManager(unittest.TestCase):
         namespace = CodebaseNamespaceManager.create_repo(
             1,
             1337,
-            "github",
-            "getsentry/seer",
+            RepoDefinition(provider="github", owner="getsentry", name="seer", external_id="123"),
             "sha",
             tracking_branch="main",
             should_set_as_default=True,
@@ -134,8 +142,7 @@ class TestNamespaceManager(unittest.TestCase):
         namespace = CodebaseNamespaceManager.create_repo(
             1,
             1337,
-            "github",
-            "getsentry/seer",
+            RepoDefinition(provider="github", owner="getsentry", name="seer", external_id="123"),
             "sha",
             tracking_branch="main",
             should_set_as_default=True,
@@ -176,8 +183,7 @@ class TestNamespaceManager(unittest.TestCase):
         namespace = CodebaseNamespaceManager.create_repo(
             1,
             1337,
-            "github",
-            "getsentry/seer",
+            RepoDefinition(provider="github", owner="getsentry", name="seer", external_id="123"),
             "sha",
             tracking_branch="main",
             should_set_as_default=True,
@@ -224,7 +230,11 @@ class TestNamespaceManager(unittest.TestCase):
 
     def test_chunk_hashes_exist(self):
         namespace = CodebaseNamespaceManager.create_repo(
-            1, 1337, "github", "getsentry/seer", "sha", tracking_branch="main"
+            1,
+            1337,
+            RepoDefinition(provider="github", owner="getsentry", name="seer", external_id="123"),
+            "sha",
+            tracking_branch="main",
         )
 
         namespace.insert_chunks(

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import patch
 
+from pydantic import ValidationError
+
 from seer.automation.codebase.repo_client import RepoClient
 from seer.automation.models import InitializationError, RepoDefinition
 
@@ -20,17 +22,11 @@ class TestRepoClient(unittest.TestCase):
         )
         self.assertEqual(client.provider, "github")
 
-    @patch("seer.automation.codebase.repo_client.get_github_auth")
-    def test_repo_client_rejects_unsupported_provider(self, mock_get_github_auth):
-        mock_get_github_auth.return_value = (
-            None  # Assuming get_github_auth returns None for simplicity
-        )
-        with self.assertRaises(InitializationError):
-            RepoClient(
-                RepoDefinition(
-                    provider="unsupported_provider",
-                    owner="getsentry",
-                    name="seer",
-                    external_id="123",
-                )
+    def test_repo_definition_rejects_unsupported_provider(self):
+        with self.assertRaises(ValidationError):
+            RepoDefinition(
+                provider="unsupported_provider",
+                owner="getsentry",
+                name="seer",
+                external_id="123",
             )

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch
 
 from seer.automation.codebase.repo_client import RepoClient
-from seer.automation.models import InitializationError
+from seer.automation.models import InitializationError, RepoDefinition
 
 
 class TestRepoClient(unittest.TestCase):
@@ -15,7 +15,9 @@ class TestRepoClient(unittest.TestCase):
         mock_get_github_auth.return_value = (
             None  # Assuming get_github_auth returns None for simplicity
         )
-        client = RepoClient(repo_provider="github", repo_owner="test_owner", repo_name="test_repo")
+        client = RepoClient(
+            RepoDefinition(provider="github", owner="getsentry", name="seer", external_id="123")
+        )
         self.assertEqual(client.provider, "github")
 
     @patch("seer.automation.codebase.repo_client.get_github_auth")
@@ -25,5 +27,10 @@ class TestRepoClient(unittest.TestCase):
         )
         with self.assertRaises(InitializationError):
             RepoClient(
-                repo_provider="unsupported_provider", repo_owner="test_owner", repo_name="test_repo"
+                RepoDefinition(
+                    provider="unsupported_provider",
+                    owner="getsentry",
+                    name="seer",
+                    external_id="123",
+                )
             )


### PR DESCRIPTION
Use `external_id` which should be a unique id from the github integration from sentry to reference repos instead of the slug.

Tested locally by sending seer's repo id with `timeseries-analysis-service` old name.

The migration will completely drop the repositories and namespaces tables and create a new one enforcing a non-null `external_id` field which will be sent from sentry. This was a manually made migration...would appreciate a double check.

Depends on https://github.com/getsentry/sentry/pull/69449