### PR TITLE
fix(autofix): Log errors in autofix pipelines to ui

### DIFF
--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -211,3 +211,10 @@ class AutofixEventManager:
                         type=ProgressType.INFO,
                     )
                 )
+
+    def on_error(self, error_msg: str = "Something went wrong"):
+        with self.state.update() as cur:
+            cur.mark_running_steps_errored()
+            cur.set_last_step_completed_message(error_msg)
+
+            cur.status = AutofixStatus.ERROR

--- a/src/seer/automation/autofix/pipelines.py
+++ b/src/seer/automation/autofix/pipelines.py
@@ -131,9 +131,7 @@ class AutofixRootCause(Pipeline):
         ]
 
     @traceable(name="Root Cause", tags=["autofix:v2"])
-    def invoke(self):
-        self.invoke_side_effects()
-
+    def _invoke(self):
         self.context.event_manager.send_root_cause_analysis_start()
 
         if self.context.has_missing_codebase_indexes():
@@ -152,6 +150,9 @@ class AutofixRootCause(Pipeline):
 
         self.context.event_manager.send_root_cause_analysis_result(root_cause_output)
 
+    def _handle_exception(self, exception: Exception):
+        self.context.event_manager.on_error()
+
 
 class AutofixExecution(Pipeline):
     """
@@ -166,9 +167,7 @@ class AutofixExecution(Pipeline):
         self.side_effects = [CheckCodebaseForUpdatesSideEffect(context)]
 
     @traceable(name="Execution", tags=["autofix:v2"])
-    def invoke(self):
-        self.invoke_side_effects()
-
+    def _invoke(self):
         self.context.event_manager.send_planning_start()
 
         if self.context.has_missing_codebase_indexes():
@@ -228,6 +227,9 @@ class AutofixExecution(Pipeline):
             codebase_changes.append(change)
 
         self.context.event_manager.send_execution_complete(codebase_changes)
+
+    def _handle_exception(self, exception: Exception):
+        self.context.event_manager.on_error()
 
     @traceable(name="Executor with Retriever", run_type="llm")
     def _run_executor_with_retriever(

--- a/src/seer/automation/pipeline.py
+++ b/src/seer/automation/pipeline.py
@@ -26,10 +26,22 @@ class Pipeline(abc.ABC):
     def __init__(self, context: PipelineContext):
         self.context = context
 
-    def invoke_side_effects(self):
+    def _invoke_side_effects(self):
         for side_effect in self.side_effects:
             side_effect.invoke()
 
+    def invoke(self) -> Any:
+        try:
+            self._invoke_side_effects()
+            return self._invoke()
+        except Exception as e:
+            self._handle_exception(e)
+            raise e
+
     @abc.abstractmethod
-    def invoke(self, request: Any) -> Any:
+    def _handle_exception(self, exception: Exception):
+        pass
+
+    @abc.abstractmethod
+    def _invoke(self) -> Any:
         pass


### PR DESCRIPTION
Errors in the new pipelines weren't correctly showing up on the UI after the state change. This makes sure they're caught and presented in the UI accordingly by having an exception handler in each pipeline

Tested e2e locally