### PR TITLE
perf: add endpoint that only calculates embedding

### DIFF
--- a/src/seer/grouping/grouping.py
+++ b/src/seer/grouping/grouping.py
@@ -66,6 +66,10 @@ class SimilarityResponse(BaseModel):
     token: Optional[int]
 
 
+class SimilarityBenchmarkResponse(BaseModel):
+    embedding: List[float]
+
+
 class GroupingLookup:
     """Manages the grouping of similar stack traces using sentence embeddings and pgvector for similarity search.
 


### PR DESCRIPTION
we'd like to isolate the embeddings for testing different hardware/deployment configs. creates an endpoint that only calculates embeddings, and no comparisons.

