### PR TITLE
fix(autofix): Fix newline + quote problems in execution

### DIFF
--- a/src/seer/automation/autofix/components/snippet_replacement.py
+++ b/src/seer/automation/autofix/components/snippet_replacement.py
@@ -3,6 +3,7 @@ import textwrap
 from seer.automation.agent.client import GptClient
 from seer.automation.agent.models import Message
 from seer.automation.autofix.autofix_context import AutofixContext
+from seer.automation.autofix.utils import extract_text_inside_tags
 from seer.automation.component import BaseComponent, BaseComponentOutput, BaseComponentRequest
 
 
@@ -48,7 +49,7 @@ class SnippetReplacementPrompts:
             Make sure you fix any errors in the code and ensure it is working as expected to the intent of the change.
             Do not make extraneous changes to the code or whitespace that are not related to the intent of the change.
 
-            You MUST return the code result under the "code": key in the response JSON object."""
+            You MUST return the code result inside a <code></code> tag."""
         ).format(
             reference_snippet=reference_snippet,
             replacement_snippet=replacement_snippet,
@@ -62,6 +63,9 @@ class SnippetReplacementComponent(
 ):
     context: AutofixContext
 
+    def _parser(self, text: str | None):
+        return extract_text_inside_tags(text, "code", strip_newlines=True) if text else None
+
     def invoke(self, request: SnippetReplacementRequest) -> SnippetReplacementOutput | None:
         prompt = SnippetReplacementPrompts.format_default_msg(
             reference_snippet=request.reference_snippet,
@@ -70,8 +74,8 @@ class SnippetReplacementComponent(
             commit_message=request.commit_message,
         )
 
-        data, message, usage = GptClient().json_completion(
-            [Message(role="user", content=prompt)],
+        data, message, usage = GptClient().completion_with_parser(
+            [Message(role="user", content=prompt)], parser=self._parser
         )
 
         with self.context.state.update() as cur:
@@ -80,4 +84,4 @@ class SnippetReplacementComponent(
         if data is None:
             return None
 
-        return SnippetReplacementOutput(snippet=data["code"])
+        return SnippetReplacementOutput(snippet=data)

--- a/src/seer/automation/autofix/utils.py
+++ b/src/seer/automation/autofix/utils.py
@@ -181,6 +181,31 @@ def escape_multi_xml(s: str, tags: List[str]) -> str:
     return s
 
 
+def extract_text_inside_tags(content: str, tag: str, strip_newlines: bool = True) -> str:
+    """
+    Extract the text inside the specified XML tag.
+
+    Args:
+        content (str): The XML content.
+        tag (str): The tag to extract the text from.
+
+    Returns:
+        str: The text inside the specified XML tag.
+    """
+    start_tag = f"<{tag}>"
+    end_tag = f"</{tag}>"
+
+    start_index = content.find(start_tag)
+    end_index = content.find(end_tag)
+
+    if start_index == -1 or end_index == -1:
+        return ""
+
+    text = content[start_index + len(start_tag) : end_index]
+
+    return text.strip("\n") if strip_newlines else text
+
+
 def extract_xml_element_text(element: ET.Element, tag: str) -> str | None:
     """
     Extract the text from an XML element with the given tag.

--- a/tests/automation/autofix/components/test_snippet_replacement.py
+++ b/tests/automation/autofix/components/test_snippet_replacement.py
@@ -1,0 +1,106 @@
+import textwrap
+import unittest
+from unittest.mock import patch
+
+from seer.automation.agent.models import Message, Usage
+from seer.automation.autofix.components.snippet_replacement import (
+    SnippetReplacementComponent,
+    SnippetReplacementRequest,
+)
+
+
+class TestSnippetReplacementComponent(unittest.TestCase):
+    @patch("seer.automation.autofix.components.snippet_replacement.AutofixContext")
+    @patch("seer.automation.autofix.components.snippet_replacement.GptClient.completion")
+    def test_simple(self, mock_completion_with_parser, mock_autofix_context):
+        component = SnippetReplacementComponent(mock_autofix_context.return_value)
+
+        mock_completion_with_parser.return_value = (
+            Message(
+                role="assistant",
+                content=textwrap.dedent(
+                    """\
+                    <code>
+                    function foo() {
+                        const y = 0;
+                    }
+                    </code>"""
+                ),
+            ),
+            Usage(),
+        )
+
+        output = component.invoke(
+            SnippetReplacementRequest(
+                reference_snippet="const x = 0",
+                replacement_snippet="const y = 0",
+                chunk=textwrap.dedent(
+                    """\
+                    function foo() {
+                        const x = 0;
+                    }"""
+                ),
+                commit_message="Message",
+            )
+        )
+
+        self.assertIsNotNone(output)
+        if output is not None:
+            self.assertEqual(
+                output.snippet,
+                textwrap.dedent(
+                    """\
+                    function foo() {
+                        const y = 0;
+                    }"""
+                ),
+            )
+
+    @patch("seer.automation.autofix.components.snippet_replacement.AutofixContext")
+    @patch("seer.automation.autofix.components.snippet_replacement.GptClient.completion")
+    def test_with_extra_newlines(self, mock_completion_with_parser, mock_autofix_context):
+        component = SnippetReplacementComponent(mock_autofix_context.return_value)
+
+        mock_completion_with_parser.return_value = (
+            Message(
+                role="assistant",
+                content=textwrap.dedent(
+                    """\
+                    <code>
+
+                    function foo() {
+                        const y = 0;
+                    }
+
+
+                    </code>"""
+                ),
+            ),
+            Usage(),
+        )
+
+        output = component.invoke(
+            SnippetReplacementRequest(
+                reference_snippet="const x = 0",
+                replacement_snippet="const y = 0",
+                chunk=textwrap.dedent(
+                    """\
+                    function foo() {
+                        const x = 0;
+                    }"""
+                ),
+                commit_message="Message",
+            )
+        )
+
+        self.assertIsNotNone(output)
+        if output is not None:
+            self.assertEqual(
+                output.snippet,
+                textwrap.dedent(
+                    """\
+                    function foo() {
+                        const y = 0;
+                    }"""
+                ),
+            )

--- a/tests/automation/autofix/test_autofix_tools.py
+++ b/tests/automation/autofix/test_autofix_tools.py
@@ -2,15 +2,17 @@ import textwrap
 import unittest
 from unittest.mock import MagicMock, patch
 
+from seer.automation.autofix.components.snippet_replacement import SnippetReplacementOutput
 from seer.automation.autofix.tools import CodeActionTools
 from seer.automation.models import FileChange
 
 
 class TestReplaceSnippetWith(unittest.TestCase):
-    @patch("seer.automation.autofix.components.snippet_replacement.GptClient")
-    def test_replace_snippet_with_success(self, mock_gpt_client):
+    @patch(
+        "seer.automation.autofix.components.snippet_replacement.SnippetReplacementComponent.invoke"
+    )
+    def test_replace_snippet_with_success(self, mock_invoke):
         mock_context = MagicMock()
-        mock_gpt_client = mock_gpt_client
         code_action_tools = CodeActionTools(context=mock_context)
 
         # Setup
@@ -37,7 +39,7 @@ class TestReplaceSnippetWith(unittest.TestCase):
             """
         )
         completion_with_parser.return_value = ({"code": code}, MagicMock(), MagicMock())
-        mock_gpt_client.return_value.json_completion = completion_with_parser
+        mock_invoke.return_value = SnippetReplacementOutput(snippet=code)
 
         result = code_action_tools.replace_snippet_with(
             file_path, "repo", original_snippet, replacement_snippet, "message"
@@ -45,7 +47,7 @@ class TestReplaceSnippetWith(unittest.TestCase):
 
         # Assert
         self.assertTrue(result)
-        self.assertEquals(result, f"success: Resulting code after replacement:\n```\n{code}\n```\n")
+        self.assertEqual(result, f"success: Resulting code after replacement:\n```\n{code}\n```\n")
         mock_codebase.store_file_change.assert_called_once_with(
             FileChange(
                 change_type="edit",
@@ -56,10 +58,11 @@ class TestReplaceSnippetWith(unittest.TestCase):
             )
         )
 
-    @patch("seer.automation.autofix.components.snippet_replacement.GptClient")
-    def test_replace_snippet_with_chunk_newlines(self, mock_gpt_client):
+    @patch(
+        "seer.automation.autofix.components.snippet_replacement.SnippetReplacementComponent.invoke"
+    )
+    def test_replace_snippet_with_chunk_newlines(self, mock_invoke):
         mock_context = MagicMock()
-        mock_gpt_client = mock_gpt_client
         code_action_tools = CodeActionTools(context=mock_context)
 
         # Setup
@@ -88,7 +91,7 @@ class TestReplaceSnippetWith(unittest.TestCase):
                 return True"""
         )
         completion_with_parser.return_value = ({"code": code}, MagicMock(), MagicMock())
-        mock_gpt_client.return_value.json_completion = completion_with_parser
+        mock_invoke.return_value = SnippetReplacementOutput(snippet=code)
 
         result = code_action_tools.replace_snippet_with(
             file_path, "repo", original_snippet, replacement_snippet, "message"
@@ -96,7 +99,7 @@ class TestReplaceSnippetWith(unittest.TestCase):
 
         # Assert
         self.assertTrue(result)
-        self.assertEquals(result, f"success: Resulting code after replacement:\n```\n{code}\n```\n")
+        self.assertEqual(result, f"success: Resulting code after replacement:\n```\n{code}\n```\n")
         mock_codebase.store_file_change.assert_called_once_with(
             FileChange(
                 change_type="edit",


### PR DESCRIPTION
Revert to using xml in the snippet replacement component + trim any newlines