### PR TITLE
perf: add torch num threads env var

### DIFF
--- a/src/seer/bootup.py
+++ b/src/seer/bootup.py
@@ -72,6 +72,11 @@ def bootup(
     if async_load_models:
         start_loading(async_load_models)
 
+    if os.environ.get("TORCH_NUM_THREADS"):
+        import torch
+
+        torch.set_num_threads(int(os.environ.get("TORCH_NUM_THREADS")))
+
     return app
 
 

--- a/src/seer/bootup.py
+++ b/src/seer/bootup.py
@@ -72,10 +72,11 @@ def bootup(
     if async_load_models:
         start_loading(async_load_models)
 
-    if os.environ.get("TORCH_NUM_THREADS"):
+    torch_num_threads = os.environ.get("TORCH_NUM_THREADS")
+    if torch_num_threads:
         import torch
 
-        torch.set_num_threads(int(os.environ.get("TORCH_NUM_THREADS")))
+        torch.set_num_threads(int(torch_num_threads))
 
     return app
 


### PR DESCRIPTION
depending on how we want to tune our deployments for latency vs throughput, configuring the number of threads for pytorch to use is an important lever. this PR lets us do that through an environment variable


see https://huggingface.co/blog/bert-cpu-scaling-part-1#6-core-count-scaling---does-using-more-cores-actually-improve-performance for more info