### PR TITLE
perf: add benchmark vm commands

### DIFF
--- a/bin/create-benchmark-request-maker.sh
+++ b/bin/create-benchmark-request-maker.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+gcloud compute instances create seer-benchmark-request-maker-20240430-213423 \
+    --project=ml-ai-420606 \
+    --zone=us-central1-a \
+    --machine-type=c3d-standard-4 \
+    --network-interface=network-tier=PREMIUM,nic-type=GVNIC,stack-type=IPV4_ONLY,subnet=default \
+    --maintenance-policy=MIGRATE \
+    --provisioning-model=STANDARD \
+    --service-account=996102297610-compute@developer.gserviceaccount.com \
+    --scopes=https://www.googleapis.com/auth/cloud-platform \
+    --create-disk=auto-delete=yes,boot=yes,device-name=seer-benchmark-request-maker,image=projects/ubuntu-os-cloud/global/images/ubuntu-2004-focal-v20240307b,mode=rw,size=200,type=projects/ml-ai-420606/zones/us-central1-a/diskTypes/pd-balanced \
+    --no-shielded-secure-boot \
+    --shielded-vtpm \
+    --shielded-integrity-monitoring \
+    --labels=goog-ec-src=vm_add-gcloud \
+    --reservation-affinity=any
+
+
+# run this stuff then u good to go
+# gcloud compute ssh    seer-benchmark-request-maker-20240430-213423
+# git clone https://github.com/getsentry/seer.git
+# sudo apt update
+# sudo apt -y upgrade
+# sudo apt install -y python3-pip
+# pip3 install locust

--- a/bin/create-benchmark-seer-vm.sh
+++ b/bin/create-benchmark-seer-vm.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+gcloud compute instances create-with-container seer-benchmark-20240430-212403 \
+    --project=ml-ai-420606 \
+    --zone=us-central1-a \
+    --machine-type=c3-highcpu-22 \
+    --network-interface=network-tier=PREMIUM,nic-type=GVNIC,subnet=default \
+    --maintenance-policy=MIGRATE \
+    --provisioning-model=STANDARD \
+    --service-account=996102297610-compute@developer.gserviceaccount.com \
+    --scopes=https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append \
+    --tags=http-server \
+    --image=projects/cos-cloud/global/images/cos-stable-109-17800-147-60 \
+    --boot-disk-size=200GB \
+    --boot-disk-type=pd-balanced \
+    --boot-disk-device-name=seer-benchmark \
+    --container-image=us-central1-docker.pkg.dev/ml-ai-420606/seer-benchmar/benchmark@sha256:01836d995f83e62666fb7f6dec24806aca647493c46788aeaa4707097eb383ce \
+    --container-restart-policy=always \
+    --container-privileged \
+    --container-stdin \
+    --container-tty \
+    --container-env=SEVERITY_ENABLED=true,GROUPING_ENABLED=true,PORT=80,SENTRY_BASE_URL=values.sentry_base_url,DATABASE_URL=postgresql\+psycopg://root:seer@10.128.0.7/seer,WEB_CONCURRENCY=11 \
+    --no-shielded-secure-boot \
+    --shielded-vtpm \
+    --shielded-integrity-monitoring \
+    --labels=goog-ec-src=vm_add-gcloud,container-vm=cos-stable-109-17800-147-60

--- a/bin/create-benchmark-seer-vm.sh
+++ b/bin/create-benchmark-seer-vm.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-gcloud compute instances create-with-container seer-benchmark-20240430-212403 \
+gcloud compute instances create-with-container seer-benchmark-1 \
     --project=ml-ai-420606 \
     --zone=us-central1-a \
-    --machine-type=c3-highcpu-22 \
-    --network-interface=network-tier=PREMIUM,nic-type=GVNIC,subnet=default \
-    --maintenance-policy=MIGRATE \
+    --machine-type=g2-standard-4 \
+    --accelerator=count=1,type=nvidia-l4 \
+    --network-interface=network-tier=PREMIUM,nic-type=GVNIC,subnet=default,private-network-ip=10.128.0.100 \
     --provisioning-model=STANDARD \
+    --maintenance-policy=TERMINATE \
     --service-account=996102297610-compute@developer.gserviceaccount.com \
     --scopes=https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append \
     --tags=http-server \

--- a/bin/rm-benchmark-seer-vm.sh
+++ b/bin/rm-benchmark-seer-vm.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+gcloud compute instances delete seer-benchmark-1 \
+    --project=ml-ai-420606 \
+    --zone=us-central1-a \
+    --quiet

--- a/bin/run-locust-command.sh
+++ b/bin/run-locust-command.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+gcloud compute ssh --zone "us-central1-a" "seer-benchmark-request-maker-20240430-213423" --project "ml-ai-420606" --command "cd /home/jferge/seer/benchmark && /home/jferge/.local/bin/locust --headless --host http://10.128.0.100 -u 1"


### PR DESCRIPTION
these commands are used to create vms for benchmarking seer. they are more of a references as it requires them to be edited for any customizations you'd want to do for them. but a good start!