### PR TITLE
ref(codebase): Split codebase create and indexing

### DIFF
--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -105,10 +105,13 @@ class AutofixContext(PipelineContext):
         return self.state.get().find_step(id=self.event_manager.indexing_step.id) is not None
 
     def create_codebase_index(self, repo: RepoDefinition) -> CodebaseIndex:
-        codebase_index = CodebaseIndex.create(
+        namespace_id = CodebaseIndex.create(
             self.organization_id,
             self.project_id,
             repo,
+        )
+        codebase_index = CodebaseIndex.index(
+            namespace_id,
             embedding_model=self.embedding_model,
         )
 

--- a/src/seer/automation/codebase/codebase_index.py
+++ b/src/seer/automation/codebase/codebase_index.py
@@ -41,7 +41,15 @@ from seer.automation.codebase.utils import (
     read_directory,
     read_specific_files,
 )
-from seer.automation.models import FileChange, FilePatch, Hunk, Line, RepoDefinition, Stacktrace
+from seer.automation.models import (
+    FileChange,
+    FilePatch,
+    Hunk,
+    InitializationError,
+    Line,
+    RepoDefinition,
+    Stacktrace,
+)
 from seer.automation.state import State
 from seer.db import DbRepositoryInfo, Session
 from seer.utils import class_method_lru_cache
@@ -221,7 +229,7 @@ class CodebaseIndex:
         workspace = CodebaseNamespaceManager.load_workspace(namespace_id, skip_copy=True)
 
         if not workspace:
-            raise ValueError("Failed to load workspace")
+            raise InitializationError("Failed to load workspace for namespace_id")
 
         try:
             repo_client = RepoClient.from_repo_info(workspace.repo_info)

--- a/src/seer/automation/codebase/codebase_index.py
+++ b/src/seer/automation/codebase/codebase_index.py
@@ -172,20 +172,14 @@ class CodebaseIndex:
 
         raise ValueError(f"Repository with id {repo_id} not found")
 
-    @classmethod
-    @traceable(name="Creating codebase index")
-    @ai_track(description="Creating codebase index")
+    @staticmethod
     def create(
-        cls,
         organization: int,
         project: int,
         repo: RepoDefinition,
-        embedding_model: SentenceTransformer,
         tracking_branch: str | None = None,
         sha: str | None = None,
-        state: State | None = None,
-        state_manager_class: Type[CodebaseStateManager] | None = None,
-    ):
+    ) -> int:
         repo_client = RepoClient(repo)
 
         head_sha = sha
@@ -203,20 +197,40 @@ class CodebaseIndex:
         if not head_sha:
             raise ValueError("Failed to get head sha")
 
-        tmp_dir, tmp_repo_dir = repo_client.load_repo_to_tmp_dir(head_sha)
-        logger.debug(f"Loaded repository to {tmp_repo_dir}")
+        workspace = CodebaseNamespaceManager.create_namespace_with_new_or_existing_repo(
+            organization=organization,
+            project=project,
+            repo=repo,
+            head_sha=head_sha,
+            tracking_branch=branch,
+            should_set_as_default=is_default_branch,
+        )
+
+        return workspace.namespace.id
+
+    @classmethod
+    @traceable(name="Indexing namespace")
+    @ai_track(description="Indexing namespace")
+    def index(
+        cls,
+        namespace_id: int,
+        embedding_model: SentenceTransformer,
+        state: State | None = None,
+        state_manager_class: Type[CodebaseStateManager] | None = None,
+    ):
+        workspace = CodebaseNamespaceManager.load_workspace(namespace_id, skip_copy=True)
+
+        if not workspace:
+            raise ValueError("Failed to load workspace")
+
         try:
-            workspace = CodebaseNamespaceManager.create_namespace_with_new_or_existing_repo(
-                organization=organization,
-                project=project,
-                repo=repo,
-                head_sha=head_sha,
-                tracking_branch=branch,
-                should_set_as_default=is_default_branch,
-            )
+            repo_client = RepoClient.from_repo_info(workspace.repo_info)
+
+            tmp_dir, tmp_repo_dir = repo_client.load_repo_to_tmp_dir(workspace.namespace.sha)
+            logger.debug(f"Loaded repository to {tmp_repo_dir}")
 
             try:
-                documents = read_directory(tmp_repo_dir)
+                documents = read_directory(tmp_repo_dir)[:12]
 
                 logger.debug(f"Read {len(documents)} documents:")
                 documents_by_language = group_documents_by_language(documents)
@@ -233,32 +247,32 @@ class CodebaseIndex:
                 workspace.insert_chunks(embedded_chunks)
                 workspace.namespace.status = CodebaseNamespaceStatus.CREATED
                 workspace.save()
-            except Exception as e:
-                logger.error(f"Failed to create codebase index: {e}")
 
-                try:
-                    workspace.delete()
-                except Exception as ex:
-                    sentry_sdk.capture_exception(ex)
+                logger.debug(f"Create Step: Inserted {len(chunks)} chunks into the database")
 
-                raise e
+                return cls(
+                    workspace.repo_info.organization,
+                    workspace.repo_info.project,
+                    repo_client,
+                    workspace=workspace,
+                    state_manager=(
+                        state_manager_class(repo_id=workspace.repo_info.id, state=state)
+                        if state and state_manager_class
+                        else DummyCodebaseStateManager()
+                    ),
+                    embedding_model=embedding_model,
+                )
+            finally:
+                cleanup_dir(tmp_dir)
+        except Exception as e:
+            logger.error(f"Failed to create codebase index: {e}")
 
-            logger.debug(f"Create Step: Inserted {len(chunks)} chunks into the database")
+            try:
+                workspace.delete()
+            except Exception as ex:
+                sentry_sdk.capture_exception(ex)
 
-            return cls(
-                organization,
-                project,
-                repo_client,
-                workspace=workspace,
-                state_manager=(
-                    state_manager_class(repo_id=workspace.repo_info.id, state=state)
-                    if state and state_manager_class
-                    else DummyCodebaseStateManager()
-                ),
-                embedding_model=embedding_model,
-            )
-        finally:
-            cleanup_dir(tmp_dir)
+            raise e
 
     def save(self):
         self.workspace.save()

--- a/src/seer/automation/codebase/codebase_index.py
+++ b/src/seer/automation/codebase/codebase_index.py
@@ -230,7 +230,7 @@ class CodebaseIndex:
             logger.debug(f"Loaded repository to {tmp_repo_dir}")
 
             try:
-                documents = read_directory(tmp_repo_dir)[:12]
+                documents = read_directory(tmp_repo_dir)
 
                 logger.debug(f"Read {len(documents)} documents:")
                 documents_by_language = group_documents_by_language(documents)

--- a/src/seer/automation/codebase/codebase_index.py
+++ b/src/seer/automation/codebase/codebase_index.py
@@ -178,7 +178,7 @@ class CodebaseIndex:
                     embedding_model=embedding_model,
                 )
 
-        raise ValueError(f"Repository with id {repo_id} not found")
+        return None
 
     @staticmethod
     def create(

--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -15,10 +15,14 @@ from seer.automation.models import PromptXmlModel, RepoDefinition
 from seer.db import DbCodebaseNamespace, DbRepositoryInfo
 
 
-class CreateCodebaseTaskRequest(BaseModel):
+class CreateCodebaseRequest(BaseModel):
     organization_id: int
     project_id: int
     repo: RepoDefinition
+
+
+class IndexNamespaceTaskRequest(BaseModel):
+    namespace_id: int
 
 
 class UpdateCodebaseTaskRequest(BaseModel):

--- a/src/seer/automation/codebase/namespace.py
+++ b/src/seer/automation/codebase/namespace.py
@@ -12,6 +12,7 @@ from seer.automation.codebase.models import (
     ChunkQueryResult,
     ChunkResult,
     CodebaseNamespace,
+    CodebaseNamespaceStatus,
     EmbeddedDocumentChunk,
     RepositoryInfo,
 )
@@ -155,7 +156,7 @@ class CodebaseNamespaceManager:
             return CodebaseNamespace.from_db(db_namespace)
 
     @classmethod
-    def load_workspace(cls, namespace_id: int):
+    def load_workspace(cls, namespace_id: int, skip_copy: bool = False):
         with Session() as session:
             db_repo_info = session.get(DbRepositoryInfo, namespace_id)
 
@@ -172,14 +173,16 @@ class CodebaseNamespaceManager:
 
         storage_adapter = get_storage_adapter_class()(repo_info.id, namespace.id, namespace.slug)
 
-        cls._wait_for_mutex_clear(namespace.id)
-        cls._set_mutex(namespace.id)
+        did_copy = False
+        if not skip_copy:
+            cls._wait_for_mutex_clear(namespace.id)
+            cls._set_mutex(namespace.id)
 
-        did_copy = storage_adapter.copy_to_workspace()
+            did_copy = storage_adapter.copy_to_workspace()
 
-        cls._clear_mutex(namespace.id)
+            cls._clear_mutex(namespace.id)
 
-        if did_copy:
+        if skip_copy or did_copy:
             return cls(repo_info, namespace, storage_adapter)
         return None
 
@@ -279,6 +282,7 @@ class CodebaseNamespaceManager:
                 repo_id=db_repo_info.id,
                 sha=head_sha,
                 tracking_branch=tracking_branch,
+                status=CodebaseNamespaceStatus.PENDING,
             )
 
             session.add(db_namespace)
@@ -373,6 +377,7 @@ class CodebaseNamespaceManager:
                     repo_id=repo_id,
                     sha=sha,
                     tracking_branch=tracking_branch,
+                    status=CodebaseNamespaceStatus.PENDING,
                 )
 
                 session.add(db_namespace)

--- a/src/seer/automation/codebase/storage_adapters.py
+++ b/src/seer/automation/codebase/storage_adapters.py
@@ -81,7 +81,12 @@ class FilesystemStorageAdapter(StorageAdapter):
         workspace_path = self.get_workspace_location(self.repo_id, self.namespace_id)
         storage_path = self.get_storage_location(self.repo_id, self.namespace_slug)
 
-        shutil.copytree(storage_path, workspace_path, dirs_exist_ok=True)
+        if os.path.exists(storage_path):
+            try:
+                shutil.copytree(storage_path, workspace_path, dirs_exist_ok=True)
+            except Exception as e:
+                autofix_logger.exception(e)
+                return False
 
         return True
 
@@ -123,27 +128,31 @@ class GcsStorageAdapter(StorageAdapter):
         workspace_path = self.get_workspace_location(self.repo_id, self.namespace_id)
         storage_prefix = self.get_storage_prefix(self.repo_id, self.namespace_slug)
 
-        blobs = self.get_bucket().list_blobs(prefix=storage_prefix)
-        blobs_list: list[storage.Blob] = list(blobs)
-        for blob in blobs_list:
-            if blob.name:
-                filename = blob.name.replace(storage_prefix + "/", "")
-                download_path = os.path.join(workspace_path, filename)
+        try:
+            blobs = self.get_bucket().list_blobs(prefix=storage_prefix)
+            blobs_list: list[storage.Blob] = list(blobs)
+            for blob in blobs_list:
+                if blob.name:
+                    filename = blob.name.replace(storage_prefix + "/", "")
+                    download_path = os.path.join(workspace_path, filename)
 
-                if not os.path.exists(os.path.dirname(download_path)):
-                    os.makedirs(os.path.dirname(download_path))
+                    if not os.path.exists(os.path.dirname(download_path)):
+                        os.makedirs(os.path.dirname(download_path))
 
-                blob.download_to_filename(download_path)
+                    blob.download_to_filename(download_path)
 
-                # Update the custom time of the blob to the current time
-                # We use custom time to track when the file was last used
-                # This is to manage the lifecycle of the files in the storage
-                blob.custom_time = datetime.datetime.now()
-                blob.patch()
+                    # Update the custom time of the blob to the current time
+                    # We use custom time to track when the file was last used
+                    # This is to manage the lifecycle of the files in the storage
+                    blob.custom_time = datetime.datetime.now()
+                    blob.patch()
 
-        autofix_logger.debug(
-            f"Downloaded files from {storage_prefix} to workspace: {workspace_path}"
-        )
+            autofix_logger.debug(
+                f"Downloaded files from {storage_prefix} to workspace: {workspace_path}"
+            )
+        except Exception as e:
+            autofix_logger.exception(e)
+            return False
 
         return True
 
@@ -151,27 +160,33 @@ class GcsStorageAdapter(StorageAdapter):
         workspace_path = self.get_workspace_location(self.repo_id, self.namespace_id)
         storage_prefix = self.get_storage_prefix(self.repo_id, self.namespace_slug)
 
-        blobs = self.get_bucket().list_blobs(prefix=storage_prefix)
-        for blob in blobs:
-            # Delete the existing blobs in the storage prefix
-            blob.delete()
+        try:
+            blobs = self.get_bucket().list_blobs(prefix=storage_prefix)
+            for blob in blobs:
+                # Delete the existing blobs in the storage prefix
+                blob.delete()
 
-        for root, dirs, files in os.walk(workspace_path):
-            for file in files:
-                file_path = os.path.join(root, file)
-                relative_path = os.path.relpath(file_path, workspace_path)
-                blob_path = f"{storage_prefix}/{relative_path}"
+            for root, dirs, files in os.walk(workspace_path):
+                for file in files:
+                    file_path = os.path.join(root, file)
+                    relative_path = os.path.relpath(file_path, workspace_path)
+                    blob_path = f"{storage_prefix}/{relative_path}"
 
-                blob = self.get_bucket().blob(blob_path)
+                    blob = self.get_bucket().blob(blob_path)
 
-                # Update the custom time of the blob to the current time
-                # We use custom time to track when the file was last used
-                # This is to manage the lifecycle of the files in the storage
-                blob.custom_time = datetime.datetime.now()
+                    # Update the custom time of the blob to the current time
+                    # We use custom time to track when the file was last used
+                    # This is to manage the lifecycle of the files in the storage
+                    blob.custom_time = datetime.datetime.now()
 
-                blob.upload_from_filename(file_path)
+                    blob.upload_from_filename(file_path)
 
-        autofix_logger.debug(f"Uploaded files from workspace: {workspace_path} to {storage_prefix}")
+            autofix_logger.debug(
+                f"Uploaded files from workspace: {workspace_path} to {storage_prefix}"
+            )
+        except Exception as e:
+            autofix_logger.exception(e)
+            return False
 
         return True
 

--- a/src/seer/automation/codebase/tasks.py
+++ b/src/seer/automation/codebase/tasks.py
@@ -13,7 +13,7 @@ from seer.automation.codebase.models import (
 )
 from seer.automation.codebase.namespace import CodebaseNamespaceManager
 from seer.automation.codebase.repo_client import RepoClient
-from seer.automation.models import RepoDefinition
+from seer.automation.models import InitializationError, RepoDefinition
 from seer.automation.utils import get_embedding_model
 
 logger = logging.getLogger("autofix")
@@ -49,6 +49,9 @@ def update_codebase_index(data: dict[str, Any]) -> None:
     logger.info("Updating codebase index for repo: %s", request.repo_id)
 
     codebase = CodebaseIndex.from_repo_id(request.repo_id, embedding_model=get_embedding_model())
+
+    if not codebase:
+        raise InitializationError(f"Codebase not found for repo: {request.repo_id}")
 
     with sentry_sdk.start_span(
         op="seer.automation.background.update_codebase_index",


### PR DESCRIPTION
Splits out the codebase index creation into a separate creation of the db entries and the index/embedding step. This was needed to be done to return the indexing status to Sentry immediately. In the previous version, it would've needed to wait for a celery worker to pick up the job before the indexing status is present.

This actually plays nicely into splitting up logic that doesn't need the GPU power out (creating the db entries) from the work that does, which is sent to the celery worker.