### PR TITLE
fix(gocd): Fixing run-migrations script

### DIFF
--- a/gocd/templates/bash/run-migrations.sh
+++ b/gocd/templates/bash/run-migrations.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 echo "running flask db upgrade" \
+  && eval "$(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")" \
   && /devinfra/scripts/k8s/k8stunnel \
   && /devinfra/scripts/k8s/k8s-spawn-job.py \
   --container-name="seer" \


### PR DESCRIPTION
Adding env-var function explicitly in the script rather than relying on k8stunnel. This should fix the issue we are having with the env vars not being present.