### PR TITLE
fix(autofix-codebase): Use tmp dir for workspace

### DIFF
--- a/src/seer/automation/codebase/namespace.py
+++ b/src/seer/automation/codebase/namespace.py
@@ -48,9 +48,7 @@ class CodebaseNamespaceManager:
         self.repo_info = repo_info
         self.namespace = namespace
         self.storage_adapter = storage_adapter
-        self.client = chromadb.PersistentClient(
-            path=storage_adapter.get_workspace_location(namespace.repo_id, namespace.id)
-        )
+        self.client = chromadb.PersistentClient(path=storage_adapter.tmpdir)
 
         self._log_accessed_at()
 
@@ -171,7 +169,9 @@ class CodebaseNamespaceManager:
             repo_info = RepositoryInfo.from_db(db_repo_info)
             namespace = CodebaseNamespace.from_db(db_namespace)
 
-        storage_adapter = get_storage_adapter_class()(repo_info.id, namespace.id, namespace.slug)
+        storage_adapter = get_storage_adapter_class()(
+            repo_id=repo_info.id, namespace_slug=namespace.slug
+        )
 
         did_copy = False
         if not skip_copy:
@@ -244,7 +244,9 @@ class CodebaseNamespaceManager:
             repo_info = RepositoryInfo.from_db(db_repo_info)
             namespace = CodebaseNamespace.from_db(db_namespace)
 
-        storage_adapter = get_storage_adapter_class()(repo_info.id, namespace.id, namespace.slug)
+        storage_adapter = get_storage_adapter_class()(
+            repo_id=repo_info.id, namespace_slug=namespace.slug
+        )
 
         cls._wait_for_mutex_clear(namespace.id)
         cls._set_mutex(namespace.id)
@@ -296,7 +298,9 @@ class CodebaseNamespaceManager:
             repo_info = RepositoryInfo.from_db(db_repo_info)
             namespace = CodebaseNamespace.from_db(db_namespace)
 
-        storage_adapter = get_storage_adapter_class()(repo_info.id, namespace.id, namespace.slug)
+        storage_adapter = get_storage_adapter_class()(
+            repo_id=repo_info.id, namespace_slug=namespace.slug
+        )
 
         return cls(repo_info, namespace, storage_adapter)
 
@@ -390,7 +394,9 @@ class CodebaseNamespaceManager:
 
             namespace = CodebaseNamespace.from_db(db_namespace)
 
-        storage_adapter = get_storage_adapter_class()(repo_info.id, namespace.id, namespace.slug)
+        storage_adapter = get_storage_adapter_class()(
+            repo_id=repo_info.id, namespace_slug=namespace.slug
+        )
 
         return cls(repo_info, namespace, storage_adapter)
 
@@ -558,7 +564,7 @@ class CodebaseNamespaceManager:
         autofix_logger.info(f"Deleted workspace for namespace {self.namespace.id}")
 
     def cleanup(self):
-        self.storage_adapter.cleanup()
+        self.storage_adapter.clear_workspace()
 
         autofix_logger.info(f"Cleaned up workspace for namespace {self.namespace.id}")
 

--- a/src/seer/automation/codebase/storage_adapters.py
+++ b/src/seer/automation/codebase/storage_adapters.py
@@ -1,10 +1,8 @@
 import abc
-import dataclasses
 import datetime
 import os
 import shutil
-
-import sentry_sdk
+import tempfile
 
 # Why is this all good on pylance but mypy is complaining?
 from google.cloud import storage  # type: ignore
@@ -13,27 +11,23 @@ from seer.automation.autofix.utils import autofix_logger
 from seer.automation.codebase.utils import cleanup_dir
 
 
-@dataclasses.dataclass
 class StorageAdapter(abc.ABC):
     repo_id: int
-    namespace_id: int
     namespace_slug: str
 
-    @staticmethod
-    def get_workspace_dir():
-        workspace_dir = os.getenv("CODEBASE_WORKSPACE_DIR", "data/chroma/workspaces")
-        return os.path.abspath(workspace_dir)
+    def __init__(self, repo_id: int, namespace_slug: str):
+        self.repo_id = repo_id
+        self.namespace_slug = namespace_slug
+        self.tmpdir = tempfile.mkdtemp()
 
-    @staticmethod
-    def get_workspace_location(repo_id: int, namespace_id: int):
-        workspace_dir = StorageAdapter.get_workspace_dir()
-        return os.path.join(workspace_dir, f"{repo_id}/{namespace_id}")
+    def __del__(self):
+        self.clear_workspace()
 
-    @staticmethod
-    def clear_all_workspaces():
-        workspace_dir = StorageAdapter.get_workspace_dir()
-        if os.path.exists(workspace_dir):
-            shutil.rmtree(workspace_dir, ignore_errors=False)
+    def clear_workspace(self):
+        try:
+            cleanup_dir(self.tmpdir)
+        except Exception as e:
+            autofix_logger.exception(e)
 
     @abc.abstractmethod
     def copy_to_workspace(self) -> bool:
@@ -46,12 +40,6 @@ class StorageAdapter(abc.ABC):
     @abc.abstractmethod
     def delete_from_storage(self) -> bool:
         pass
-
-    def cleanup(self):
-        workspace_path = self.get_workspace_location(self.repo_id, self.namespace_id)
-
-        if os.path.exists(workspace_path):
-            cleanup_dir(workspace_path)
 
 
 class FilesystemStorageAdapter(StorageAdapter):
@@ -78,12 +66,11 @@ class FilesystemStorageAdapter(StorageAdapter):
         shutil.rmtree(storage_dir, ignore_errors=True)
 
     def copy_to_workspace(self):
-        workspace_path = self.get_workspace_location(self.repo_id, self.namespace_id)
         storage_path = self.get_storage_location(self.repo_id, self.namespace_slug)
 
         if os.path.exists(storage_path):
             try:
-                shutil.copytree(storage_path, workspace_path, dirs_exist_ok=True)
+                shutil.copytree(storage_path, self.tmpdir, dirs_exist_ok=True)
             except Exception as e:
                 autofix_logger.exception(e)
                 return False
@@ -91,9 +78,8 @@ class FilesystemStorageAdapter(StorageAdapter):
         return True
 
     def save_to_storage(self):
-        workspace_path = self.get_workspace_location(self.repo_id, self.namespace_id)
         storage_path = self.get_storage_location(self.repo_id, self.namespace_slug)
-        shutil.copytree(workspace_path, storage_path, dirs_exist_ok=True)
+        shutil.copytree(self.tmpdir, storage_path, dirs_exist_ok=True)
 
         return True
 
@@ -125,7 +111,6 @@ class GcsStorageAdapter(StorageAdapter):
         return os.path.join(storage_dir, f"{repo_id}/{namespace_slug}")
 
     def copy_to_workspace(self) -> bool:
-        workspace_path = self.get_workspace_location(self.repo_id, self.namespace_id)
         storage_prefix = self.get_storage_prefix(self.repo_id, self.namespace_slug)
 
         try:
@@ -134,7 +119,7 @@ class GcsStorageAdapter(StorageAdapter):
             for blob in blobs_list:
                 if blob.name:
                     filename = blob.name.replace(storage_prefix + "/", "")
-                    download_path = os.path.join(workspace_path, filename)
+                    download_path = os.path.join(self.tmpdir, filename)
 
                     if not os.path.exists(os.path.dirname(download_path)):
                         os.makedirs(os.path.dirname(download_path))
@@ -148,7 +133,7 @@ class GcsStorageAdapter(StorageAdapter):
                     blob.patch()
 
             autofix_logger.debug(
-                f"Downloaded files from {storage_prefix} to workspace: {workspace_path}"
+                f"Downloaded files from {storage_prefix} to workspace: {self.tmpdir}"
             )
         except Exception as e:
             autofix_logger.exception(e)
@@ -157,7 +142,6 @@ class GcsStorageAdapter(StorageAdapter):
         return True
 
     def save_to_storage(self) -> bool:
-        workspace_path = self.get_workspace_location(self.repo_id, self.namespace_id)
         storage_prefix = self.get_storage_prefix(self.repo_id, self.namespace_slug)
 
         try:
@@ -166,10 +150,10 @@ class GcsStorageAdapter(StorageAdapter):
                 # Delete the existing blobs in the storage prefix
                 blob.delete()
 
-            for root, dirs, files in os.walk(workspace_path):
+            for root, dirs, files in os.walk(self.tmpdir):
                 for file in files:
                     file_path = os.path.join(root, file)
-                    relative_path = os.path.relpath(file_path, workspace_path)
+                    relative_path = os.path.relpath(file_path, self.tmpdir)
                     blob_path = f"{storage_prefix}/{relative_path}"
 
                     blob = self.get_bucket().blob(blob_path)
@@ -182,7 +166,7 @@ class GcsStorageAdapter(StorageAdapter):
                     blob.upload_from_filename(file_path)
 
             autofix_logger.debug(
-                f"Uploaded files from workspace: {workspace_path} to {storage_prefix}"
+                f"Uploaded files from workspace: {self.tmpdir} to {storage_prefix}"
             )
         except Exception as e:
             autofix_logger.exception(e)

--- a/tests/automation/codebase/test_codebase_index.py
+++ b/tests/automation/codebase/test_codebase_index.py
@@ -28,7 +28,6 @@ class TestCodebaseIndexCreateAndIndex(unittest.TestCase):
 
     def tearDown(self) -> None:
         FilesystemStorageAdapter.clear_all_storage()
-        FilesystemStorageAdapter.clear_all_workspaces()
         return super().tearDown()
 
     @patch("seer.automation.codebase.codebase_index.RepoClient")
@@ -245,7 +244,6 @@ class TestCodebaseIndexUpdate(unittest.TestCase):
 
     def tearDown(self) -> None:
         FilesystemStorageAdapter.clear_all_storage()
-        FilesystemStorageAdapter.clear_all_workspaces()
         return super().tearDown()
 
     def mock_embed_chunks(self, chunks: list[BaseDocumentChunk], embedding_model: Any):
@@ -635,7 +633,6 @@ class TestCodebaseIndexGetFilePatches(unittest.TestCase):
 
     def tearDown(self) -> None:
         FilesystemStorageAdapter.clear_all_storage()
-        FilesystemStorageAdapter.clear_all_workspaces()
         return super().tearDown()
 
     def test_get_file_patches(self):

--- a/tests/automation/codebase/test_namespace.py
+++ b/tests/automation/codebase/test_namespace.py
@@ -21,7 +21,6 @@ class TestNamespaceManager(unittest.TestCase):
 
     def tearDown(self) -> None:
         FilesystemStorageAdapter.clear_all_storage()
-        FilesystemStorageAdapter.clear_all_workspaces()
         return super().tearDown()
 
     def test_create_repo(self):


### PR DESCRIPTION
Logical failure, because the workspace was using the namespace id for the directory name, we couldn't concurrently run on the same namespace.

Fix: Use a temp dir instead that's cleaned with the storage adapter.