### PR TITLE
feat(celery): Separate gpu/cpu celery queue and workers

### DIFF
--- a/celeryworker.sh
+++ b/celeryworker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$CELERY_WORKER_ENABLE" = "true" ]; then
-    exec celery -A src.celery_app.tasks worker --loglevel=info -c 4 # Use 4 processes with one GPU per process
+    exec celery -A src.celery_app.tasks worker --loglevel=info $CELERY_WORKER_OPTIONS
 else
     echo "Celery worker is disabled via environment variable CELERY_WORKER_ENABLE"
     exit 0

--- a/src/celery_app/config.py
+++ b/src/celery_app/config.py
@@ -1,0 +1,6 @@
+from enum import StrEnum
+
+
+class CeleryQueues(StrEnum):
+    DEFAULT = "seer"
+    CUDA = "seer-cuda"

--- a/src/seer/automation/autofix/pipelines.py
+++ b/src/seer/automation/autofix/pipelines.py
@@ -4,6 +4,7 @@ import sentry_sdk
 from langsmith import traceable
 from sentry_sdk.ai_analytics import ai_track
 
+from celery_app.config import CeleryQueues
 from seer.automation.autofix.autofix_context import AutofixContext
 from seer.automation.autofix.components.change_describer import (
     ChangeDescriptionComponent,
@@ -117,6 +118,7 @@ class CheckCodebaseForUpdatesSideEffect(PipelineSideEffect):
                     update_codebase_index.apply_async(
                         (UpdateCodebaseTaskRequest(repo_id=repo_id).model_dump(),),
                         countdown=10 * 60,
+                        queue=CeleryQueues.CUDA,
                     )  # 10 minutes
                     autofix_logger.info(f"Codebase indexing scheduled for later")
 

--- a/src/seer/automation/utils.py
+++ b/src/seer/automation/utils.py
@@ -13,9 +13,15 @@ EXPECTED_CUDA_DEVICES = 4
 logger = logging.getLogger("autofix")
 
 
+def _use_cuda():
+    return os.getenv("USE_CUDA", "false").lower() in ("true", "t", "1")
+
+
 def _get_torch_device_name():
     device: str = "cpu"
-    if torch.cuda.is_available():
+    cuda = _use_cuda()
+    logger.debug(f"env USE_CUDA set to: {cuda}")
+    if cuda and torch.cuda.is_available():
         if torch.cuda.device_count() >= EXPECTED_CUDA_DEVICES:
             try:
                 index: int = billiard.process.current_process().index

--- a/src/seer/bootup.py
+++ b/src/seer/bootup.py
@@ -93,6 +93,10 @@ CELERY_CONFIG = dict(
             "exchange": "seer",
             "routing_key": "seer",
         },
+        "seer-cuda": {
+            "exchange": "seer-cuda",
+            "routing_key": "seer-cuda",
+        },
     },
     result_backend="rpc://",
 )

--- a/src/seer/bootup.py
+++ b/src/seer/bootup.py
@@ -9,6 +9,7 @@ from psycopg import Connection
 from sentry_sdk.integrations import Integration
 from sqlalchemy.ext.asyncio import create_async_engine
 
+from celery_app.config import CeleryQueues
 from seer.db import AsyncSession, Session, db, migrate
 
 logger = logging.getLogger(__name__)
@@ -87,15 +88,15 @@ CELERY_CONFIG = dict(
     result_serializer="json",
     accept_content=["json"],
     enable_utc=True,
-    task_default_queue="seer",
+    task_default_queue=CeleryQueues.DEFAULT,
     task_queues={
-        "seer": {
-            "exchange": "seer",
-            "routing_key": "seer",
+        CeleryQueues.DEFAULT: {
+            "exchange": CeleryQueues.DEFAULT,
+            "routing_key": CeleryQueues.DEFAULT,
         },
-        "seer-cuda": {
-            "exchange": "seer-cuda",
-            "routing_key": "seer-cuda",
+        CeleryQueues.CUDA: {
+            "exchange": CeleryQueues.CUDA,
+            "routing_key": CeleryQueues.CUDA,
         },
     },
     result_backend="rpc://",

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true
 
 [program:gunicorn]
 ; FYI, all the environment variables that are used in this file with supervisord are prefixed with ENV_. For example, the PORT environment variable is referenced as %(ENV_PORT)s.
-command=gunicorn --bind :%(ENV_PORT)s --worker-class sync --threads 1 --timeout 0 src.seer.app:app
+command=gunicorn --bind :%(ENV_PORT)s --worker-class sync --threads 1 --timeout 0 --access-logfile - src.seer.app:app
 directory=/app
 autostart=true
 autorestart=true
@@ -13,8 +13,22 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 ; The celery worker program is disabled by default. Set CELERY_WORKER_ENABLE=true in the environment to enable it.
-[program:celeryworker]
-command=/app/celeryworker.sh
+; We use 4 processes with one GPU per process
+[program:celeryworker-cuda]
+command=env CELERY_WORKER_OPTIONS="-c 4 -Q seer-cuda -n seer-cuda@%%h" env USE_CUDA=true /app/celeryworker.sh
+directory=/app
+startsecs=0
+autostart=true
+autorestart=unexpected
+exitcodes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+; The celery worker program is disabled by default. Set CELERY_WORKER_ENABLE=true in the environment to enable it.
+[program:celeryworker-default]
+command=env CELERY_WORKER_OPTIONS="-c 32 -Q seer -n seer@%%h" /app/celeryworker.sh
 directory=/app
 startsecs=0
 autostart=true


### PR DESCRIPTION
Separates our celery setup into a cuda and a cpu queue. With 4 processes (1 per gpu) on the cuda worker and 32 processes on the cpu worker.

Initial codebase indexing & Autofix execution will run on the cuda worker.

Next steps is to split out the work even more + move the potential codebase indexing that happens during a re-index to the gpu