### PR TITLE
fix(autofix-fs): Make sure storage location is clear

### DIFF
--- a/src/seer/automation/codebase/storage_adapters.py
+++ b/src/seer/automation/codebase/storage_adapters.py
@@ -85,6 +85,7 @@ class FilesystemStorageAdapter(StorageAdapter):
                 shutil.rmtree(storage_path, ignore_errors=False)
             except Exception as e:
                 autofix_logger.exception(e)
+                return False
 
         shutil.copytree(self.tmpdir, storage_path, dirs_exist_ok=True)
 

--- a/src/seer/automation/codebase/storage_adapters.py
+++ b/src/seer/automation/codebase/storage_adapters.py
@@ -79,6 +79,13 @@ class FilesystemStorageAdapter(StorageAdapter):
 
     def save_to_storage(self):
         storage_path = self.get_storage_location(self.repo_id, self.namespace_slug)
+
+        if os.path.exists(storage_path):
+            try:
+                shutil.rmtree(storage_path, ignore_errors=False)
+            except Exception as e:
+                autofix_logger.exception(e)
+
         shutil.copytree(self.tmpdir, storage_path, dirs_exist_ok=True)
 
         return True


### PR DESCRIPTION
Local runs were getting mixed up filesystem storage dumps, we already are deleting before saving to gcs in prod but good to add a test for it too.