### PR TITLE
dev: update supervisord container process to log to stdout

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,5 +1,9 @@
 [supervisord]
 nodaemon=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 
 [program:gunicorn]
 ; FYI, all the environment variables that are used in this file with supervisord are prefixed with ENV_. For example, the PORT environment variable is referenced as %(ENV_PORT)s.


### PR DESCRIPTION
these logs cause issues on containers with no permissions -- log to stdout instead of creating a file in the container.