### PR TITLE
ref(similarity-embeddings): Reset grouping_records table in s4s

### DIFF
--- a/src/migrations/versions/704569328ec7_delete_s4s_group_records.py
+++ b/src/migrations/versions/704569328ec7_delete_s4s_group_records.py
@@ -1,0 +1,62 @@
+"""delete s4s group records
+
+Revision ID: 704569328ec7
+Revises: b6cca7c6d99c
+Create Date: 2024-05-09 17:12:28.920636
+
+"""
+import os
+
+import sqlalchemy as sa
+from alembic import op
+from pgvector.sqlalchemy import Vector  # type: ignore
+
+# revision identifiers, used by Alembic.
+revision = "704569328ec7"
+down_revision = "b6cca7c6d99c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if os.getenv("SENTRY_REGION", None) == "s4s":
+        with op.batch_alter_table("grouping_records", schema=None) as batch_op:
+            batch_op.drop_index(
+                "ix_grouping_records_stacktrace_embedding_hnsw",
+                postgresql_using="hnsw",
+                postgresql_with={"m": 16, "ef_construction": 64},
+                postgresql_ops={"stacktrace_embedding": "vector_cosine_ops"},
+            )
+            batch_op.drop_index("ix_grouping_records_project_id")
+
+        op.drop_table("grouping_records")
+        print("DROPPED!")
+        op.create_table(
+            "grouping_records",
+            sa.Column("id", sa.Integer(), nullable=False),
+            sa.Column("group_id", sa.BigInteger(), nullable=True),
+            sa.Column("project_id", sa.BigInteger(), nullable=False),
+            sa.Column("message", sa.String(), nullable=False),
+            sa.Column("stacktrace_embedding", Vector(dim=768), nullable=False),
+            sa.Column(
+                "hash",
+                sa.String(length=32),
+                server_default="00000000000000000000000000000000",
+                nullable=False,
+            ),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        with op.batch_alter_table("grouping_records", schema=None) as batch_op:
+            batch_op.create_index("ix_grouping_records_project_id", ["project_id"], unique=False)
+            batch_op.create_index(
+                "ix_grouping_records_stacktrace_embedding_hnsw",
+                ["stacktrace_embedding"],
+                unique=False,
+                postgresql_using="hnsw",
+                postgresql_with={"m": 16, "ef_construction": 64},
+                postgresql_ops={"stacktrace_embedding": "vector_cosine_ops"},
+            )
+
+
+def downgrade():
+    pass

--- a/src/seer/grouping/grouping.py
+++ b/src/seer/grouping/grouping.py
@@ -94,42 +94,6 @@ class GroupingLookup:
         )
         logger.info(f"GroupingLookup model initialized using device: {model_device}")
         sentry_sdk.capture_message(f"GroupingLookup model initialized using device: {model_device}")
-        self.initialize_db(data_path)
-
-    def initialize_db(self, data_path: str):
-        """
-        Initializes the database with records from a pickle file if a specific record does not exist.
-
-        This method checks for the existence of a record with a specific group_id in the database.
-        If the record exists, the database is assumed to be initialized, and the method returns early.
-        If the record does not exist, the method proceeds to load data from a pickle file located at
-        `data_path` and populates the database with these records.
-
-        :param data_path: The file path to the pickle file containing the records to load into the database.
-        """
-        with Session() as session:
-            key_group_id = 4506283937  # TODO: less hacky solution to populating the DB if needed
-            record_exists = (
-                session.query(DbGroupingRecord)
-                .filter(DbGroupingRecord.group_id == key_group_id)
-                .first()
-                is not None
-            )
-
-            if record_exists:
-                return
-
-            with open(data_path, mode="rb") as records_file:
-                records_df = pd.read_pickle(records_file)
-                for _, row in records_df.iterrows():
-                    new_record = DbGroupingRecord(
-                        group_id=row["group_id"],
-                        project_id=row["project_id"],
-                        message=row["message"],
-                        stacktrace_embedding=row["stacktrace_embedding"].astype(np.float32),
-                    )
-                    session.add(new_record)
-                session.commit()
 
     def encode_text(self, stacktrace: str) -> np.ndarray:
         """


### PR DESCRIPTION
Reset the grouping_records table if SENTRY_REGION is s4s
Remove janky logic to initialize the grouping_records table using a static pickle file

- this logic is incorrect for s4s
- this logic has already been applied for sentry and we will eventually want to correctly backfill later