### PR TITLE
fix(codebase): Fix default namespace not cleared and not set

### DIFF
--- a/tests/automation/codebase/test_namespace.py
+++ b/tests/automation/codebase/test_namespace.py
@@ -6,7 +6,11 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 
-from seer.automation.codebase.models import CodebaseNamespace, EmbeddedDocumentChunk
+from seer.automation.codebase.models import (
+    CodebaseNamespace,
+    CodebaseNamespaceStatus,
+    EmbeddedDocumentChunk,
+)
 from seer.automation.codebase.namespace import CodebaseNamespaceManager
 from seer.automation.codebase.storage_adapters import FilesystemStorageAdapter
 from seer.automation.models import RepoDefinition
@@ -461,6 +465,8 @@ class TestNamespaceManager(unittest.TestCase):
                 )
             ]
         )
+
+        namespace.namespace.status = CodebaseNamespaceStatus.CREATED
 
         self.assertTrue(namespace.is_ready())
 


### PR DESCRIPTION
### Problem:
Couldn't set up autofix on the sentry javascript project because the default namespace id was set to a no-longer-existing codebase

### Solution:
- Make sure the default namespace id is cleared on a delete
- Make sure it's being overwritten on a new create

### More improvements:
- The ready check should check the status too
- Skip indexing if the workspace is already ready

### Next Steps
- We should add a file check to check whether the files in our index matches the ones in the git repo at the specified sha...