### PR TITLE
fix(autofix): Increase pipeline step time limits

### DIFF
--- a/src/seer/automation/pipeline.py
+++ b/src/seer/automation/pipeline.py
@@ -12,8 +12,8 @@ from seer.automation.utils import automation_logger
 Signature = Any
 SerializedSignature = str
 
-DEFAULT_PIPELINE_STEP_SOFT_TIME_LIMIT_SECS = 15  # 15 seconds
-DEFAULT_PIPELINE_STEP_HARD_TIME_LIMIT_SECS = 30  # 30 seconds
+DEFAULT_PIPELINE_STEP_SOFT_TIME_LIMIT_SECS = 50  # 50 seconds
+DEFAULT_PIPELINE_STEP_HARD_TIME_LIMIT_SECS = 60  # 60 seconds
 
 
 class PipelineContext(abc.ABC):


### PR DESCRIPTION
Fixes [SEER-55](https://sentry.sentry.io/issues/5332811854/)

Loading from GCS takes longer, p75 of 7 seconds which would easily make it hit the 15 second soft limit. Increase it to 50 seconds because this should be killing overrun steps not just steps that take long.