### PR TITLE
fix(autofix): model dump when calling apply_async

### DIFF
--- a/src/seer/automation/autofix/steps/create_missing_indexes_chain.py
+++ b/src/seer/automation/autofix/steps/create_missing_indexes_chain.py
@@ -80,7 +80,7 @@ class CreateMissingIndexesStep(PipelineChain, AutofixPipelineStep):
                             (
                                 UpdateCodebaseTaskRequest(
                                     repo_id=codebase.repo_info.id,
-                                ),
+                                ).model_dump(mode="json"),
                             ),
                             countdown=60 * 15,  # 15 minutes
                             queue=CeleryQueues.CUDA,


### PR DESCRIPTION
Fixes [SEER-56](https://sentry.sentry.io/issues/5332812124/)