### PR TITLE
feat(autofix): Better metadata/tags logging to langsmith

### DIFF
--- a/src/seer/automation/autofix/steps/create_index_step.py
+++ b/src/seer/automation/autofix/steps/create_index_step.py
@@ -39,7 +39,7 @@ class CreateIndexStep(AutofixPipelineStep):
     def get_task():
         return create_index_task
 
-    def _invoke(self):
+    def _invoke(self, **kwargs):
         repo = self.request.repo
 
         self.context.event_manager.send_codebase_indexing_start()  # This should only create the step once and get every next time it's called...

--- a/src/seer/automation/autofix/steps/create_missing_indexes_chain.py
+++ b/src/seer/automation/autofix/steps/create_missing_indexes_chain.py
@@ -47,7 +47,7 @@ class CreateMissingIndexesStep(PipelineChain, AutofixPipelineStep):
     def get_task():
         return create_missing_indexes_task
 
-    def _invoke(self):
+    def _invoke(self, **kwargs):
         event_details = EventDetails.from_event(self.context.state.get().request.issue.events[0])
 
         repos_to_create: list[RepoDefinition] = []

--- a/src/seer/automation/autofix/steps/execution_step.py
+++ b/src/seer/automation/autofix/steps/execution_step.py
@@ -57,7 +57,7 @@ class AutofixExecutionStep(AutofixPipelineStep):
 
     @traceable(name="Execution", tags=["autofix:v2"])
     @ai_track(description="Execution")
-    def _invoke(self):
+    def _invoke(self, **kwargs):
         self.context.event_manager.send_codebase_indexing_complete_if_exists()
         self.context.event_manager.send_planning_start()
 

--- a/src/seer/automation/autofix/steps/root_cause_step.py
+++ b/src/seer/automation/autofix/steps/root_cause_step.py
@@ -45,7 +45,7 @@ class RootCauseStep(AutofixPipelineStep):
 
     @traceable(name="Root Cause", tags=["autofix:v2"])
     @ai_track(description="Root Cause")
-    def _invoke(self):
+    def _invoke(self, **kwargs):
         self.context.event_manager.send_codebase_indexing_complete_if_exists()
         self.context.event_manager.send_root_cause_analysis_start()
 

--- a/src/seer/automation/autofix/steps/update_index_step.py
+++ b/src/seer/automation/autofix/steps/update_index_step.py
@@ -38,7 +38,7 @@ class UpdateIndexStep(AutofixPipelineStep):
     def get_task():
         return update_index_task
 
-    def _invoke(self):
+    def _invoke(self, **kwargs):
         codebase = self.context.get_codebase(self.request.repo_id)
 
         if not codebase:

--- a/src/seer/automation/pipeline.py
+++ b/src/seer/automation/pipeline.py
@@ -50,12 +50,15 @@ class PipelineStep(abc.ABC):
         try:
             if not self._pre_invoke():
                 return
-            result = self._invoke()
+            result = self._invoke(**self._get_extra_invoke_kwargs())
             self._post_invoke(result)
             return result
         except Exception as e:
             self._handle_exception(e)
             raise e
+
+    def _get_extra_invoke_kwargs(self) -> dict[str, Any]:
+        return {}
 
     def _pre_invoke(self) -> bool:
         return True
@@ -103,7 +106,7 @@ class PipelineStep(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def _invoke(self) -> Any:
+    def _invoke(self, **kwargs) -> Any:
         pass
 
 

--- a/src/seer/automation/steps.py
+++ b/src/seer/automation/steps.py
@@ -27,7 +27,7 @@ class ConditionalStep(PipelineChain, PipelineStep):
     def condition(self) -> bool:
         pass
 
-    def _invoke(self):
+    def _invoke(self, **kwargs):
         result = self.condition()
 
         self.logger.debug(f"Conditional step {self.request.step_id} condition result: {result}")
@@ -83,7 +83,7 @@ class ParallelizedChainStep(PipelineChain, PipelineStep):
     def _get_conditional_step_class() -> Type[ParallelizedChainConditionalStep]:
         pass
 
-    def _invoke(self):
+    def _invoke(self, **kwargs):
         signatures = [self.instantiate_signature(step) for step in self.request.steps]
 
         expected_signals = [

--- a/tests/automation/autofix/steps/test_autofix_steps.py
+++ b/tests/automation/autofix/steps/test_autofix_steps.py
@@ -16,7 +16,7 @@ class ConcreteAutofixPipelineStep(AutofixPipelineStep):
     def _instantiate_context(request):
         return MagicMock()
 
-    def _invoke(self):
+    def _invoke(self, **kwargs):
         return True
 
     def _handle_exception(self, exception):


### PR DESCRIPTION
Log more tags/metadata to langsmith to aid in debugging and analytics. We will be able to filter by these fields on langsmith ui or by calling their API.

Should also follow up with @colin-sentry on logging these to sentry ai monitoring too

<img width="1461" alt="Screenshot 2024-05-13 at 11 39 51 AM" src="https://github.com/getsentry/seer/assets/30991498/a6996f3f-b899-476e-b548-c880f1c26a18">
