### PR TITLE
fix(steps): Change SerializedSignature back to Any

### DIFF
--- a/src/seer/automation/pipeline.py
+++ b/src/seer/automation/pipeline.py
@@ -10,7 +10,7 @@ from seer.automation.state import State
 from seer.automation.utils import automation_logger
 
 Signature = Any
-SerializedSignature = str
+SerializedSignature = Any
 
 DEFAULT_PIPELINE_STEP_SOFT_TIME_LIMIT_SECS = 50  # 50 seconds
 DEFAULT_PIPELINE_STEP_HARD_TIME_LIMIT_SECS = 60  # 60 seconds


### PR DESCRIPTION
It confuses pydantic when you pass in the actual celery signatures...they're aren't typed and I can't find how to correctly type them otherwise.