### PR TITLE
add delete endpoint to clear grouping records for project

### DIFF
--- a/src/seer/grouping/grouping.py
+++ b/src/seer/grouping/grouping.py
@@ -250,3 +250,12 @@ class GroupingLookup:
         with Session() as session:
             session.bulk_save_objects(records)
             session.commit()
+
+    def delete_grouping_records_for_project(self, project_id: int) -> bool:
+        """
+        Deletes grouping records for a project.
+        """
+        with Session() as session:
+            session.query(DbGroupingRecord).filter_by(project_id=project_id).delete()
+            session.commit()
+        return True


### PR DESCRIPTION
- [x] adds an endpoint that will allow us to delete all the grouping records for a project, so we can clear out to test the backfill as we're iterating on it