### PR TITLE
devenv: install and start colima

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -13,6 +13,9 @@ else
   fi
 fi
 
+PATH_add "${PWD}/.devenv/bin"
+export PATH
+
 if [ -f .venv/bin/activate ]; then
   source .venv/bin/activate
 fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,10 @@ RUN ln -s /usr/bin/python /usr/local/bin/python && \
 COPY models/ models/
 
 # Copy setup files, requirements, and scripts
-COPY setup.py requirements.txt celeryworker.sh asyncworker.sh gunicorn.sh ./
+COPY setup.py requirements.txt celeryworker.sh gunicorn.sh ./
 
 # Make celeryworker.sh and asyncworker.sh executable
-RUN chmod +x ./celeryworker.sh ./asyncworker.sh ./gunicorn.sh
+RUN chmod +x ./celeryworker.sh ./gunicorn.sh
 
 # Install dependencies
 RUN pip install --upgrade pip==24.0
@@ -54,7 +54,7 @@ COPY supervisord.conf /etc/supervisord.conf
 # this skips annoying rebuilds where requirements would technically be met anyways.
 RUN pip install --default-timeout=120 -e . --no-cache-dir --no-deps
 
-ENV FLASK_APP=src.seer.app
+ENV FLASK_APP=src.seer.app:start_app()
 # Set in cloudbuild.yaml for production images
 ARG SEER_VERSION_SHA
 ENV SEER_VERSION_SHA ${SEER_VERSION_SHA}

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,6 @@ COPY models/ models/
 # Copy setup files, requirements, and scripts
 COPY setup.py requirements.txt celeryworker.sh gunicorn.sh ./
 
-# Make celeryworker.sh and asyncworker.sh executable
 RUN chmod +x ./celeryworker.sh ./gunicorn.sh
 
 # Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR $APP_HOME
 RUN apt-get update && \
     apt-get install -y \
     python3.11 \
-    python3.11-pip \
+    python3-pip \
     python3.11-dev \
     supervisor \
     libpq-dev \

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Seer uses docker compose to manage the development environment contained in `doc
 The first invocation of `devenv sync` or `direnv allow` can take a long time due to the complex
 contain image that will be built locally.  Generally it should be cached and more performant afterwards.
 
-For now, we recommend installing and using docker desktop over colima due to some differences
-in behavior in the tooling.
 
 ### Autofix
 

--- a/devenv/config.ini
+++ b/devenv/config.ini
@@ -13,3 +13,15 @@ linux_x86_64 = https://github.com/indygreg/python-build-standalone/releases/down
 linux_x86_64_sha256 = 94e13d0e5ad417035b80580f3e893a72e094b0900d5d64e7e34ab08e95439987
 linux_arm64 = https://github.com/indygreg/python-build-standalone/releases/download/20240224/cpython-3.11.8+20240224-aarch64-unknown-linux-gnu-install_only.tar.gz
 linux_arm64_sha256 = 389b9005fb78dd5a6f68df5ea45ab7b30d9a4b3222af96999e94fd20d4ad0c6a
+
+[colima]
+darwin_x86_64 = https://github.com/abiosoft/colima/releases/download/v0.6.6/colima-Darwin-x86_64
+darwin_x86_64_sha256 = 84e72678945aacba5805fe363f6c7c87dc73e05cbbfdfc09f9b57cedf110865d
+darwin_arm64 = https://github.com/abiosoft/colima/releases/download/v0.6.6/colima-Darwin-arm64
+darwin_arm64_sha256 = b2729edcf99470071240ab6986349346211e25944a5dc317bba8fa27ed0f25e5
+linux_x86_64 = https://github.com/abiosoft/colima/releases/download/v0.6.6/colima-Linux-x86_64
+linux_x86_64_sha256 = bf9e370c4bacbbebdfaa46de04d0e01fe2649a8e366f282cf35ae7dd84559a25
+linux_arm64 = https://github.com/abiosoft/colima/releases/download/v0.6.6/colima-Linux-aarch64
+linux_arm64_sha256 = 6ecba675e90d154f22e20200fa5684f20ad1495b73c0462f1bd7da4e9d0beaf8
+# used for autoupdate
+version = v0.6.6

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -30,7 +30,7 @@ def main(context: dict[str, str]) -> int:
     # start colima if it's not already running
     colima.start(reporoot)
 
-    # print("Executing update tasks in Makefile...")
-    # proc.run(("make", "-C", reporoot, "update"), exit=True)
+    print("Executing update tasks in Makefile...")
+    proc.run(("make", "-C", reporoot, "update"), exit=True)
 
     return 0

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from devenv.lib import config, proc, venv
+import configparser
+
+from devenv.lib import colima, limactl, config, proc, venv
+from devenv import constants
 
 
 def main(context: dict[str, str]) -> int:
@@ -13,6 +16,21 @@ def main(context: dict[str, str]) -> int:
     venv.ensure(venv_dir, python_version, url, sha256)
     venv.sync(reporoot, venv_dir, requirements)
 
-    print("Executing update tasks in Makefile...")
-    proc.run(("make", "-C", reporoot, "update"), exit=True)
+    # install colima
+    repo_config = configparser.ConfigParser()
+    repo_config.read(f"{reporoot}/devenv/config.ini")
+    colima.install(
+        repo_config["colima"]["version"],
+        repo_config["colima"][constants.SYSTEM_MACHINE],
+        repo_config["colima"][f"{constants.SYSTEM_MACHINE}_sha256"],
+        reporoot,
+    )
+    limactl.install(reporoot)
+
+    # start colima if it's not already running
+    colima.start(reporoot)
+
+    # print("Executing update tasks in Makefile...")
+    # proc.run(("make", "-C", reporoot, "update"), exit=True)
+
     return 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ scikit-learn==1.3.0
 scipy==1.11.2
 seaborn==0.12.2
 sentence_transformers==2.3.1
-sentry-sdk==2.11.0
+sentry-sdk[flask]==2.11.0
 simdkalman==1.0.2
 six==1.16.0
 statsmodels==0.14.0


### PR DESCRIPTION
this installs and starts colima (in a way that mounts ~ read-write so that docker compose volume mounts work) in sync.py

this requires devenv >= 1.8.0 so you'll need to download and rerun https://github.com/getsentry/devenv/blob/main/install-devenv.sh