### PR TITLE
fix(autofix): More reliable Change describer output

### DIFF
--- a/src/seer/automation/autofix/components/change_describer.py
+++ b/src/seer/automation/autofix/components/change_describer.py
@@ -34,7 +34,11 @@ class ChangeDescriptionPrompts:
             In the style of:
             {hint}
 
-            You must output a title and description of the changes in the JSON."""
+            You must output a title and description of the changes in the JSON, follow the format of:
+            {{
+                "title": "Title of the change",
+                "description": "Description of the change"
+            }}"""
         ).format(
             change_dump=change_dump,
             hint=hint,


### PR DESCRIPTION
Noticed the change describer often failed in eval runs I've done, we were expecting a title and description and never provided a format.

When we have time to spare, should consider refactoring this and all our other prompts to use XML to align. also maybe an xml prompt (automatic xml extraction using the pydantic model) extraction util would be useful so we don't have to rely on custom extraction methods for every time we call an llm