### PR TITLE
ref(autofix): Stop logging github key issues in dev + use AppConfig

### DIFF
--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -63,12 +63,6 @@ def get_write_app_credentials(config: AppConfig = injected) -> tuple[int | str |
     private_key = config.GITHUB_PRIVATE_KEY
 
     if not app_id or not private_key:
-        if not config.DEV:
-            logger.exception(
-                InitializationError(
-                    "GITHUB_APP_ID and GITHUB_PRIVATE_KEY environment variables must be set for app authentication."
-                )
-            )
 
         return None, None
 
@@ -81,12 +75,6 @@ def get_read_app_credentials(config: AppConfig = injected) -> tuple[int | str | 
     private_key = config.GITHUB_SENTRY_PRIVATE_KEY
 
     if not app_id or not private_key:
-        if not config.DEV:
-            logger.exception(
-                InitializationError(
-                    "GITHUB_SENTRY_APP_ID and GITHUB_SENTRY_PRIVATE_KEY not set, falling back to 'write' app."
-                )
-            )
         return get_write_app_credentials()
 
     return app_id, private_key

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -47,8 +47,9 @@ def get_repo_app_permissions(
         return None
 
 
-def get_github_token_auth():
-    github_token = os.environ.get("GITHUB_TOKEN")
+@inject
+def get_github_token_auth(config: AppConfig = injected) -> Auth.Token | None:
+    github_token = config.GITHUB_TOKEN
 
     if github_token is None:
         return None
@@ -58,8 +59,8 @@ def get_github_token_auth():
 
 @inject
 def get_write_app_credentials(config: AppConfig = injected) -> tuple[int | str | None, str | None]:
-    app_id = os.environ.get("GITHUB_APP_ID")
-    private_key = os.environ.get("GITHUB_PRIVATE_KEY")
+    app_id = config.GITHUB_APP_ID
+    private_key = config.GITHUB_PRIVATE_KEY
 
     if not app_id or not private_key:
         if not config.DEV:
@@ -76,8 +77,8 @@ def get_write_app_credentials(config: AppConfig = injected) -> tuple[int | str |
 
 @inject
 def get_read_app_credentials(config: AppConfig = injected) -> tuple[int | str | None, str | None]:
-    app_id = os.environ.get("GITHUB_SENTRY_APP_ID")
-    private_key = os.environ.get("GITHUB_SENTRY_PRIVATE_KEY")
+    app_id = config.GITHUB_SENTRY_APP_ID
+    private_key = config.GITHUB_SENTRY_PRIVATE_KEY
 
     if not app_id or not private_key:
         if not config.DEV:

--- a/src/seer/configuration.py
+++ b/src/seer/configuration.py
@@ -48,11 +48,11 @@ class AppConfig(BaseModel):
 
     DATABASE_URL: str
     CELERY_BROKER_URL: str
-    GITHUB_TOKEN: str = ""
+    GITHUB_TOKEN: str | None = None
     GITHUB_APP_ID: str = ""
     GITHUB_PRIVATE_KEY: str = ""
-    GITHUB_SENTRY_APP_ID: str = ""
-    GITHUB_SENTRY_PRIVATE_KEY: str = ""
+    GITHUB_SENTRY_APP_ID: str | None = None
+    GITHUB_SENTRY_PRIVATE_KEY: str | None = None
 
     CODEBASE_GCS_STORAGE_BUCKET: str = "sentry-ml"
     CODEBASE_GCS_STORAGE_DIR: str = "tmp_jenn/dev/chroma/storage"

--- a/src/seer/configuration.py
+++ b/src/seer/configuration.py
@@ -51,6 +51,8 @@ class AppConfig(BaseModel):
     GITHUB_TOKEN: str = ""
     GITHUB_APP_ID: str = ""
     GITHUB_PRIVATE_KEY: str = ""
+    GITHUB_SENTRY_APP_ID: str = ""
+    GITHUB_SENTRY_PRIVATE_KEY: str = ""
 
     CODEBASE_GCS_STORAGE_BUCKET: str = "sentry-ml"
     CODEBASE_GCS_STORAGE_DIR: str = "tmp_jenn/dev/chroma/storage"

--- a/src/seer/configuration.py
+++ b/src/seer/configuration.py
@@ -74,6 +74,14 @@ class AppConfig(BaseModel):
         if self.is_production:
             assert self.has_sentry_integration, "Sentry integration required for production mode."
             assert self.SENTRY_DSN, "SENTRY_DSN required for production!"
+            assert self.GITHUB_APP_ID, "GITHUB_APP_ID required for production!"
+            assert self.GITHUB_PRIVATE_KEY, "GITHUB_PRIVATE_KEY required for production!"
+            assert (
+                self.DEV or self.GITHUB_SENTRY_APP_ID
+            ), "GITHUB_SENTRY_APP_ID required for production!"
+            assert (
+                self.DEV or self.GITHUB_SENTRY_PRIVATE_KEY
+            ), "GITHUB_SENTRY_PRIVATE_KEY required for production!"
 
 
 @configuration_module.provider


### PR DESCRIPTION
Fix the annoying github key logs from showing up in dev, also refactor to use the `AppConfig` from dependency injection