### PR TITLE
feat(grouping): add reranking logic

### DIFF
--- a/src/seer/app.py
+++ b/src/seer/app.py
@@ -110,8 +110,9 @@ def breakpoint_trends_endpoint(data: BreakpointRequest) -> BreakpointResponse:
 def similarity_endpoint(data: GroupingRequest) -> SimilarityResponse:
     with sentry_sdk.start_span(op="seer.grouping", description="grouping lookup"):
         sentry_sdk.set_tag("read_only", data.read_only)
-        sentry_sdk.set_tag("stacktrace_len", len(data.stacktrace))
-        sentry_sdk.set_tag("request_hash", data.hash)
+        sentry_sdk.metrics.distribution(
+            key="stacktrace_len", value=len(data.stacktrace), unit="none"
+        )
         similar_issues = grouping_lookup().get_nearest_neighbors(data)
     return similar_issues
 

--- a/src/seer/app.py
+++ b/src/seer/app.py
@@ -110,6 +110,8 @@ def breakpoint_trends_endpoint(data: BreakpointRequest) -> BreakpointResponse:
 def similarity_endpoint(data: GroupingRequest) -> SimilarityResponse:
     with sentry_sdk.start_span(op="seer.grouping", description="grouping lookup"):
         sentry_sdk.set_tag("read_only", data.read_only)
+        sentry_sdk.set_tag("stacktrace_len", len(data.stacktrace))
+        sentry_sdk.set_tag("request_hash", data.hash)
         sentry_sdk.metrics.distribution(
             key="stacktrace_len", value=len(data.stacktrace), unit="none"
         )

--- a/src/seer/grouping/grouping.py
+++ b/src/seer/grouping/grouping.py
@@ -207,6 +207,11 @@ class GroupingLookup:
                 key="reranking_changed_output",
                 value=1,
             )
+            logger.info(
+                "Reranking changed output: original_hash=%s, new_hash=%s",
+                candidates[0].hash,
+                reranked[0][0].hash,
+            )
 
         return reranked[:k]
 

--- a/src/seer/grouping/grouping.py
+++ b/src/seer/grouping/grouping.py
@@ -2,7 +2,7 @@ import difflib
 import gc
 import logging
 from functools import wraps
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import numpy as np
 import sentry_sdk
@@ -295,9 +295,10 @@ class GroupingLookup:
     def cosine_distance(
         embedding: np.ndarray,
         candidate_embedding: np.ndarray,
-        embedding_norm: Optional[float] = None,
+        embedding_norm: np.floating[Any] | None = None,
     ) -> float:
-        embedding_norm = embedding_norm if embedding_norm is not None else np.linalg.norm(embedding)
+        if embedding_norm is None:
+            embedding_norm = np.linalg.norm(embedding)
 
         candidate_norm = np.linalg.norm(candidate_embedding)
         dot_product = np.dot(candidate_embedding, embedding)

--- a/src/seer/grouping/grouping.py
+++ b/src/seer/grouping/grouping.py
@@ -35,6 +35,7 @@ class GroupingRequest(BaseModel):
     read_only: bool = False
     hnsw_candidates: int = NN_GROUPING_HNSW_CANDIDATES
     hnsw_distance: float = NN_GROUPING_HNSW_DISTANCE
+    use_reranking: bool = False
 
     @field_validator("stacktrace", "message")
     @classmethod
@@ -67,6 +68,11 @@ class CreateGroupingRecordsRequest(BaseModel):
     data: List[CreateGroupingRecordData]
     stacktrace_list: List[str]
     encode_stacktrace_batch_size: int = 1
+    threshold: float = NN_GROUPING_DISTANCE
+    k: int = 1
+    hnsw_candidates: int = NN_GROUPING_HNSW_CANDIDATES
+    hnsw_distance: float = NN_GROUPING_HNSW_DISTANCE
+    use_reranking: bool = False
 
 
 class BulkCreateGroupingRecordsResponse(BaseModel):
@@ -183,6 +189,76 @@ class GroupingLookup:
         k: int,
         hnsw_candidates: int,
         hnsw_distance: float,
+        use_reranking: bool,
+    ) -> List[tuple[DbGroupingRecord, float]]:
+        """
+        Query the nearest k neighbors for a given embedding.
+
+        This method performs a similarity search to find the k nearest neighbors
+        for the provided embedding. It can reranking based on the
+        `use_reranking` parameter.
+
+        Args:
+            session (sqlalchemy.orm.Session): The database session.
+            embedding (np.ndarray): The embedding to search for similar records.
+            project_id (int): The ID of the project to search within.
+            hash (str): The hash to exclude from the search results.
+            distance (float): The maximum cosine distance for similarity.
+            k (int): The number of nearest neighbors to return.
+            hnsw_candidates (int): The number of candidates for HNSW search (used with reranking).
+            hnsw_distance (float): The maximum distance for HNSW search (used with reranking).
+            use_reranking (bool): Whether to use reranking in the search process.
+
+        Returns:
+            List[tuple[DbGroupingRecord, float]]: A list of tuples containing the nearest
+            neighbor records and their distances.
+        """
+        if use_reranking:
+            return self._query_with_reranking(
+                session, embedding, project_id, hash, distance, k, hnsw_candidates, hnsw_distance
+            )
+        else:
+            return self._query_without_reranking(session, embedding, project_id, hash, distance, k)
+
+    def _query_without_reranking(
+        self,
+        session: sqlalchemy.orm.Session,
+        embedding: np.ndarray,
+        project_id: int,
+        hash: str,
+        distance: float,
+        k: int,
+    ) -> List[tuple[DbGroupingRecord, float]]:
+        custom_options = {"postgresql_execute_before": "SET LOCAL hnsw.ef_search = 100"}
+
+        candidates = (
+            session.query(DbGroupingRecord)
+            .filter(
+                DbGroupingRecord.project_id == project_id,
+                DbGroupingRecord.stacktrace_embedding.cosine_distance(embedding) <= distance,
+                DbGroupingRecord.hash != hash,
+            )
+            .order_by(DbGroupingRecord.stacktrace_embedding.cosine_distance(embedding))
+            .limit(k)
+            .execution_options(**custom_options)
+            .all()
+        )
+
+        return [
+            (candidate, self.cosine_distance(embedding, candidate.stacktrace_embedding))
+            for candidate in candidates
+        ]
+
+    def _query_with_reranking(
+        self,
+        session: sqlalchemy.orm.Session,
+        embedding: np.ndarray,
+        project_id: int,
+        hash: str,
+        distance: float,
+        k: int,
+        hnsw_candidates: int,
+        hnsw_distance: float,
     ) -> List[tuple[DbGroupingRecord, float]]:
         custom_options = {"postgresql_execute_before": "SET LOCAL hnsw.ef_search = 100"}
 
@@ -216,22 +292,31 @@ class GroupingLookup:
         return reranked[:k]
 
     @staticmethod
+    def cosine_distance(
+        embedding: np.ndarray,
+        candidate_embedding: np.ndarray,
+        embedding_norm: Optional[float] = None,
+    ) -> float:
+        embedding_norm = embedding_norm if embedding_norm is not None else np.linalg.norm(embedding)
+
+        candidate_norm = np.linalg.norm(candidate_embedding)
+        dot_product = np.dot(candidate_embedding, embedding)
+        return 1 - dot_product / (candidate_norm * embedding_norm)
+
     @sentry_sdk.tracing.trace
     def rerank_candidates(
-        candidates: List[DbGroupingRecord], embedding: np.ndarray, distance: float
+        self, candidates: List[DbGroupingRecord], embedding: np.ndarray, distance: float
     ) -> List[tuple[DbGroupingRecord, float]]:
         embedding_norm = np.linalg.norm(embedding)
 
-        def cosine_distance(candidate_embedding):
-            candidate_norm = np.linalg.norm(candidate_embedding)
-            dot_product = np.dot(candidate_embedding, embedding)
-            return 1 - dot_product / (candidate_norm * embedding_norm)
+        reranked = []
+        for candidate in candidates:
+            cos_distance = self.cosine_distance(
+                embedding, candidate.stacktrace_embedding, embedding_norm
+            )
+            if cos_distance <= distance:
+                reranked.append((candidate, cos_distance))
 
-        reranked = [
-            (candidate, cosine_distance(candidate.stacktrace_embedding))
-            for candidate in candidates
-            if cosine_distance(candidate.stacktrace_embedding) <= distance
-        ]
         return sorted(reranked, key=lambda x: x[1])
 
     @sentry_sdk.tracing.trace
@@ -256,6 +341,7 @@ class GroupingLookup:
                 issue.k,
                 issue.hnsw_candidates,
                 issue.hnsw_distance,
+                issue.use_reranking,
             )
 
             # If no existing groups within the threshold, insert the request as a new GroupingRecord
@@ -336,10 +422,11 @@ class GroupingLookup:
                     embedding,
                     entry.project_id,
                     entry.hash,
-                    NN_GROUPING_DISTANCE,
-                    1,
-                    NN_GROUPING_HNSW_CANDIDATES,
-                    NN_GROUPING_HNSW_DISTANCE,
+                    data.threshold,
+                    data.k,
+                    data.hnsw_candidates,
+                    data.hnsw_distance,
+                    data.use_reranking,
                 )
 
                 if nearest_neighbor:

--- a/src/seer/grouping/grouping.py
+++ b/src/seer/grouping/grouping.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 NN_GROUPING_DISTANCE = 0.01
 NN_GROUPING_HNSW_DISTANCE = 0.05
+NN_GROUPING_HNSW_CANDIDATES = 100
 NN_SIMILARITY_DISTANCE = 0.05
 
 
@@ -248,6 +249,8 @@ class GroupingLookup:
                 issue.hash,
                 NN_SIMILARITY_DISTANCE if issue.read_only else issue.threshold,
                 issue.k,
+                issue.hnsw_candidates,
+                issue.hnsw_distance,
             )
 
             # If no existing groups within the threshold, insert the request as a new GroupingRecord
@@ -330,6 +333,8 @@ class GroupingLookup:
                     entry.hash,
                     NN_GROUPING_DISTANCE,
                     1,
+                    NN_GROUPING_HNSW_CANDIDATES,
+                    NN_GROUPING_HNSW_DISTANCE,
                 )
 
                 if nearest_neighbor:

--- a/src/seer/grouping/grouping.py
+++ b/src/seer/grouping/grouping.py
@@ -33,7 +33,7 @@ class GroupingRequest(BaseModel):
     k: int = 1
     threshold: float = NN_GROUPING_DISTANCE
     read_only: bool = False
-    hnsw_candidates: int = 100
+    hnsw_candidates: int = NN_GROUPING_HNSW_CANDIDATES
     hnsw_distance: float = NN_GROUPING_HNSW_DISTANCE
 
     @field_validator("stacktrace", "message")

--- a/tests/seer/grouping/test_grouping.py
+++ b/tests/seer/grouping/test_grouping.py
@@ -367,6 +367,8 @@ class TestGrouping(unittest.TestCase):
             )
 
         response = grouping_lookup().bulk_create_and_insert_grouping_records(record_requests)
+        for group_response in response.groups_with_neighbor.values():
+            group_response.stacktrace_distance = round(group_response.stacktrace_distance, 3)
         assert response == BulkCreateGroupingRecordsResponse(
             success=True, groups_with_neighbor=expected_groups_with_neighbor
         )
@@ -420,28 +422,32 @@ class TestGrouping(unittest.TestCase):
         # Create mock candidates with incorrect initial ordering
         embedding = np.array([1, 2, 3], dtype=np.float32)
         candidates = [
-            (DbGroupingRecord(stacktrace_embedding=np.array([7, 8, 9], dtype=np.float32)), 0.1),
-            (DbGroupingRecord(stacktrace_embedding=np.array([4, 5, 6], dtype=np.float32)), 0.2),
-            (DbGroupingRecord(stacktrace_embedding=np.array([1, 2, 3], dtype=np.float32)), 0.3),
+            DbGroupingRecord(stacktrace_embedding=np.array([7, 8, 9], dtype=np.float32)),
+            DbGroupingRecord(stacktrace_embedding=np.array([4, 5, 6], dtype=np.float32)),
+            DbGroupingRecord(stacktrace_embedding=np.array([1, 2, 3], dtype=np.float32)),
+            DbGroupingRecord(stacktrace_embedding=np.array([-1, -2, -3], dtype=np.float32)),
         ]
 
+        # Set a distance threshold that includes all candidates except for the one that is reversed
+        distance_threshold = 0.05
+
         # Rerank candidates
-        reranked = grouping_lookup().rerank_candidates(candidates, embedding)
+        reranked = grouping_lookup().rerank_candidates(candidates, embedding, distance_threshold)
 
         # Check that the order is correct after reranking
         self.assertEqual(len(reranked), 3)
         self.assertAlmostEqual(reranked[0][1], 0.0, places=6)  # Should be exact match
-        self.assertAlmostEqual(reranked[1][1], 0.0252214, places=6)
-        self.assertAlmostEqual(reranked[2][1], 0.0462649, places=6)
+        self.assertAlmostEqual(reranked[1][1], 0.0253682, places=6)
+        self.assertAlmostEqual(reranked[2][1], 0.0405881, places=6)
 
         # Check that the order of candidates is corrected
-        self.assertEqual(reranked[0][0], candidates[2][0])  # [1, 2, 3] should be first now
-        self.assertEqual(reranked[1][0], candidates[1][0])  # [4, 5, 6] should be second
-        self.assertEqual(reranked[2][0], candidates[0][0])  # [7, 8, 9] should be last
+        self.assertEqual(reranked[0][0], candidates[2])  # [1, 2, 3] should be first now
+        self.assertEqual(reranked[1][0], candidates[1])  # [4, 5, 6] should be second
+        self.assertEqual(reranked[2][0], candidates[0])  # [7, 8, 9] should be 3rd
 
-        # Verify that the initial order was indeed incorrect
-        self.assertNotEqual(candidates[0][0], reranked[0][0])
-        self.assertNotEqual(candidates[2][0], reranked[2][0])
+        # Verify that the initial order was incorrect
+        self.assertNotEqual(candidates[0], reranked[0][0])
+        self.assertNotEqual(candidates[2], reranked[2][0])
 
 
 @parametrize(count=1)

--- a/tests/test_seer.py
+++ b/tests/test_seer.py
@@ -13,6 +13,7 @@ from seer.app import app
 from seer.automation.autofix.models import AutofixContinuation
 from seer.automation.state import LocalMemoryState
 from seer.db import DbGroupingRecord, ProcessRequest, Session
+from seer.grouping.grouping import CreateGroupingRecordData, CreateGroupingRecordsRequest
 from seer.inference_models import dummy_deferred, reset_loading_state, start_loading
 
 
@@ -310,22 +311,22 @@ class TestSeer(unittest.TestCase):
     def test_similarity_grouping_record_endpoint_valid(self):
         """Test the similarity grouping record endpoint"""
         hashes = [str(i) * 32 for i in range(5)]
-        record_requests = {
-            "data": [
-                {
-                    "group_id": i,
-                    "hash": hashes[i],
-                    "project_id": 1,
-                    "message": "message " + str(i),
-                }
+        record_requests = CreateGroupingRecordsRequest(
+            data=[
+                CreateGroupingRecordData(
+                    group_id=i,
+                    hash=hashes[i],
+                    project_id=1,
+                    message="message " + str(i),
+                )
                 for i in range(5)
             ],
-            "stacktrace_list": ["stacktrace " + str(i) for i in range(5)],
-        }
+            stacktrace_list=["stacktrace " + str(i) for i in range(5)],
+        )
 
         response = app.test_client().post(
             "/v0/issues/similar-issues/grouping-record",
-            data=json.dumps(record_requests),
+            data=record_requests.json(),
             content_type="application/json",
         )
         output = json.loads(response.get_data(as_text=True))
@@ -341,22 +342,22 @@ class TestSeer(unittest.TestCase):
         different lengths
         """
         hashes = [str(i) * 32 for i in range(5, 7)]
-        record_requests = {
-            "data": [
-                {
-                    "group_id": i,
-                    "hash": hashes[i],
-                    "project_id": 1,
-                    "message": "message " + str(i),
-                }
+        record_requests = CreateGroupingRecordsRequest(
+            data=[
+                CreateGroupingRecordData(
+                    group_id=i,
+                    hash=hashes[i],
+                    project_id=1,
+                    message="message " + str(i),
+                )
                 for i in range(2)
             ],
-            "stacktrace_list": ["stacktrace " + str(i) for i in range(3)],
-        }
+            stacktrace_list=["stacktrace " + str(i) for i in range(3)],
+        )
 
         response = app.test_client().post(
             "/v0/issues/similar-issues/grouping-record",
-            data=json.dumps(record_requests),
+            data=record_requests.json(),
             content_type="application/json",
         )
         output = json.loads(response.get_data(as_text=True))


### PR DESCRIPTION
quickly tested and it takes ~1ms for 100 records on my laptop, we can probably bump this up but lets confirm performance in prod first. i also added some sentry metrics dogfooding stuff - lmk if this seems appropriate

logic:

- take first 100 records from pg, sorted by HNSW index implied distance - no longer include "distance" calculation from pg, require at least 0.05 distance for candidates
- manually calculate cosine distance for all 100 candidates
- rerank based on distance and then return top k