### PR TITLE
Support BaseModel better with @provider and @inject

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from johen.generators import pydantic, sqlalchemy
 from sqlalchemy import text
 
 from celery_app.config import CeleryConfig
+from seer.app import module
 from seer.bootup import bootup, stub_module
 from seer.configuration import configuration_test_module
 from seer.db import Session, db
@@ -27,7 +28,7 @@ def configure_environment():
 
 @pytest.fixture(autouse=True)
 def setup_app(test_module: Module):
-    with configuration_test_module, test_module:
+    with module, configuration_test_module, test_module:
         reset_loading_state()
         bootup(start_model_loading=False, integrations=[])
         app = resolve(Flask)

--- a/tests/test_dependency_injection.py
+++ b/tests/test_dependency_injection.py
@@ -2,6 +2,7 @@ import dataclasses
 from typing import Annotated, Any, Mapping
 
 import pytest
+from pydantic import BaseModel
 
 from seer.dependency_injection import FactoryAnnotation, Labeled, Module, inject, injected, resolve
 
@@ -111,8 +112,7 @@ def test_injections():
         config_a: Annotated[str, Labeled("a")] = injected
 
     @module.provider
-    @dataclasses.dataclass
-    class ServiceB:
+    class ServiceB(BaseModel):
         service_a: ServiceA = injected
         config_b: Annotated[str, Labeled("b")] = injected
 


### PR DESCRIPTION
Fixes two problems:

1.  Running individual pytest cases would fail with an injector issue.  Resolve by insuring `conftest` fully imports the app module and installs it.
2.  Fixes using injection with BaseModel (pydantic).  Test case adjusted.