### PR TITLE
fix: Fix langfuse init

### DIFF
--- a/src/seer/bootup.py
+++ b/src/seer/bootup.py
@@ -10,7 +10,6 @@ from seer.configuration import AppConfig
 from seer.db import initialize_database
 from seer.dependency_injection import Module, inject, injected
 from seer.inference_models import initialize_models
-from seer.langfuse import initialize_langfuse_context
 from seer.logging import initialize_logs
 
 logger = logging.getLogger(__name__)
@@ -41,7 +40,6 @@ def bootup(
     config.do_validation()
     initialize_database()
     initialize_models(start_model_loading)
-    initialize_langfuse_context()
 
 
 @inject

--- a/src/seer/langfuse.py
+++ b/src/seer/langfuse.py
@@ -11,16 +11,6 @@ logger = logging.getLogger(__name__)
 langfuse_module = Module()
 
 
-@inject
-def initialize_langfuse_context(config: AppConfig = injected):
-    langfuse_context.configure(
-        public_key=config.LANGFUSE_PUBLIC_KEY,
-        secret_key=config.LANGFUSE_SECRET_KEY,
-        host=config.LANGFUSE_HOST,
-        enabled=bool(config.LANGFUSE_HOST),
-    )
-
-
 @langfuse_module.provider
 def provide_langfuse(config: AppConfig = injected) -> Langfuse:
     return Langfuse(

--- a/tests/test_langfuse.py
+++ b/tests/test_langfuse.py
@@ -5,7 +5,7 @@ from langfuse import Langfuse
 
 from seer.configuration import AppConfig, provide_test_defaults
 from seer.dependency_injection import Module, resolve
-from seer.langfuse import append_langfuse_trace_tags, initialize_langfuse_context, provide_langfuse
+from seer.langfuse import append_langfuse_trace_tags, provide_langfuse
 
 langfuse_configuration_test_module = Module()
 
@@ -30,32 +30,6 @@ def provide_langfuse_mock() -> Langfuse:
 def setup_langfuse_config():
     with langfuse_configuration_test_module:
         yield
-
-
-class TestInitializeLangfuseContext:
-    @patch("seer.langfuse.langfuse_context")
-    def test_initialize_langfuse_context(self, mock_langfuse_context):
-        # The environment variables are now mocked, so we don't need to set them on the config object
-
-        initialize_langfuse_context()
-
-        mock_langfuse_context.configure.assert_called_once_with(
-            public_key="public_key",
-            secret_key="secret_key",
-            host="https://api.langfuse.com",
-            enabled=True,
-        )
-
-    @patch("seer.langfuse.langfuse_context")
-    def test_initialize_langfuse_context_disabled(self, mock_langfuse_context):
-
-        resolve(AppConfig).LANGFUSE_HOST = ""
-
-        initialize_langfuse_context()
-
-        mock_langfuse_context.configure.assert_called_once_with(
-            public_key="public_key", secret_key="secret_key", host="", enabled=False
-        )
 
 
 class TestProvideLangfuse:


### PR DESCRIPTION
looks like we have to call `langfuse_context.configure` before any of the decorators are used, otherwise it messes up the langfuse singleton...we can't do that and use the AppConfig, so we revert to just using the env variables for langfuse but keep the checks in AppConfig