### PR TITLE
(autofix): Switch root cause formatter to gpt-4o-mini

### DIFF
--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -59,7 +59,8 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
                     role="user",
                     content=RootCauseAnalysisPrompts.root_cause_formatter_msg(extracted_response),
                 )
-            ]
+            ],
+            model="gpt-4o-mini-2024-07-18",
         )
 
         with self.context.state.update() as cur:


### PR DESCRIPTION
Faster and cheaper for a simple step. #999 