### PR TITLE
feat(autofix): Enable root cause re-selection

### DIFF
--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -122,6 +122,7 @@ class AutofixEventManager:
         with self.state.update() as cur:
             root_cause_step = cur.find_or_add(self.root_cause_analysis_step)
             root_cause_step.selection = root_cause_selection
+            cur.delete_steps_after(root_cause_step)
 
             cur.status = AutofixStatus.PROCESSING
 

--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -123,6 +123,7 @@ class AutofixEventManager:
             root_cause_step = cur.find_or_add(self.root_cause_analysis_step)
             root_cause_step.selection = root_cause_selection
             cur.delete_steps_after(root_cause_step)
+            cur.clear_file_changes()
 
             cur.status = AutofixStatus.PROCESSING
 

--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -351,6 +351,11 @@ class AutofixContinuation(AutofixGroupState):
                 break
         self.steps = steps_to_keep
 
+    def clear_file_changes(self):
+        for key, codebase in self.codebases.items():
+            codebase.file_changes = []
+            self.codebases[key] = codebase
+
     @property
     def is_running(self):
         return self.status == AutofixStatus.PROCESSING or self.status == AutofixStatus.PENDING

--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -343,6 +343,14 @@ class AutofixContinuation(AutofixGroupState):
     def mark_updated(self):
         self.updated_at = datetime.datetime.now()
 
+    def delete_steps_after(self, step: Step):
+        steps_to_keep = []
+        for cur_step in self.steps:
+            steps_to_keep.append(cur_step)
+            if step.id == cur_step.id:
+                break
+        self.steps = steps_to_keep
+
     @property
     def is_running(self):
         return self.status == AutofixStatus.PROCESSING or self.status == AutofixStatus.PENDING


### PR DESCRIPTION
When a root cause selection is received, we now delete any steps after the root cause step and clear any file changes made so we can re-run cleanly with the new root cause.