### PR TITLE
(autofix): Prompt engineering to make root cause output descriptions more detailed

### DIFF
--- a/src/seer/automation/autofix/components/root_cause/models.py
+++ b/src/seer/automation/autofix/components/root_cause/models.py
@@ -77,10 +77,10 @@ class RootCauseAnalysisItemPromptXml(PromptXmlModel, tag="potential_cause", skip
     @classmethod
     def get_example(cls):
         return cls(
-            title="foo() is returning the wrong value",
+            title="Summarize the root cause here in a few words.",
             likelihood=0.8,
             actionability=1.0,
-            description="The foo() function is returning the wrong value due to a typo in bar().",
+            description="Explain the root cause in full detail here with the full chain of reasoning behind it.",
             relevant_code=RootCauseAnalysisRelevantContextPromptXml.get_example(),
         )
 
@@ -135,10 +135,10 @@ class MultipleRootCauseAnalysisOutputPromptXml(PromptXmlModel, tag="potential_ro
             causes=[
                 RootCauseAnalysisItemPromptXml.get_example(),
                 RootCauseAnalysisItemPromptXml(
-                    title="bar() sends an incorrect value to foo(), which itself does not have validation",
+                    title="Summarize the root cause here in a few words.",
                     likelihood=0.2,
                     actionability=1.0,
-                    description="The upstream bar() function sends an incorrect value to foo(), which itself does not have validation, causing this error downstream.",
+                    description="Explain the root cause in full detail here with the full chain of reasoning behind it.",
                     relevant_code=RootCauseAnalysisRelevantContextPromptXml.get_example(),
                 ),
             ]

--- a/src/seer/automation/autofix/components/root_cause/prompts.py
+++ b/src/seer/automation/autofix/components/root_cause/prompts.py
@@ -46,7 +46,7 @@ class RootCauseAnalysisPrompts:
 
             # Guidelines:
             - Each root cause should be inside its own <root_cause> block.
-            - Include a title and description in each root cause.
+            - Include a title and description in each root cause. Your description may be as long as you need to help your team understand the issue, explaining the issue, the root cause, why this is happening, and how you came to your conclusion.
             - Include float values from 0.0-1.0 of the likelihood and actionability of each root cause.
             - In each root cause, provide snippets of the original code, each with their own titles and descriptions, to highlight where and why the issue is occurring so that your colleagues fully understand the root cause. Provide as many snippets as you want. Within your snippets, you may highlight specific lines with a comment beginning with ***.
             - You MUST include the EXACT file name and repository name in the code snippets you provide. If you cannot, do not provide a code snippet.


### PR DESCRIPTION
An example below of how it's more informative to the user now.
Also results in a small eval bump from 0.43/0.53 to 0.44/0.54 (error weighted/normal).

<img width="895" alt="Screenshot 2024-08-07 at 7 35 54 AM" src="https://github.com/user-attachments/assets/367e8c7e-5bb3-407b-bb2c-5670aae73371">
