### PR TITLE
fix(autofix): Make repo name have default value to prevent validation error

### DIFF
--- a/src/seer/automation/autofix/components/root_cause/models.py
+++ b/src/seer/automation/autofix/components/root_cause/models.py
@@ -25,7 +25,7 @@ class SnippetPromptXml(PromptXmlModel, tag="code"):
 
 class RootCauseRelevantCodeSnippet(BaseModel):
     file_path: str
-    repo_name: Optional[str]
+    repo_name: Optional[str] = None
     snippet: str
 
 


### PR DESCRIPTION
Should fix https://sentry.sentry.io/issues/5244174915/?project=6178942&query=is:unresolved+issue.priority:%5Bhigh,+medium%5D&statsPeriod=14d&stream_index=0