### PR TITLE
fix(autofix-celery): Set default queues

### DIFF
--- a/src/celery_app/app.py
+++ b/src/celery_app/app.py
@@ -29,7 +29,10 @@ def capture_worker_name(sender, instance, **kwargs):
 
 @signals.after_task_publish.connect
 def handle_task_publish(sender, **kwargs):
-    logger.info(f"Task published, task: {sender}")
+    routing_key = kwargs.get("routing_key")
+    exchange = kwargs.get("exchange")
+
+    logger.info(f"Task published, task: {sender}, routing_key: {routing_key}, exchange: {exchange}")
 
 
 @signals.task_prerun.connect

--- a/src/celery_app/config.py
+++ b/src/celery_app/config.py
@@ -30,11 +30,7 @@ def celery_config(app_config: AppConfig = injected) -> CeleryConfig:
             CeleryQueues.DEFAULT: {
                 "exchange": CeleryQueues.DEFAULT,
                 "routing_key": CeleryQueues.DEFAULT,
-            },
-            CeleryQueues.CUDA: {
-                "exchange": CeleryQueues.CUDA,
-                "routing_key": CeleryQueues.CUDA,
-            },
+            }
         },
         result_backend="rpc://",
     )

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -112,7 +112,8 @@ def run_autofix_root_cause(
     RootCauseStep.get_signature(
         RootCauseStepRequest(
             run_id=cur_state.run_id,
-        )
+        ),
+        queue=CeleryQueues.DEFAULT,
     ).apply_async()
 
     return cur_state.run_id
@@ -144,6 +145,7 @@ def run_autofix_execution(request: AutofixUpdateRequest):
             AutofixCodingStepRequest(
                 run_id=cur.run_id,
             ),
+            queue=CeleryQueues.DEFAULT,
         ).apply_async()
     except InitializationError as e:
         sentry_sdk.capture_exception(e)


### PR DESCRIPTION
Need to set default queues for celery, for some reason the `default_task_queue` setting doesn't work