### PR TITLE
feat(autofix): Add retry logic

### DIFF
--- a/src/seer/automation/autofix/components/coding/utils.py
+++ b/src/seer/automation/autofix/components/coding/utils.py
@@ -132,6 +132,11 @@ def task_to_file_change(task: PlanTaskPromptXml, file_content: str) -> list[File
     diff_chunks = extract_diff_chunks(task.diff)
 
     for chunk in diff_chunks:
+        if chunk.original_chunk == chunk.new_chunk:
+            continue
+        if chunk.original_chunk.strip() == "":
+            raise ValueError(f"Original chunk is empty for task: {task}")
+
         result = find_original_snippet(
             chunk.original_chunk,
             file_content,

--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -57,7 +57,9 @@ class AutofixEventManager:
     def send_root_cause_analysis_pending(self):
         with self.state.update() as cur:
             step = cur.add_step(self.root_cause_analysis_processing_step)
-            step.status = AutofixStatus.PROCESSING
+            step.status = (
+                AutofixStatus.PROCESSING
+            )  # We want it to be spinning on the UI, not a grey pending, so we just make it processing.
 
     def send_root_cause_analysis_start(self):
         with self.state.update() as cur:

--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -343,13 +343,10 @@ class AutofixContinuation(AutofixGroupState):
     def mark_updated(self):
         self.updated_at = datetime.datetime.now()
 
-    def delete_steps_after(self, step: Step):
-        steps_to_keep = []
-        for cur_step in self.steps:
-            steps_to_keep.append(cur_step)
-            if step.id == cur_step.id:
-                break
-        self.steps = steps_to_keep
+    def delete_steps(self, step: Step, include_current: bool = False):
+        found_index = next((i for i, s in enumerate(self.steps) if s.id == step.id), -1)
+        if found_index != -1:
+            self.steps = self.steps[: found_index + (0 if include_current else 1)]
 
     def clear_file_changes(self):
         for key, codebase in self.codebases.items():

--- a/src/seer/automation/autofix/runs.py
+++ b/src/seer/automation/autofix/runs.py
@@ -14,6 +14,6 @@ def create_initial_autofix_run(request: AutofixRequest):
     cur = state.get()
 
     event_manager = AutofixEventManager(state)
-    event_manager.send_root_cause_analysis_start()
+    event_manager.send_root_cause_analysis_pending()
 
     return state

--- a/src/seer/automation/autofix/steps/change_describer_step.py
+++ b/src/seer/automation/autofix/steps/change_describer_step.py
@@ -38,6 +38,12 @@ class AutofixChangeDescriberStep(AutofixPipelineStep):
     name = "AutofixChangeDescriberStep"
     request: AutofixChangeDescriberRequest
 
+    max_retries = 2
+
+    @property
+    def step_key(self) -> str:
+        return "change_describer"
+
     @staticmethod
     def _instantiate_request(request: dict[str, Any]) -> AutofixChangeDescriberRequest:
         return AutofixChangeDescriberRequest.model_validate(request)

--- a/src/seer/automation/autofix/steps/change_describer_step.py
+++ b/src/seer/automation/autofix/steps/change_describer_step.py
@@ -40,10 +40,6 @@ class AutofixChangeDescriberStep(AutofixPipelineStep):
 
     max_retries = 1
 
-    @property
-    def step_key(self) -> str:
-        return "change_describer"
-
     @staticmethod
     def _instantiate_request(request: dict[str, Any]) -> AutofixChangeDescriberRequest:
         return AutofixChangeDescriberRequest.model_validate(request)
@@ -95,4 +91,4 @@ class AutofixChangeDescriberStep(AutofixPipelineStep):
 
                     codebase_changes.append(change)
 
-        self.context.event_manager.send_execution_complete(codebase_changes)
+        self.context.event_manager.send_coding_complete(codebase_changes)

--- a/src/seer/automation/autofix/steps/change_describer_step.py
+++ b/src/seer/automation/autofix/steps/change_describer_step.py
@@ -38,7 +38,7 @@ class AutofixChangeDescriberStep(AutofixPipelineStep):
     name = "AutofixChangeDescriberStep"
     request: AutofixChangeDescriberRequest
 
-    max_retries = 2
+    max_retries = 1
 
     @property
     def step_key(self) -> str:

--- a/src/seer/automation/autofix/steps/coding_step.py
+++ b/src/seer/automation/autofix/steps/coding_step.py
@@ -77,9 +77,6 @@ class AutofixCodingStep(AutofixPipelineStep):
 
         self.context.event_manager.send_coding_result(coding_output)
 
-        if self.get_retry_count() < 1:
-            raise ValueError("Coding step must be retried at least once")
-
         self.next(
             AutofixChangeDescriberStep.get_signature(
                 AutofixChangeDescriberRequest(**self.step_request_fields)

--- a/src/seer/automation/autofix/steps/coding_step.py
+++ b/src/seer/automation/autofix/steps/coding_step.py
@@ -39,7 +39,7 @@ class AutofixCodingStep(AutofixPipelineStep):
     """
 
     name = "AutofixCodingStep"
-    max_retries = 3
+    max_retries = 2
 
     @property
     def step_key(self) -> str:
@@ -56,6 +56,8 @@ class AutofixCodingStep(AutofixPipelineStep):
     @observe(name="Autofix - Plan+Code Step")
     @ai_track(description="Autofix - Plan+Code Step")
     def _invoke(self, **kwargs):
+        self.context.event_manager.clear_steps_from(self.context.event_manager.plan_step)
+
         self.logger.info("Executing Autofix - Plan+Code Step")
 
         self.context.event_manager.send_coding_start()

--- a/src/seer/automation/autofix/steps/coding_step.py
+++ b/src/seer/automation/autofix/steps/coding_step.py
@@ -17,7 +17,7 @@ from seer.automation.autofix.steps.change_describer_step import (
 )
 from seer.automation.autofix.steps.steps import AutofixPipelineStep
 from seer.automation.models import EventDetails
-from seer.automation.pipeline import PipelineChain, PipelineStepTaskRequest
+from seer.automation.pipeline import PipelineStepTaskRequest
 
 
 class AutofixCodingStepRequest(PipelineStepTaskRequest):
@@ -32,13 +32,18 @@ def autofix_coding_task(*args, request: dict[str, Any]):
     AutofixCodingStep(request).invoke()
 
 
-class AutofixCodingStep(PipelineChain, AutofixPipelineStep):
+class AutofixCodingStep(AutofixPipelineStep):
     """
-    This class represents the execution pipeline in the autofix system. It is responsible for
+    This class represents the coding step in the autofix pipeline. It is responsible for
     executing the fixes suggested by the coding component based on the root cause analysis.
     """
 
     name = "AutofixCodingStep"
+    max_retries = 3
+
+    @property
+    def step_key(self) -> str:
+        return "coding"
 
     @staticmethod
     def _instantiate_request(request: dict[str, Any]) -> AutofixCodingStepRequest:

--- a/src/seer/automation/autofix/steps/root_cause_step.py
+++ b/src/seer/automation/autofix/steps/root_cause_step.py
@@ -35,6 +35,12 @@ class RootCauseStep(AutofixPipelineStep):
 
     name = "RootCauseStep"
 
+    @property
+    def step_key(self) -> str:
+        return "root_cause"
+
+    max_retries = 3
+
     @staticmethod
     def get_task():
         return root_cause_task

--- a/src/seer/automation/autofix/steps/root_cause_step.py
+++ b/src/seer/automation/autofix/steps/root_cause_step.py
@@ -39,7 +39,7 @@ class RootCauseStep(AutofixPipelineStep):
     def step_key(self) -> str:
         return "root_cause"
 
-    max_retries = 3
+    max_retries = 2
 
     @staticmethod
     def get_task():
@@ -52,6 +52,9 @@ class RootCauseStep(AutofixPipelineStep):
     @observe(name="Autofix - Root Cause Step")
     @ai_track(description="Autofix - Root Cause Step")
     def _invoke(self, **kwargs):
+        self.context.event_manager.clear_steps_from(
+            self.context.event_manager.root_cause_analysis_step
+        )
         self.context.event_manager.send_root_cause_analysis_start()
 
         state = self.context.state.get()
@@ -64,4 +67,5 @@ class RootCauseStep(AutofixPipelineStep):
                 instruction=state.request.instruction,
             )
         )
+
         self.context.event_manager.send_root_cause_analysis_result(root_cause_output)

--- a/src/seer/automation/autofix/steps/root_cause_step.py
+++ b/src/seer/automation/autofix/steps/root_cause_step.py
@@ -61,7 +61,4 @@ class RootCauseStep(AutofixPipelineStep):
             )
         )
 
-        if self.get_retry_count() < 1:
-            raise Exception("Root cause analysis failed")
-
         self.context.event_manager.send_root_cause_analysis_result(root_cause_output)

--- a/src/seer/automation/autofix/steps/root_cause_step.py
+++ b/src/seer/automation/autofix/steps/root_cause_step.py
@@ -35,10 +35,6 @@ class RootCauseStep(AutofixPipelineStep):
 
     name = "RootCauseStep"
 
-    @property
-    def step_key(self) -> str:
-        return "root_cause"
-
     max_retries = 2
 
     @staticmethod
@@ -52,9 +48,6 @@ class RootCauseStep(AutofixPipelineStep):
     @observe(name="Autofix - Root Cause Step")
     @ai_track(description="Autofix - Root Cause Step")
     def _invoke(self, **kwargs):
-        self.context.event_manager.clear_steps_from(
-            self.context.event_manager.root_cause_analysis_step
-        )
         self.context.event_manager.send_root_cause_analysis_start()
 
         state = self.context.state.get()
@@ -67,5 +60,8 @@ class RootCauseStep(AutofixPipelineStep):
                 instruction=state.request.instruction,
             )
         )
+
+        if self.get_retry_count() < 1:
+            raise Exception("Root cause analysis failed")
 
         self.context.event_manager.send_root_cause_analysis_result(root_cause_output)

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -168,13 +168,9 @@ def run_autofix_create_pr(request: AutofixUpdateRequest):
         state=state, sentry_client=get_sentry_client(), event_manager=event_manager
     )
 
-    event_manager.send_pr_creation_start()
-
     context.commit_changes(
         repo_external_id=request.payload.repo_external_id, repo_id=request.payload.repo_id
     )
-
-    event_manager.send_pr_creation_complete()
 
 
 def run_autofix_evaluation(request: AutofixEvaluationRequest):

--- a/src/seer/automation/utils.py
+++ b/src/seer/automation/utils.py
@@ -86,12 +86,12 @@ def make_done_signal(id: str | int) -> str:
     return f"done:{id}"
 
 
-def make_retry_prefix(step_key: str) -> str:
-    return f"retry:{step_key}:"
+def make_retry_prefix(step_id: int) -> str:
+    return f"retry:{step_id}:"
 
 
-def make_retry_signal(step_key: str, retry_attempt_no: int) -> str:
-    return f"{make_retry_prefix(step_key)}{retry_attempt_no}"
+def make_retry_signal(step_id: int, retry_attempt_no: int) -> str:
+    return f"{make_retry_prefix(step_id)}{retry_attempt_no}"
 
 
 def process_repo_provider(provider: str) -> str:

--- a/src/seer/automation/utils.py
+++ b/src/seer/automation/utils.py
@@ -86,6 +86,14 @@ def make_done_signal(id: str | int) -> str:
     return f"done:{id}"
 
 
+def make_retry_prefix(step_key: str) -> str:
+    return f"retry:{step_key}:"
+
+
+def make_retry_signal(step_key: str, retry_attempt_no: int) -> str:
+    return f"{make_retry_prefix(step_key)}{retry_attempt_no}"
+
+
 def process_repo_provider(provider: str) -> str:
     if provider.startswith("integrations:"):
         return provider.split(":")[1]

--- a/tests/automation/autofix/steps/test_autofix_steps.py
+++ b/tests/automation/autofix/steps/test_autofix_steps.py
@@ -1,9 +1,15 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from seer.automation.autofix.steps.steps import AutofixPipelineStep
 
 
 class ConcreteAutofixPipelineStep(AutofixPipelineStep):
+    @property
+    def step_key(self):
+        return "test"
+
     @classmethod
     def get_task(cls):
         return MagicMock()
@@ -45,3 +51,84 @@ class TestAutofixPipelineStep:
 
         step.context.state.update.assert_called_once()
         assert mock_state.signals == ["done:1"]
+
+    @pytest.fixture
+    def mock_step(self):
+        class MockStep(AutofixPipelineStep):
+            @property
+            def step_key(self):
+                return "mock_step"
+
+            @classmethod
+            def get_task(cls):
+                return MagicMock()
+
+            def _instantiate_request(self, request):
+                return MagicMock()
+
+            def _instantiate_context(self, request):
+                return MagicMock()
+
+            def _invoke(self, **kwargs):
+                return True
+
+        return MockStep({"run_id": 1, "step_id": 1})
+
+    def test_step_key_property(self, mock_step):
+        assert mock_step.step_key == "mock_step"
+
+    def test_max_retries_default(self, mock_step):
+        assert mock_step.max_retries == 0
+
+    @patch("seer.automation.autofix.steps.steps.make_retry_prefix")
+    @patch("seer.automation.autofix.steps.steps.make_retry_signal")
+    def test_handle_exception_no_retry(
+        self, mock_make_retry_signal, mock_make_retry_prefix, mock_step
+    ):
+        mock_make_retry_prefix.return_value = "retry:mock_step:"
+        mock_step.context.signals = []
+        mock_step.context.event_manager.on_error = MagicMock()
+        mock_step.next = MagicMock()
+
+        exception = Exception("Test error")
+        mock_step._handle_exception(exception)
+
+        mock_step.context.event_manager.on_error.assert_called_once_with(str(exception))
+        mock_step.next.assert_not_called()
+
+    @patch("seer.automation.autofix.steps.steps.make_retry_prefix")
+    @patch("seer.automation.autofix.steps.steps.make_retry_signal")
+    def test_handle_exception_with_retry(
+        self, mock_make_retry_signal, mock_make_retry_prefix, mock_step
+    ):
+        mock_make_retry_prefix.return_value = "retry:mock_step:"
+        mock_make_retry_signal.return_value = "retry:mock_step:1"
+        mock_step.max_retries = 1
+        mock_step.context.signals = []
+        mock_step.context.state.update = MagicMock()
+        mock_step.context.state.update.return_value.__enter__.return_value = MagicMock(signals=[])
+        mock_step.next = MagicMock()
+
+        exception = Exception("Test error")
+        mock_step._handle_exception(exception)
+
+        mock_make_retry_signal.assert_called_once_with("mock_step", 1)
+        mock_step.next.assert_called_once()
+        mock_step.context.event_manager.on_error.assert_not_called()
+
+    @patch("seer.automation.autofix.steps.steps.make_retry_prefix")
+    @patch("seer.automation.autofix.steps.steps.make_retry_signal")
+    def test_handle_exception_max_retries_reached(
+        self, mock_make_retry_signal, mock_make_retry_prefix, mock_step
+    ):
+        mock_make_retry_prefix.return_value = "retry:mock_step:"
+        mock_step.max_retries = 1
+        mock_step.context.signals = ["retry:mock_step:1"]
+        mock_step.context.event_manager.on_error = MagicMock()
+        mock_step.next = MagicMock()
+
+        exception = Exception("Test error")
+        mock_step._handle_exception(exception)
+
+        mock_step.context.event_manager.on_error.assert_called_once_with(str(exception))
+        mock_step.next.assert_not_called()

--- a/tests/automation/autofix/steps/test_autofix_steps.py
+++ b/tests/automation/autofix/steps/test_autofix_steps.py
@@ -80,6 +80,24 @@ class TestAutofixPipelineStep:
     def test_max_retries_default(self, mock_step):
         assert mock_step.max_retries == 0
 
+    def test_get_retry_count_no_retries(self, mock_step):
+        mock_step.context.signals = []
+        assert mock_step.get_retry_count() == 0
+
+    def test_get_retry_count_with_retries(self, mock_step):
+        mock_step.context.signals = ["retry:mock_step:1", "retry:mock_step:2"]
+        assert mock_step.get_retry_count() == 2
+
+    def test_get_retry_count_with_mixed_signals(self, mock_step):
+        mock_step.context.signals = ["retry:mock_step:1", "other_signal", "retry:mock_step:2"]
+        assert mock_step.get_retry_count() == 2
+
+    @patch("seer.automation.autofix.steps.steps.make_retry_prefix")
+    def test_get_retry_count_with_custom_prefix(self, mock_make_retry_prefix, mock_step):
+        mock_make_retry_prefix.return_value = "custom_retry:"
+        mock_step.context.signals = ["custom_retry:1", "custom_retry:2", "other_signal"]
+        assert mock_step.get_retry_count() == 2
+
     @patch("seer.automation.autofix.steps.steps.make_retry_prefix")
     @patch("seer.automation.autofix.steps.steps.make_retry_signal")
     def test_handle_exception_no_retry(

--- a/tests/automation/autofix/test_autofix_event_manager.py
+++ b/tests/automation/autofix/test_autofix_event_manager.py
@@ -1,0 +1,49 @@
+import pytest
+from johen import generate
+
+from seer.automation.autofix.event_manager import AutofixEventManager
+from seer.automation.autofix.models import (
+    AutofixContinuation,
+    AutofixRequest,
+    AutofixStatus,
+    ProgressType,
+    RootCauseStep,
+)
+from seer.automation.state import LocalMemoryState
+
+
+class TestAutofixEventManager:
+    @pytest.fixture
+    def state(self):
+        return LocalMemoryState(AutofixContinuation(request=next(generate(AutofixRequest))))
+
+    @pytest.fixture
+    def event_manager(self, state):
+        return AutofixEventManager(state)
+
+    def test_add_log_to_current_step(self, event_manager, state):
+        state.get().steps = [
+            RootCauseStep(id="1", title="Test Step", status=AutofixStatus.PROCESSING, progress=[])
+        ]
+
+        event_manager.add_log("Test log message")
+
+        assert len(state.get().steps[0].progress) == 1
+        assert state.get().steps[0].progress[0].message == "Test log message"
+        assert state.get().steps[0].progress[0].type == ProgressType.INFO
+
+    def test_add_log_no_processing_step(self, event_manager, state):
+        state.get().steps = [
+            RootCauseStep(id="1", title="Test Step", status=AutofixStatus.COMPLETED, progress=[])
+        ]
+
+        event_manager.add_log("Test log message")
+
+        assert len(state.get().steps[0].progress) == 0
+
+    def test_add_log_empty_steps(self, event_manager, state):
+        state.get().steps = []
+
+        event_manager.add_log("Test log message")
+
+        assert state.get().steps == []

--- a/tests/automation/autofix/test_autofix_tasks.py
+++ b/tests/automation/autofix/test_autofix_tasks.py
@@ -180,6 +180,4 @@ class TestRunAutofixCreatePr:
 
         # Assert
         mock_continuation_state.from_id.assert_called_once_with(1, model=AutofixContinuation)
-        mock_event_manager.return_value.send_pr_creation_start.assert_called_once()
         mock_context.commit_changes.assert_called_once_with(repo_external_id="repo1", repo_id=1)
-        mock_event_manager.return_value.send_pr_creation_complete.assert_called_once()

--- a/tests/automation/autofix/test_models.py
+++ b/tests/automation/autofix/test_models.py
@@ -309,14 +309,23 @@ class TestAutofixContinuation(unittest.TestCase):
             self.continuation.mark_updated()
             self.assertEqual(self.continuation.updated_at, mock_now)
 
-    def test_delete_steps_after(self):
+    def test_delete_steps(self):
         step1 = DefaultStep(id="step1", title="test")
         step2 = DefaultStep(id="step2", title="test")
         step3 = DefaultStep(id="step3", title="test")
         self.continuation.steps = [step1, step2, step3]
 
-        self.continuation.delete_steps_after(step2)
+        self.continuation.delete_steps(step2)
         self.assertEqual(self.continuation.steps, [step1, step2])
+
+    def test_delete_steps_including_self(self):
+        step1 = DefaultStep(id="step1", title="test")
+        step2 = DefaultStep(id="step2", title="test")
+        step3 = DefaultStep(id="step3", title="test")
+        self.continuation.steps = [step1, step2, step3]
+
+        self.continuation.delete_steps(step2, include_current=True)
+        self.assertEqual(self.continuation.steps, [step1])
 
     def test_clear_file_changes(self):
         codebase1 = Mock()

--- a/tests/automation/autofix/test_models.py
+++ b/tests/automation/autofix/test_models.py
@@ -221,7 +221,57 @@ class TestAutofixContinuation(unittest.TestCase):
         self.request = Mock(spec=AutofixRequest)
         self.continuation = AutofixContinuation(request=self.request)
 
-    def test_find_step(self):
+    def test_auto_generated_step_ids(self):
+        # Create steps without specifying IDs
+        step1 = DefaultStep(key="step1", title="Test Step 1")
+        step2 = DefaultStep(key="step2", title="Test Step 2")
+
+        # Add steps to the continuation
+        added_step1 = self.continuation.add_step(step1)
+        added_step2 = self.continuation.add_step(step2)
+
+        # Check that IDs were auto-generated
+        self.assertIsNotNone(added_step1.id)
+        self.assertIsNotNone(added_step2.id)
+
+        # Check that the IDs are strings (UUIDs)
+        self.assertIsInstance(added_step1.id, str)
+        self.assertIsInstance(added_step2.id, str)
+
+        # Check that the IDs are unique
+        self.assertNotEqual(added_step1.id, added_step2.id)
+
+        # Verify that we can find steps by their auto-generated IDs
+        self.assertEqual(self.continuation.find_step(id=added_step1.id), added_step1)
+        self.assertEqual(self.continuation.find_step(id=added_step2.id), added_step2)
+
+    def test_model_copy_with_new_id(self):
+        original_step = DefaultStep(key="original", title="Original Step")
+        self.continuation.add_step(original_step)
+
+        copied_step = original_step.model_copy_with_new_id()
+
+        # Check that a new ID was generated
+        self.assertNotEqual(original_step.id, copied_step.id)
+
+        # Check that other attributes remain the same
+        self.assertEqual(original_step.key, copied_step.key)
+        self.assertEqual(original_step.title, copied_step.title)
+
+        # Add the copied step and verify it can be found by its new ID
+        added_copied_step = self.continuation.add_step(copied_step)
+        self.assertEqual(self.continuation.find_step(id=copied_step.id), added_copied_step)
+
+    def test_find_step_by_key(self):
+        step1 = DefaultStep(key="step1", title="test")
+        step2 = DefaultStep(key="step2", title="test")
+        self.continuation.steps = [step1, step2]
+
+        self.assertEqual(self.continuation.find_step(key="step1"), step1)
+        self.assertEqual(self.continuation.find_step(key="step2"), step2)
+        self.assertIsNone(self.continuation.find_step(key="step3"))
+
+    def test_find_step_by_id(self):
         step1 = DefaultStep(id="step1", title="test")
         step2 = DefaultStep(id="step2", title="test")
         self.continuation.steps = [step1, step2]
@@ -230,8 +280,27 @@ class TestAutofixContinuation(unittest.TestCase):
         self.assertEqual(self.continuation.find_step(id="step2"), step2)
         self.assertIsNone(self.continuation.find_step(id="step3"))
 
+    def test_add_step(self):
+        step1 = DefaultStep(key="step1", title="test")
+        step2 = DefaultStep(key="step2", title="test")
+
+        # Add first step
+        added_step1 = self.continuation.add_step(step1)
+        self.assertEqual(added_step1.index, 0)
+        self.assertEqual(len(self.continuation.steps), 1)
+        self.assertEqual(self.continuation.steps[0], added_step1)
+
+        # Add second step
+        added_step2 = self.continuation.add_step(step2)
+        self.assertEqual(added_step2.index, 1)
+        self.assertEqual(len(self.continuation.steps), 2)
+        self.assertEqual(self.continuation.steps[1], added_step2)
+
+        # Verify both steps are in the continuation
+        self.assertEqual(self.continuation.steps, [added_step1, added_step2])
+
     def test_find_or_add(self):
-        step1 = DefaultStep(id="step1", title="test")
+        step1 = DefaultStep(key="step1", title="test")
         self.continuation.steps = [step1]
 
         # Test finding existing step
@@ -240,34 +309,38 @@ class TestAutofixContinuation(unittest.TestCase):
         self.assertEqual(len(self.continuation.steps), 1)
 
         # Test adding new step
-        step2 = DefaultStep(id="step2", title="test")
+        step2 = DefaultStep(key="step2", title="test")
         added_step = self.continuation.find_or_add(step2)
-        self.assertEqual(added_step.id, "step2")
+        self.assertEqual(added_step.key, "step2")
         self.assertEqual(added_step.index, 1)
         self.assertEqual(len(self.continuation.steps), 2)
 
     def test_make_step_latest(self):
-        step1 = DefaultStep(id="step1", title="test")
-        step2 = DefaultStep(id="step2", title="test")
-        step3 = DefaultStep(id="step3", title="test")
+        step1 = DefaultStep(key="step1", title="test")
+        step2 = DefaultStep(key="step2", title="test")
+        step3 = DefaultStep(key="step3", title="test")
         self.continuation.steps = [step1, step2, step3]
 
         self.continuation.make_step_latest(step2)
         self.assertEqual(self.continuation.steps, [step1, step3, step2])
 
-    def test_mark_all_steps_completed(self):
-        step1 = DefaultStep(id="step1", status=AutofixStatus.PROCESSING, title="test")
-        step2 = DefaultStep(id="step2", status=AutofixStatus.PENDING, title="test")
-        self.continuation.steps = [step1, step2]
+    def test_mark_all_running_steps_completed(self):
+        step1 = DefaultStep(key="step1", status=AutofixStatus.PROCESSING, title="test")
+        step2 = DefaultStep(key="step2", status=AutofixStatus.PENDING, title="test")
+        step3 = DefaultStep(key="step3", status=AutofixStatus.COMPLETED, title="test")
+        step4 = DefaultStep(key="step4", status=AutofixStatus.ERROR, title="test")
+        self.continuation.steps = [step1, step2, step3, step4]
 
-        self.continuation.mark_all_steps_completed()
+        self.continuation.mark_all_running_steps_completed()
         self.assertEqual(step1.status, AutofixStatus.COMPLETED)
         self.assertEqual(step2.status, AutofixStatus.COMPLETED)
+        self.assertEqual(step3.status, AutofixStatus.COMPLETED)
+        self.assertEqual(step4.status, AutofixStatus.ERROR)
 
     def test_mark_running_steps_errored(self):
-        step1 = DefaultStep(id="step1", status=AutofixStatus.PROCESSING, title="test")
-        step2 = DefaultStep(id="step2", status=AutofixStatus.PENDING, title="test")
-        substep = DefaultStep(id="substep", status=AutofixStatus.PROCESSING, title="test")
+        step1 = DefaultStep(key="step1", status=AutofixStatus.PROCESSING, title="test")
+        step2 = DefaultStep(key="step2", status=AutofixStatus.PENDING, title="test")
+        substep = DefaultStep(key="substep", status=AutofixStatus.PROCESSING, title="test")
         step1.progress = [substep]
         self.continuation.steps = [step1, step2]
 
@@ -277,14 +350,14 @@ class TestAutofixContinuation(unittest.TestCase):
         self.assertEqual(substep.status, AutofixStatus.ERROR)
 
     def test_set_last_step_completed_message(self):
-        step = DefaultStep(id="step1", title="test")
+        step = DefaultStep(key="step1", title="test")
         self.continuation.steps = [step]
 
         self.continuation.set_last_step_completed_message("Test message")
         self.assertEqual(step.completedMessage, "Test message")
 
     def test_get_selected_root_cause_and_fix(self):
-        root_cause_step = RootCauseStep(id="root_cause_analysis", title="test")
+        root_cause_step = RootCauseStep(key="root_cause_analysis", title="test")
         cause = RootCauseAnalysisItem(
             id=1, title="test", description="test", likelihood=0.5, actionability=0.5
         )
@@ -310,18 +383,18 @@ class TestAutofixContinuation(unittest.TestCase):
             self.assertEqual(self.continuation.updated_at, mock_now)
 
     def test_delete_steps(self):
-        step1 = DefaultStep(id="step1", title="test")
-        step2 = DefaultStep(id="step2", title="test")
-        step3 = DefaultStep(id="step3", title="test")
+        step1 = DefaultStep(key="step1", title="test")
+        step2 = DefaultStep(key="step2", title="test")
+        step3 = DefaultStep(key="step3", title="test")
         self.continuation.steps = [step1, step2, step3]
 
         self.continuation.delete_steps(step2)
         self.assertEqual(self.continuation.steps, [step1, step2])
 
     def test_delete_steps_including_self(self):
-        step1 = DefaultStep(id="step1", title="test")
-        step2 = DefaultStep(id="step2", title="test")
-        step3 = DefaultStep(id="step3", title="test")
+        step1 = DefaultStep(key="step1", title="test")
+        step2 = DefaultStep(key="step2", title="test")
+        step3 = DefaultStep(key="step3", title="test")
         self.continuation.steps = [step1, step2, step3]
 
         self.continuation.delete_steps(step2, include_current=True)

--- a/tests/automation/autofix/test_runs.py
+++ b/tests/automation/autofix/test_runs.py
@@ -19,14 +19,12 @@ def mock_request():
         repos=[],
         issue=IssueDetails(id=123, title="Test Issue", short_id="TEST-123", events=[]),
         invoking_user=None,
-        base_commit_sha=None,
         instruction=None,
         options=AutofixRequestOptions(),
     )
 
 
 class TestRuns:
-
     @pytest.fixture(autouse=True)
     def setup_mocks(self):
         self.mock_event_manager = patch("seer.automation.autofix.runs.AutofixEventManager").start()
@@ -53,7 +51,7 @@ class TestRuns:
         mock_state.get.assert_called_once()
 
         self.mock_event_manager.assert_called_once_with(mock_state)
-        self.mock_event_manager.return_value.send_root_cause_analysis_start.assert_called_once()
+        self.mock_event_manager.return_value.send_root_cause_analysis_pending.assert_called_once()
 
         assert result == mock_state
 


### PR DESCRIPTION
Adds a high-level step retry logic to retry a whole step when something unexpected that we didn't account for goes wrong. This should reduce the number of red error skulls seen by users.

It should log **Something went wrong, let me try this again...** in the logs when it retries:
![Screenshot 2024-08-07 at 3 46 03 PM](https://github.com/user-attachments/assets/c7ceea55-0af9-4c1d-8a18-67629fdc2665)
