### PR TITLE
feat(autofix): Allow repeating steps + backwards compatibility

### DIFF
--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -76,6 +76,9 @@ class AutofixContext(PipelineContext):
         self.event_manager = event_manager
         self.state = state
 
+        # TODO: Remove this when we no longer need the backwards compatibility.
+        self.event_manager.migrate_step_keys()
+
         logger.info(f"AutofixContext initialized with run_id {self.run_id}")
 
     @classmethod

--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -1,6 +1,5 @@
 import dataclasses
 import logging
-from typing import Literal
 
 from seer.automation.autofix.components.coding.models import CodingOutput
 from seer.automation.autofix.components.root_cause.models import RootCauseAnalysisOutput
@@ -29,42 +28,55 @@ class AutofixEventManager:
     @property
     def root_cause_analysis_processing_step(self) -> DefaultStep:
         return DefaultStep(
-            id="root_cause_analysis_processing",
-            title="Analyze Issue",
+            key="root_cause_analysis_processing",
+            title="Analyzing the Issue",
         )
 
     @property
     def root_cause_analysis_step(self) -> RootCauseStep:
         return RootCauseStep(
-            id="root_cause_analysis",
+            key="root_cause_analysis",
             title="Root Cause Analysis",
         )
 
     @property
     def plan_step(self) -> DefaultStep:
         return DefaultStep(
-            id="plan",
+            key="plan",
             title="Create Fix",
         )
 
     @property
     def changes_step(self) -> ChangesStep:
         return ChangesStep(
-            id="changes",
+            key="changes",
             title="Changes",
             changes=[],
         )
 
+    def migrate_step_keys(self):
+        # TODO: Remove this we no longer need the backwards compatibility.
+        with self.state.update() as cur:
+            for step in cur.steps:
+                step.ensure_uuid_id()
+
     def send_root_cause_analysis_pending(self):
         with self.state.update() as cur:
-            root_cause_step = cur.find_or_add(self.root_cause_analysis_processing_step)
-            root_cause_step.status = AutofixStatus.PENDING
-
-            cur.status = AutofixStatus.PROCESSING
+            step = cur.add_step(self.root_cause_analysis_processing_step)
+            step.status = (
+                AutofixStatus.PROCESSING
+            )  # We want it to be spinning on the UI, not a grey pending, so we just make it processing.
 
     def send_root_cause_analysis_start(self):
         with self.state.update() as cur:
             root_cause_step = cur.find_or_add(self.root_cause_analysis_processing_step)
+
+            if (
+                root_cause_step.status != AutofixStatus.PROCESSING
+                and root_cause_step.status != AutofixStatus.PENDING
+            ):
+                root_cause_step = cur.add_step(self.root_cause_analysis_processing_step)
+
             root_cause_step.status = AutofixStatus.PROCESSING
             cur.make_step_latest(root_cause_step)
 
@@ -101,21 +113,14 @@ class AutofixEventManager:
         with self.state.update() as cur:
             root_cause_step = cur.find_or_add(self.root_cause_analysis_step)
             root_cause_step.selection = root_cause_selection
-            cur.delete_steps_after(root_cause_step)
+            cur.delete_steps(root_cause_step, include_current=False)
             cur.clear_file_changes()
-
-            cur.status = AutofixStatus.PROCESSING
-
-    def send_planning_pending(self):
-        with self.state.update() as cur:
-            root_cause_step = cur.find_or_add(self.plan_step)
-            root_cause_step.status = AutofixStatus.PENDING
 
             cur.status = AutofixStatus.PROCESSING
 
     def send_coding_start(self):
         with self.state.update() as cur:
-            plan_step = cur.find_or_add(self.plan_step)
+            plan_step = cur.add_step(self.plan_step)
             plan_step.status = AutofixStatus.PROCESSING
 
             cur.status = AutofixStatus.PROCESSING
@@ -125,61 +130,16 @@ class AutofixEventManager:
             plan_step = cur.find_or_add(self.plan_step)
             plan_step.status = AutofixStatus.PROCESSING if result else AutofixStatus.ERROR
 
-            if result:
-                for i, child_step in enumerate(result.tasks):
-                    step = plan_step.find_or_add_child(
-                        DefaultStep(
-                            id=str(i),
-                            title=child_step.commit_message,
-                        )
-                    )
-                    step.status = AutofixStatus.PENDING
-
             cur.status = AutofixStatus.PROCESSING if result else AutofixStatus.ERROR
 
-    def send_execution_step_start(self, execution_id: int):
+    def send_coding_complete(self, codebase_changes: list[CodebaseChange]):
         with self.state.update() as cur:
-            plan_step = cur.find_or_add(self.plan_step)
-            execution_step = plan_step.find_child(id=str(execution_id))
-            if execution_step:
-                execution_step.status = AutofixStatus.PROCESSING
-            cur.status = AutofixStatus.PROCESSING
-
-    def send_execution_step_result(
-        self, execution_id: int, status: Literal[AutofixStatus.COMPLETED, AutofixStatus.ERROR]
-    ):
-        with self.state.update() as cur:
-            plan_step = cur.find_or_add(self.plan_step)
-            execution_step = plan_step.find_child(id=str(execution_id))
-            if execution_step:
-                execution_step.status = status
-
-            cur.status = (
-                AutofixStatus.PROCESSING
-                if status == AutofixStatus.COMPLETED
-                else AutofixStatus.ERROR
-            )
-
-    def send_execution_complete(self, codebase_changes: list[CodebaseChange]):
-        with self.state.update() as cur:
-            cur.mark_all_steps_completed()
+            cur.mark_all_running_steps_completed()
 
             changes_step = cur.find_or_add(self.changes_step)
             changes_step.status = AutofixStatus.COMPLETED
             changes_step.changes = codebase_changes
 
-            cur.status = AutofixStatus.COMPLETED
-
-    def send_pr_creation_start(self):
-        with self.state.update() as cur:
-            changes_step = cur.find_or_add(self.changes_step)
-            changes_step.status = AutofixStatus.PROCESSING
-            cur.status = AutofixStatus.PROCESSING
-
-    def send_pr_creation_complete(self):
-        with self.state.update() as cur:
-            changes_step = cur.find_or_add(self.changes_step)
-            changes_step.status = AutofixStatus.COMPLETED
             cur.status = AutofixStatus.COMPLETED
 
     def add_log(self, message: str):
@@ -218,9 +178,16 @@ class AutofixEventManager:
                     )
                 )
 
-    def on_error(self, error_msg: str = "Something went wrong"):
+    def on_error(
+        self, error_msg: str = "Something went wrong", should_completely_error: bool = True
+    ):
         with self.state.update() as cur:
             cur.mark_running_steps_errored()
             cur.set_last_step_completed_message(error_msg)
 
-            cur.status = AutofixStatus.ERROR
+            if should_completely_error:
+                cur.status = AutofixStatus.ERROR
+
+    def clear_file_changes(self):
+        with self.state.update() as cur:
+            cur.clear_file_changes()

--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -60,7 +60,7 @@ class AutofixEventManager:
             for step in cur.steps:
                 step.ensure_uuid_id()
 
-    def send_root_cause_analysis_pending(self):
+    def send_root_cause_analysis_will_start(self):
         with self.state.update() as cur:
             step = cur.add_step(self.root_cause_analysis_processing_step)
             step.status = (
@@ -71,10 +71,7 @@ class AutofixEventManager:
         with self.state.update() as cur:
             root_cause_step = cur.find_or_add(self.root_cause_analysis_processing_step)
 
-            if (
-                root_cause_step.status != AutofixStatus.PROCESSING
-                and root_cause_step.status != AutofixStatus.PENDING
-            ):
+            if root_cause_step.status != AutofixStatus.PROCESSING:
                 root_cause_step = cur.add_step(self.root_cause_analysis_processing_step)
 
             root_cause_step.status = AutofixStatus.PROCESSING
@@ -113,7 +110,7 @@ class AutofixEventManager:
         with self.state.update() as cur:
             root_cause_step = cur.find_or_add(self.root_cause_analysis_step)
             root_cause_step.selection = root_cause_selection
-            cur.delete_steps(root_cause_step, include_current=False)
+            cur.delete_steps_after(root_cause_step, include_current=False)
             cur.clear_file_changes()
 
             cur.status = AutofixStatus.PROCESSING
@@ -134,7 +131,7 @@ class AutofixEventManager:
 
     def send_coding_complete(self, codebase_changes: list[CodebaseChange]):
         with self.state.update() as cur:
-            cur.mark_all_running_steps_completed()
+            cur.mark_running_steps_completed()
 
             changes_step = cur.find_or_add(self.changes_step)
             changes_step.status = AutofixStatus.COMPLETED

--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -295,11 +295,9 @@ class AutofixContinuation(AutofixGroupState):
 
     def find_step(self, *, id: str | None = None, key: str | None = None) -> Step | None:
         for step in self.steps[::-1]:
-            if id and step.id == id:
+            if step.id == id:
                 return step
-            if key and step.key == key:
-                return step
-            if id and key and step.id == id and step.key == key:
+            if key is not None and step.key == key:
                 return step
         return None
 

--- a/src/seer/automation/autofix/runs.py
+++ b/src/seer/automation/autofix/runs.py
@@ -14,6 +14,6 @@ def create_initial_autofix_run(request: AutofixRequest):
     cur = state.get()
 
     event_manager = AutofixEventManager(state)
-    event_manager.send_root_cause_analysis_start()
+    event_manager.send_root_cause_analysis_pending()
 
     return state

--- a/src/seer/automation/autofix/runs.py
+++ b/src/seer/automation/autofix/runs.py
@@ -14,6 +14,6 @@ def create_initial_autofix_run(request: AutofixRequest):
     cur = state.get()
 
     event_manager = AutofixEventManager(state)
-    event_manager.send_root_cause_analysis_pending()
+    event_manager.send_root_cause_analysis_will_start()
 
     return state

--- a/src/seer/automation/autofix/steps/change_describer_step.py
+++ b/src/seer/automation/autofix/steps/change_describer_step.py
@@ -89,4 +89,4 @@ class AutofixChangeDescriberStep(AutofixPipelineStep):
 
                     codebase_changes.append(change)
 
-        self.context.event_manager.send_execution_complete(codebase_changes)
+        self.context.event_manager.send_coding_complete(codebase_changes)

--- a/src/seer/automation/autofix/steps/coding_step.py
+++ b/src/seer/automation/autofix/steps/coding_step.py
@@ -34,7 +34,7 @@ def autofix_coding_task(*args, request: dict[str, Any]):
 
 class AutofixCodingStep(PipelineChain, AutofixPipelineStep):
     """
-    This class represents the execution pipeline in the autofix system. It is responsible for
+    This class represents the coding step in the autofix pipeline. It is responsible for
     executing the fixes suggested by the coding component based on the root cause analysis.
     """
 
@@ -51,6 +51,8 @@ class AutofixCodingStep(PipelineChain, AutofixPipelineStep):
     @observe(name="Autofix - Plan+Code Step")
     @ai_track(description="Autofix - Plan+Code Step")
     def _invoke(self, **kwargs):
+        self.context.event_manager.clear_file_changes()
+
         self.logger.info("Executing Autofix - Plan+Code Step")
 
         self.context.event_manager.send_coding_start()

--- a/src/seer/automation/autofix/steps/root_cause_step.py
+++ b/src/seer/automation/autofix/steps/root_cause_step.py
@@ -58,4 +58,5 @@ class RootCauseStep(AutofixPipelineStep):
                 instruction=state.request.instruction,
             )
         )
+
         self.context.event_manager.send_root_cause_analysis_result(root_cause_output)

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -168,13 +168,9 @@ def run_autofix_create_pr(request: AutofixUpdateRequest):
         state=state, sentry_client=get_sentry_client(), event_manager=event_manager
     )
 
-    event_manager.send_pr_creation_start()
-
     context.commit_changes(
         repo_external_id=request.payload.repo_external_id, repo_id=request.payload.repo_id
     )
-
-    event_manager.send_pr_creation_complete()
 
 
 def run_autofix_evaluation(request: AutofixEvaluationRequest):

--- a/tests/automation/autofix/test_autofix_context.py
+++ b/tests/automation/autofix/test_autofix_context.py
@@ -39,6 +39,27 @@ class TestAutofixContext(unittest.TestCase):
             MagicMock(),
         )
 
+    @patch("seer.automation.autofix.autofix_context.AutofixEventManager")
+    def test_migrate_step_keys_called_in_init(self, mock_AutofixEventManager):
+        mock_event_manager = MagicMock()
+        mock_AutofixEventManager.return_value = mock_event_manager
+
+        error_event = next(generate(SentryEventData))
+        state = LocalMemoryState(
+            AutofixContinuation(
+                request=AutofixRequest(
+                    organization_id=1,
+                    project_id=1,
+                    repos=[],
+                    issue=IssueDetails(id=0, title="", events=[error_event]),
+                )
+            )
+        )
+
+        AutofixContext(state, MagicMock(), mock_event_manager)
+
+        mock_event_manager.migrate_step_keys.assert_called_once()
+
 
 class TestAutofixContextPrCommit(unittest.TestCase):
     def setUp(self):

--- a/tests/automation/autofix/test_autofix_context.py
+++ b/tests/automation/autofix/test_autofix_context.py
@@ -108,7 +108,7 @@ class TestAutofixContextPrCommit(unittest.TestCase):
                     id="changes",
                     title="changes_title",
                     type=StepType.CHANGES,
-                    status=AutofixStatus.PENDING,
+                    status=AutofixStatus.PROCESSING,
                     index=0,
                     changes=[
                         CodebaseChange(

--- a/tests/automation/autofix/test_autofix_event_manager.py
+++ b/tests/automation/autofix/test_autofix_event_manager.py
@@ -1,0 +1,49 @@
+import pytest
+from johen import generate
+
+from seer.automation.autofix.event_manager import AutofixEventManager
+from seer.automation.autofix.models import (
+    AutofixContinuation,
+    AutofixRequest,
+    AutofixStatus,
+    ProgressType,
+    RootCauseStep,
+)
+from seer.automation.state import LocalMemoryState
+
+
+class TestAutofixEventManager:
+    @pytest.fixture
+    def state(self):
+        return LocalMemoryState(AutofixContinuation(request=next(generate(AutofixRequest))))
+
+    @pytest.fixture
+    def event_manager(self, state):
+        return AutofixEventManager(state)
+
+    def test_add_log_to_current_step(self, event_manager, state):
+        state.get().steps = [
+            RootCauseStep(id="1", title="Test Step", status=AutofixStatus.PROCESSING, progress=[])
+        ]
+
+        event_manager.add_log("Test log message")
+
+        assert len(state.get().steps[0].progress) == 1
+        assert state.get().steps[0].progress[0].message == "Test log message"
+        assert state.get().steps[0].progress[0].type == ProgressType.INFO
+
+    def test_add_log_no_processing_step(self, event_manager, state):
+        state.get().steps = [
+            RootCauseStep(id="1", title="Test Step", status=AutofixStatus.COMPLETED, progress=[])
+        ]
+
+        event_manager.add_log("Test log message")
+
+        assert len(state.get().steps[0].progress) == 0
+
+    def test_add_log_empty_steps(self, event_manager, state):
+        state.get().steps = []
+
+        event_manager.add_log("Test log message")
+
+        assert state.get().steps == []

--- a/tests/automation/autofix/test_autofix_event_manager.py
+++ b/tests/automation/autofix/test_autofix_event_manager.py
@@ -21,6 +21,39 @@ class TestAutofixEventManager:
     def event_manager(self, state):
         return AutofixEventManager(state)
 
+    def test_on_error_marks_running_steps_errored(self, event_manager, state):
+        state.get().steps = [
+            RootCauseStep(id="1", title="Step 1", status=AutofixStatus.PROCESSING),
+            RootCauseStep(id="2", title="Step 2", status=AutofixStatus.COMPLETED),
+            RootCauseStep(id="3", title="Step 3", status=AutofixStatus.PROCESSING),
+        ]
+
+        event_manager.on_error("Test error message")
+
+        assert state.get().steps[0].status == AutofixStatus.ERROR
+        assert state.get().steps[1].status == AutofixStatus.COMPLETED
+        assert state.get().steps[2].status == AutofixStatus.ERROR
+
+    def test_on_error_sets_last_step_completed_message(self, event_manager, state):
+        state.get().steps = [
+            RootCauseStep(id="1", title="Test Step", status=AutofixStatus.PROCESSING),
+        ]
+
+        event_manager.on_error("Test error message")
+
+        assert state.get().steps[-1].completedMessage == "Test error message"
+
+    def test_on_error_sets_state_status_to_error(self, event_manager, state):
+        event_manager.on_error("Test error message")
+
+        assert state.get().status == AutofixStatus.ERROR
+
+    def test_on_error_does_not_set_state_status_when_flag_is_false(self, event_manager, state):
+        initial_status = state.get().status
+        event_manager.on_error("Test error message", should_completely_error=False)
+
+        assert state.get().status == initial_status
+
     def test_add_log_to_current_step(self, event_manager, state):
         state.get().steps = [
             RootCauseStep(id="1", title="Test Step", status=AutofixStatus.PROCESSING, progress=[])

--- a/tests/automation/autofix/test_autofix_tasks.py
+++ b/tests/automation/autofix/test_autofix_tasks.py
@@ -109,7 +109,7 @@ class TestRunAutofixRootCause:
         # Setup
         mock_request = MagicMock(spec=AutofixRequest)
         mock_state = MagicMock()
-        mock_state.get.return_value = MagicMock(run_id=1, status=AutofixStatus.PENDING)
+        mock_state.get.return_value = MagicMock(run_id=1, status=AutofixStatus.PROCESSING)
         mock_create_initial_autofix_run.return_value = mock_state
 
         mock_signature = MagicMock()
@@ -137,7 +137,7 @@ class TestRunAutofixExecution:
         mock_request.payload = MagicMock(spec=AutofixRootCauseUpdatePayload)
 
         mock_state = MagicMock()
-        mock_state.get.return_value = MagicMock(run_id=1, status=AutofixStatus.PENDING)
+        mock_state.get.return_value = MagicMock(run_id=1, status=AutofixStatus.PROCESSING)
         mock_continuation_state.from_id.return_value = mock_state
 
         mock_signature = MagicMock()

--- a/tests/automation/autofix/test_autofix_tasks.py
+++ b/tests/automation/autofix/test_autofix_tasks.py
@@ -180,6 +180,4 @@ class TestRunAutofixCreatePr:
 
         # Assert
         mock_continuation_state.from_id.assert_called_once_with(1, model=AutofixContinuation)
-        mock_event_manager.return_value.send_pr_creation_start.assert_called_once()
         mock_context.commit_changes.assert_called_once_with(repo_external_id="repo1", repo_id=1)
-        mock_event_manager.return_value.send_pr_creation_complete.assert_called_once()

--- a/tests/automation/autofix/test_models.py
+++ b/tests/automation/autofix/test_models.py
@@ -360,16 +360,14 @@ class TestAutofixContinuation(unittest.TestCase):
 
     def test_mark_all_running_steps_completed(self):
         step1 = DefaultStep(key="step1", status=AutofixStatus.PROCESSING, title="test")
-        step2 = DefaultStep(key="step2", status=AutofixStatus.PROCESSING, title="test")
-        step3 = DefaultStep(key="step3", status=AutofixStatus.COMPLETED, title="test")
-        step4 = DefaultStep(key="step4", status=AutofixStatus.ERROR, title="test")
-        self.continuation.steps = [step1, step2, step3, step4]
+        step2 = DefaultStep(key="step2", status=AutofixStatus.COMPLETED, title="test")
+        step3 = DefaultStep(key="step3", status=AutofixStatus.ERROR, title="test")
+        self.continuation.steps = [step1, step2, step3]
 
         self.continuation.mark_running_steps_completed()
         self.assertEqual(step1.status, AutofixStatus.COMPLETED)
         self.assertEqual(step2.status, AutofixStatus.COMPLETED)
-        self.assertEqual(step3.status, AutofixStatus.COMPLETED)
-        self.assertEqual(step4.status, AutofixStatus.ERROR)
+        self.assertEqual(step3.status, AutofixStatus.ERROR)
 
     def test_mark_running_steps_errored(self):
         step1 = DefaultStep(key="step1", status=AutofixStatus.PROCESSING, title="test")
@@ -380,7 +378,7 @@ class TestAutofixContinuation(unittest.TestCase):
 
         self.continuation.mark_running_steps_errored()
         self.assertEqual(step1.status, AutofixStatus.ERROR)
-        self.assertEqual(step2.status, AutofixStatus.PROCESSING)
+        self.assertEqual(step2.status, AutofixStatus.ERROR)
         self.assertEqual(substep.status, AutofixStatus.ERROR)
 
     def test_set_last_step_completed_message(self):

--- a/tests/automation/autofix/test_models.py
+++ b/tests/automation/autofix/test_models.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import unittest
+import uuid
 from unittest.mock import Mock, patch
 
 from johen.pytest import parametrize
@@ -11,6 +12,7 @@ from seer.automation.autofix.models import (
     AutofixContinuation,
     AutofixRequest,
     AutofixStatus,
+    BaseStep,
     CodeContextRootCauseSelection,
     DefaultStep,
     IssueDetails,
@@ -216,12 +218,94 @@ class TestAutofixRequest(unittest.TestCase):
         self.assertEqual(len(autofix_request.repos), 2)
 
 
+class TestAutofixStep(unittest.TestCase):
+    def test_ensure_uuid_id(self):
+        # Test with a non-UUID id
+        step = DefaultStep(id="non-uuid-id", key="original-key", title="Test Step")
+        step.ensure_uuid_id()
+        self.assertTrue(BaseStep.is_valid_uuid(step.id))
+        self.assertEqual(step.key, "non-uuid-id")
+
+        # Test with a valid UUID id
+        valid_uuid = str(uuid.uuid4())
+        step = DefaultStep(id=valid_uuid, key="original-key", title="Test Step")
+        original_id = step.id
+        step.ensure_uuid_id()
+        self.assertEqual(step.id, original_id)
+        self.assertEqual(step.key, "original-key")
+
+    def test_is_valid_uuid(self):
+        # Test with a valid UUID
+        valid_uuid = str(uuid.uuid4())
+        self.assertTrue(BaseStep.is_valid_uuid(valid_uuid))
+
+        # Test with an invalid UUID
+        invalid_uuid = "not-a-uuid"
+        self.assertFalse(BaseStep.is_valid_uuid(invalid_uuid))
+
+        # Test with an empty string
+        self.assertFalse(BaseStep.is_valid_uuid(""))
+
+        # Test with a None value
+        self.assertFalse(BaseStep.is_valid_uuid(None))  # type: ignore
+
+
 class TestAutofixContinuation(unittest.TestCase):
     def setUp(self):
         self.request = Mock(spec=AutofixRequest)
         self.continuation = AutofixContinuation(request=self.request)
 
-    def test_find_step(self):
+    def test_auto_generated_step_ids(self):
+        # Create steps without specifying IDs
+        step1 = DefaultStep(key="step1", title="Test Step 1")
+        step2 = DefaultStep(key="step2", title="Test Step 2")
+
+        # Add steps to the continuation
+        added_step1 = self.continuation.add_step(step1)
+        added_step2 = self.continuation.add_step(step2)
+
+        # Check that IDs were auto-generated
+        self.assertIsNotNone(added_step1.id)
+        self.assertIsNotNone(added_step2.id)
+
+        # Check that the IDs are strings (UUIDs)
+        self.assertIsInstance(added_step1.id, str)
+        self.assertIsInstance(added_step2.id, str)
+
+        # Check that the IDs are unique
+        self.assertNotEqual(added_step1.id, added_step2.id)
+
+        # Verify that we can find steps by their auto-generated IDs
+        self.assertEqual(self.continuation.find_step(id=added_step1.id), added_step1)
+        self.assertEqual(self.continuation.find_step(id=added_step2.id), added_step2)
+
+    def test_model_copy_with_new_id(self):
+        original_step = DefaultStep(key="original", title="Original Step")
+        self.continuation.add_step(original_step)
+
+        copied_step = original_step.model_copy_with_new_id()
+
+        # Check that a new ID was generated
+        self.assertNotEqual(original_step.id, copied_step.id)
+
+        # Check that other attributes remain the same
+        self.assertEqual(original_step.key, copied_step.key)
+        self.assertEqual(original_step.title, copied_step.title)
+
+        # Add the copied step and verify it can be found by its new ID
+        added_copied_step = self.continuation.add_step(copied_step)
+        self.assertEqual(self.continuation.find_step(id=copied_step.id), added_copied_step)
+
+    def test_find_step_by_key(self):
+        step1 = DefaultStep(key="step1", title="test")
+        step2 = DefaultStep(key="step2", title="test")
+        self.continuation.steps = [step1, step2]
+
+        self.assertEqual(self.continuation.find_step(key="step1"), step1)
+        self.assertEqual(self.continuation.find_step(key="step2"), step2)
+        self.assertIsNone(self.continuation.find_step(key="step3"))
+
+    def test_find_step_by_id(self):
         step1 = DefaultStep(id="step1", title="test")
         step2 = DefaultStep(id="step2", title="test")
         self.continuation.steps = [step1, step2]
@@ -230,8 +314,27 @@ class TestAutofixContinuation(unittest.TestCase):
         self.assertEqual(self.continuation.find_step(id="step2"), step2)
         self.assertIsNone(self.continuation.find_step(id="step3"))
 
+    def test_add_step(self):
+        step1 = DefaultStep(key="step1", title="test")
+        step2 = DefaultStep(key="step2", title="test")
+
+        # Add first step
+        added_step1 = self.continuation.add_step(step1)
+        self.assertEqual(added_step1.index, 0)
+        self.assertEqual(len(self.continuation.steps), 1)
+        self.assertEqual(self.continuation.steps[0], added_step1)
+
+        # Add second step
+        added_step2 = self.continuation.add_step(step2)
+        self.assertEqual(added_step2.index, 1)
+        self.assertEqual(len(self.continuation.steps), 2)
+        self.assertEqual(self.continuation.steps[1], added_step2)
+
+        # Verify both steps are in the continuation
+        self.assertEqual(self.continuation.steps, [added_step1, added_step2])
+
     def test_find_or_add(self):
-        step1 = DefaultStep(id="step1", title="test")
+        step1 = DefaultStep(key="step1", title="test")
         self.continuation.steps = [step1]
 
         # Test finding existing step
@@ -240,34 +343,38 @@ class TestAutofixContinuation(unittest.TestCase):
         self.assertEqual(len(self.continuation.steps), 1)
 
         # Test adding new step
-        step2 = DefaultStep(id="step2", title="test")
+        step2 = DefaultStep(key="step2", title="test")
         added_step = self.continuation.find_or_add(step2)
-        self.assertEqual(added_step.id, "step2")
+        self.assertEqual(added_step.key, "step2")
         self.assertEqual(added_step.index, 1)
         self.assertEqual(len(self.continuation.steps), 2)
 
     def test_make_step_latest(self):
-        step1 = DefaultStep(id="step1", title="test")
-        step2 = DefaultStep(id="step2", title="test")
-        step3 = DefaultStep(id="step3", title="test")
+        step1 = DefaultStep(key="step1", title="test")
+        step2 = DefaultStep(key="step2", title="test")
+        step3 = DefaultStep(key="step3", title="test")
         self.continuation.steps = [step1, step2, step3]
 
         self.continuation.make_step_latest(step2)
         self.assertEqual(self.continuation.steps, [step1, step3, step2])
 
-    def test_mark_all_steps_completed(self):
-        step1 = DefaultStep(id="step1", status=AutofixStatus.PROCESSING, title="test")
-        step2 = DefaultStep(id="step2", status=AutofixStatus.PENDING, title="test")
-        self.continuation.steps = [step1, step2]
+    def test_mark_all_running_steps_completed(self):
+        step1 = DefaultStep(key="step1", status=AutofixStatus.PROCESSING, title="test")
+        step2 = DefaultStep(key="step2", status=AutofixStatus.PENDING, title="test")
+        step3 = DefaultStep(key="step3", status=AutofixStatus.COMPLETED, title="test")
+        step4 = DefaultStep(key="step4", status=AutofixStatus.ERROR, title="test")
+        self.continuation.steps = [step1, step2, step3, step4]
 
-        self.continuation.mark_all_steps_completed()
+        self.continuation.mark_all_running_steps_completed()
         self.assertEqual(step1.status, AutofixStatus.COMPLETED)
         self.assertEqual(step2.status, AutofixStatus.COMPLETED)
+        self.assertEqual(step3.status, AutofixStatus.COMPLETED)
+        self.assertEqual(step4.status, AutofixStatus.ERROR)
 
     def test_mark_running_steps_errored(self):
-        step1 = DefaultStep(id="step1", status=AutofixStatus.PROCESSING, title="test")
-        step2 = DefaultStep(id="step2", status=AutofixStatus.PENDING, title="test")
-        substep = DefaultStep(id="substep", status=AutofixStatus.PROCESSING, title="test")
+        step1 = DefaultStep(key="step1", status=AutofixStatus.PROCESSING, title="test")
+        step2 = DefaultStep(key="step2", status=AutofixStatus.PENDING, title="test")
+        substep = DefaultStep(key="substep", status=AutofixStatus.PROCESSING, title="test")
         step1.progress = [substep]
         self.continuation.steps = [step1, step2]
 
@@ -277,14 +384,14 @@ class TestAutofixContinuation(unittest.TestCase):
         self.assertEqual(substep.status, AutofixStatus.ERROR)
 
     def test_set_last_step_completed_message(self):
-        step = DefaultStep(id="step1", title="test")
+        step = DefaultStep(key="step1", title="test")
         self.continuation.steps = [step]
 
         self.continuation.set_last_step_completed_message("Test message")
         self.assertEqual(step.completedMessage, "Test message")
 
     def test_get_selected_root_cause_and_fix(self):
-        root_cause_step = RootCauseStep(id="root_cause_analysis", title="test")
+        root_cause_step = RootCauseStep(key="root_cause_analysis", title="test")
         cause = RootCauseAnalysisItem(
             id=1, title="test", description="test", likelihood=0.5, actionability=0.5
         )
@@ -309,14 +416,23 @@ class TestAutofixContinuation(unittest.TestCase):
             self.continuation.mark_updated()
             self.assertEqual(self.continuation.updated_at, mock_now)
 
-    def test_delete_steps_after(self):
-        step1 = DefaultStep(id="step1", title="test")
-        step2 = DefaultStep(id="step2", title="test")
-        step3 = DefaultStep(id="step3", title="test")
+    def test_delete_steps(self):
+        step1 = DefaultStep(key="step1", title="test")
+        step2 = DefaultStep(key="step2", title="test")
+        step3 = DefaultStep(key="step3", title="test")
         self.continuation.steps = [step1, step2, step3]
 
-        self.continuation.delete_steps_after(step2)
+        self.continuation.delete_steps(step2)
         self.assertEqual(self.continuation.steps, [step1, step2])
+
+    def test_delete_steps_including_self(self):
+        step1 = DefaultStep(key="step1", title="test")
+        step2 = DefaultStep(key="step2", title="test")
+        step3 = DefaultStep(key="step3", title="test")
+        self.continuation.steps = [step1, step2, step3]
+
+        self.continuation.delete_steps(step2, include_current=True)
+        self.assertEqual(self.continuation.steps, [step1])
 
     def test_clear_file_changes(self):
         codebase1 = Mock()

--- a/tests/automation/autofix/test_models.py
+++ b/tests/automation/autofix/test_models.py
@@ -360,12 +360,12 @@ class TestAutofixContinuation(unittest.TestCase):
 
     def test_mark_all_running_steps_completed(self):
         step1 = DefaultStep(key="step1", status=AutofixStatus.PROCESSING, title="test")
-        step2 = DefaultStep(key="step2", status=AutofixStatus.PENDING, title="test")
+        step2 = DefaultStep(key="step2", status=AutofixStatus.PROCESSING, title="test")
         step3 = DefaultStep(key="step3", status=AutofixStatus.COMPLETED, title="test")
         step4 = DefaultStep(key="step4", status=AutofixStatus.ERROR, title="test")
         self.continuation.steps = [step1, step2, step3, step4]
 
-        self.continuation.mark_all_running_steps_completed()
+        self.continuation.mark_running_steps_completed()
         self.assertEqual(step1.status, AutofixStatus.COMPLETED)
         self.assertEqual(step2.status, AutofixStatus.COMPLETED)
         self.assertEqual(step3.status, AutofixStatus.COMPLETED)
@@ -373,14 +373,14 @@ class TestAutofixContinuation(unittest.TestCase):
 
     def test_mark_running_steps_errored(self):
         step1 = DefaultStep(key="step1", status=AutofixStatus.PROCESSING, title="test")
-        step2 = DefaultStep(key="step2", status=AutofixStatus.PENDING, title="test")
+        step2 = DefaultStep(key="step2", status=AutofixStatus.PROCESSING, title="test")
         substep = DefaultStep(key="substep", status=AutofixStatus.PROCESSING, title="test")
         step1.progress = [substep]
         self.continuation.steps = [step1, step2]
 
         self.continuation.mark_running_steps_errored()
         self.assertEqual(step1.status, AutofixStatus.ERROR)
-        self.assertEqual(step2.status, AutofixStatus.PENDING)
+        self.assertEqual(step2.status, AutofixStatus.PROCESSING)
         self.assertEqual(substep.status, AutofixStatus.ERROR)
 
     def test_set_last_step_completed_message(self):
@@ -416,22 +416,22 @@ class TestAutofixContinuation(unittest.TestCase):
             self.continuation.mark_updated()
             self.assertEqual(self.continuation.updated_at, mock_now)
 
-    def test_delete_steps(self):
+    def test_delete_steps_after(self):
         step1 = DefaultStep(key="step1", title="test")
         step2 = DefaultStep(key="step2", title="test")
         step3 = DefaultStep(key="step3", title="test")
         self.continuation.steps = [step1, step2, step3]
 
-        self.continuation.delete_steps(step2)
+        self.continuation.delete_steps_after(step2)
         self.assertEqual(self.continuation.steps, [step1, step2])
 
-    def test_delete_steps_including_self(self):
+    def test_delete_steps_after_including_self(self):
         step1 = DefaultStep(key="step1", title="test")
         step2 = DefaultStep(key="step2", title="test")
         step3 = DefaultStep(key="step3", title="test")
         self.continuation.steps = [step1, step2, step3]
 
-        self.continuation.delete_steps(step2, include_current=True)
+        self.continuation.delete_steps_after(step2, include_current=True)
         self.assertEqual(self.continuation.steps, [step1])
 
     def test_clear_file_changes(self):
@@ -447,7 +447,7 @@ class TestAutofixContinuation(unittest.TestCase):
         self.continuation.status = AutofixStatus.PROCESSING
         self.assertTrue(self.continuation.is_running)
 
-        self.continuation.status = AutofixStatus.PENDING
+        self.continuation.status = AutofixStatus.PROCESSING
         self.assertTrue(self.continuation.is_running)
 
         self.continuation.status = AutofixStatus.COMPLETED

--- a/tests/automation/autofix/test_runs.py
+++ b/tests/automation/autofix/test_runs.py
@@ -19,14 +19,12 @@ def mock_request():
         repos=[],
         issue=IssueDetails(id=123, title="Test Issue", short_id="TEST-123", events=[]),
         invoking_user=None,
-        base_commit_sha=None,
         instruction=None,
         options=AutofixRequestOptions(),
     )
 
 
 class TestRuns:
-
     @pytest.fixture(autouse=True)
     def setup_mocks(self):
         self.mock_event_manager = patch("seer.automation.autofix.runs.AutofixEventManager").start()
@@ -53,7 +51,7 @@ class TestRuns:
         mock_state.get.assert_called_once()
 
         self.mock_event_manager.assert_called_once_with(mock_state)
-        self.mock_event_manager.return_value.send_root_cause_analysis_start.assert_called_once()
+        self.mock_event_manager.return_value.send_root_cause_analysis_pending.assert_called_once()
 
         assert result == mock_state
 

--- a/tests/automation/autofix/test_runs.py
+++ b/tests/automation/autofix/test_runs.py
@@ -51,7 +51,7 @@ class TestRuns:
         mock_state.get.assert_called_once()
 
         self.mock_event_manager.assert_called_once_with(mock_state)
-        self.mock_event_manager.return_value.send_root_cause_analysis_pending.assert_called_once()
+        self.mock_event_manager.return_value.send_root_cause_analysis_will_start.assert_called_once()
 
         assert result == mock_state
 


### PR DESCRIPTION
Allows multiple of the same step inside an autofix run.
Each step in the autofix step state will now have a unique UUID, with the unique strings now in the `key` field.

Backwards compatible and will migrate existing runs via `event_manager.migrate_step_keys()`

![Screenshot 2024-08-07 at 5 08 02 PM](https://github.com/user-attachments/assets/0c825ba0-89ac-4ece-8c50-d50d6ee04eec)
