### PR TITLE
feat(autofix): Allow steps to retry on an exception

### DIFF
--- a/src/seer/automation/autofix/components/coding/utils.py
+++ b/src/seer/automation/autofix/components/coding/utils.py
@@ -132,6 +132,11 @@ def task_to_file_change(task: PlanTaskPromptXml, file_content: str) -> list[File
     diff_chunks = extract_diff_chunks(task.diff)
 
     for chunk in diff_chunks:
+        if chunk.original_chunk == chunk.new_chunk:
+            continue
+        if chunk.original_chunk.strip() == "":
+            raise ValueError(f"Original chunk is empty for task: {task}")
+
         result = find_original_snippet(
             chunk.original_chunk,
             file_content,

--- a/src/seer/automation/autofix/steps/change_describer_step.py
+++ b/src/seer/automation/autofix/steps/change_describer_step.py
@@ -38,6 +38,8 @@ class AutofixChangeDescriberStep(AutofixPipelineStep):
     name = "AutofixChangeDescriberStep"
     request: AutofixChangeDescriberRequest
 
+    max_retries = 1
+
     @staticmethod
     def _instantiate_request(request: dict[str, Any]) -> AutofixChangeDescriberRequest:
         return AutofixChangeDescriberRequest.model_validate(request)

--- a/src/seer/automation/autofix/steps/coding_step.py
+++ b/src/seer/automation/autofix/steps/coding_step.py
@@ -17,7 +17,7 @@ from seer.automation.autofix.steps.change_describer_step import (
 )
 from seer.automation.autofix.steps.steps import AutofixPipelineStep
 from seer.automation.models import EventDetails
-from seer.automation.pipeline import PipelineChain, PipelineStepTaskRequest
+from seer.automation.pipeline import PipelineStepTaskRequest
 
 
 class AutofixCodingStepRequest(PipelineStepTaskRequest):
@@ -32,13 +32,14 @@ def autofix_coding_task(*args, request: dict[str, Any]):
     AutofixCodingStep(request).invoke()
 
 
-class AutofixCodingStep(PipelineChain, AutofixPipelineStep):
+class AutofixCodingStep(AutofixPipelineStep):
     """
     This class represents the coding step in the autofix pipeline. It is responsible for
     executing the fixes suggested by the coding component based on the root cause analysis.
     """
 
     name = "AutofixCodingStep"
+    max_retries = 2
 
     @staticmethod
     def _instantiate_request(request: dict[str, Any]) -> AutofixCodingStepRequest:

--- a/src/seer/automation/autofix/steps/root_cause_step.py
+++ b/src/seer/automation/autofix/steps/root_cause_step.py
@@ -35,6 +35,8 @@ class RootCauseStep(AutofixPipelineStep):
 
     name = "RootCauseStep"
 
+    max_retries = 2
+
     @staticmethod
     def get_task():
         return root_cause_task

--- a/src/seer/automation/autofix/steps/steps.py
+++ b/src/seer/automation/autofix/steps/steps.py
@@ -22,7 +22,6 @@ from seer.automation.utils import make_done_signal, make_retry_prefix, make_retr
 
 class AutofixPipelineStep(PipelineChain, PipelineStep):
     context: AutofixContext
-    request: PipelineStepTaskRequest
 
     # Default to no retries, child classes will override this.
     max_retries: int = 0
@@ -131,7 +130,7 @@ def autofix_parallelized_conditional_step_task(*args, request: Any):
 
 
 class AutofixParallelizedChainConditionalStep(
-    AutofixPipelineStep, ParallelizedChainConditionalStep
+    ParallelizedChainConditionalStep, AutofixPipelineStep
 ):
     name = "AutofixParallelizedChainConditionalStep"
 
@@ -148,7 +147,7 @@ def autofix_parallelized_chain_step_task(*args, request: Any):
     AutofixParallelizedChainStep(request).invoke()
 
 
-class AutofixParallelizedChainStep(AutofixPipelineStep, ParallelizedChainStep):
+class AutofixParallelizedChainStep(ParallelizedChainStep, AutofixPipelineStep):
     name = "AutofixParallelizedChainStep"
 
     @staticmethod

--- a/src/seer/automation/autofix/utils.py
+++ b/src/seer/automation/autofix/utils.py
@@ -64,6 +64,9 @@ def find_original_snippet(
     tuple[str, int, int] | None: A tuple containing the original snippet from the file, start index, and end index,
                                  or None if the snippet could not be found.
     """
+    if snippet.strip() == "":
+        return None
+
     snippet_lines = [line for line in snippet.split("\n") if line.strip()]
     file_lines = file_contents.split("\n")
 

--- a/src/seer/automation/utils.py
+++ b/src/seer/automation/utils.py
@@ -86,6 +86,14 @@ def make_done_signal(id: str | int) -> str:
     return f"done:{id}"
 
 
+def make_retry_prefix(step_id: int) -> str:
+    return f"retry:{step_id}:"
+
+
+def make_retry_signal(step_id: int, retry_attempt_no: int) -> str:
+    return f"{make_retry_prefix(step_id)}{retry_attempt_no}"
+
+
 def process_repo_provider(provider: str) -> str:
     if provider.startswith("integrations:"):
         return provider.split(":")[1]

--- a/tests/automation/autofix/steps/test_autofix_steps.py
+++ b/tests/automation/autofix/steps/test_autofix_steps.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from seer.automation.autofix.steps.steps import AutofixPipelineStep
 
 
@@ -45,3 +47,97 @@ class TestAutofixPipelineStep:
 
         step.context.state.update.assert_called_once()
         assert mock_state.signals == ["done:1"]
+
+    @pytest.fixture
+    def mock_step(self):
+        class MockStep(AutofixPipelineStep):
+            @classmethod
+            def get_task(cls):
+                return MagicMock()
+
+            def _instantiate_request(self, request):
+                return MagicMock(**request)
+
+            def _instantiate_context(self, request):
+                return MagicMock()
+
+            def _invoke(self, **kwargs):
+                return True
+
+        return MockStep({"run_id": 1, "step_id": 1})
+
+    def test_max_retries_default(self, mock_step):
+        assert mock_step.max_retries == 0
+
+    def test_get_retry_count_no_retries(self, mock_step):
+        mock_step.context.signals = []
+        assert mock_step.get_retry_count() == 0
+
+    def test_get_retry_count_with_retries(self, mock_step):
+        mock_step.context.signals = ["retry:1:1", "retry:1:2"]
+        assert mock_step.get_retry_count() == 2
+
+    def test_get_retry_count_with_mixed_signals(self, mock_step):
+        mock_step.context.signals = ["retry:1:1", "other_signal", "retry:1:2"]
+        assert mock_step.get_retry_count() == 2
+
+    @patch("seer.automation.autofix.steps.steps.make_retry_prefix")
+    def test_get_retry_count_with_custom_prefix(self, mock_make_retry_prefix, mock_step):
+        mock_make_retry_prefix.return_value = "custom_retry:"
+        mock_step.context.signals = ["custom_retry:1", "custom_retry:2", "other_signal"]
+        assert mock_step.get_retry_count() == 2
+
+    @patch("seer.automation.autofix.steps.steps.make_retry_prefix")
+    @patch("seer.automation.autofix.steps.steps.make_retry_signal")
+    def test_handle_exception_no_retry(
+        self, mock_make_retry_signal, mock_make_retry_prefix, mock_step
+    ):
+        mock_make_retry_prefix.return_value = "retry:1:"
+        mock_step.context.signals = []
+        mock_step.context.event_manager.on_error = MagicMock()
+        mock_step.next = MagicMock()
+
+        exception = Exception("Test error")
+        mock_step._handle_exception(exception)
+
+        mock_step.context.event_manager.on_error.assert_called_once_with(str(exception))
+        mock_step.next.assert_not_called()
+
+    @patch("seer.automation.autofix.steps.steps.make_retry_prefix")
+    @patch("seer.automation.autofix.steps.steps.make_retry_signal")
+    def test_handle_exception_with_retry(
+        self, mock_make_retry_signal, mock_make_retry_prefix, mock_step
+    ):
+        mock_make_retry_prefix.return_value = "retry:1:"
+        mock_make_retry_signal.return_value = "retry:1:1"
+        mock_step.max_retries = 1
+        mock_step.context.signals = []
+        mock_step.context.state.update = MagicMock()
+        mock_step.context.state.update.return_value.__enter__.return_value = MagicMock(signals=[])
+        mock_step.next = MagicMock()
+
+        exception = Exception("Test error")
+        mock_step._handle_exception(exception)
+
+        mock_make_retry_signal.assert_called_once_with(1, 1)
+        mock_step.next.assert_called_once()
+        mock_step.context.event_manager.on_error.assert_called_once_with(
+            str(exception), should_completely_error=False
+        )
+
+    @patch("seer.automation.autofix.steps.steps.make_retry_prefix")
+    @patch("seer.automation.autofix.steps.steps.make_retry_signal")
+    def test_handle_exception_max_retries_reached(
+        self, mock_make_retry_signal, mock_make_retry_prefix, mock_step
+    ):
+        mock_make_retry_prefix.return_value = "retry:1:"
+        mock_step.max_retries = 1
+        mock_step.context.signals = ["retry:1:1"]
+        mock_step.context.event_manager.on_error = MagicMock()
+        mock_step.next = MagicMock()
+
+        exception = Exception("Test error")
+        mock_step._handle_exception(exception)
+
+        mock_step.context.event_manager.on_error.assert_called_once_with(str(exception))
+        mock_step.next.assert_not_called()

--- a/tests/automation/autofix/test_autofix_utils.py
+++ b/tests/automation/autofix/test_autofix_utils.py
@@ -82,3 +82,13 @@ class TestFindOriginalSnippet(unittest.TestCase):
         self.assertEqual(
             find_original_snippet(snippet, file_contents, threshold=0.75), expected_result
         )
+
+    def test_find_original_snippet_empty_snippet(self):
+        snippet = ""
+        file_contents = textwrap.dedent(
+            """\
+            def example_function():
+                pass
+            """
+        )
+        self.assertIsNone(find_original_snippet(snippet, file_contents))


### PR DESCRIPTION
Allow steps to retry on an exception, this is like a high-level catch all for issues that we don't specifically handle.

Current retry settings:
1. Root cause -> maximum 2 retires or 3 runs max
2. Plan+Code-> maximum 2 retries or 3 runs max
3. Change Describer -> maximum 1 retries or 2 runs max

![Screenshot 2024-08-07 at 5 08 02 PM](https://github.com/user-attachments/assets/ccae30bc-eb27-48bb-8601-8a5c28e8f169)
