### PR TITLE
chore: Bump langfuse sdk to 2.43.3 + forked commits

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -101,6 +101,6 @@ chromadb==0.4.14
 google-cloud-storage==2.16.0
 google-cloud-aiplatform==1.60.0
 anthropic[vertex]==0.31.2
-langfuse @ git+https://github.com/jennmueng/langfuse-python.git@0643fdd4a7511eba31b522362cfc929b20b37d3b
+langfuse @ git+https://github.com/jennmueng/langfuse-python.git@9d9350de1e4e84fa548fe84f82c1b826be17956e
 watchdog
 stumpy==1.12.0


### PR DESCRIPTION
Langfuse python SDK added support for openai structured output in [v2.43.1](https://github.com/langfuse/langfuse-python/releases/tag/v2.43.1), this bumps the commit in my fork to include those changes. 

Currently is broken:
![Screenshot 2024-08-14 at 10 05 14 AM](https://github.com/user-attachments/assets/e3c91b8b-ba8f-4920-874f-b2c21a184300)
