### PR TITLE
(autofix/issue summary) Trim stacktrace frames

### DIFF
--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -333,7 +333,7 @@ class EventDetails(BaseModel):
                     breadcrumbs.append(crumb_details)
 
         return cls(
-            title=error_event.get("title") if error_event.get("title") else "Error",
+            title=error_event.get("title"),
             exceptions=exceptions,
             threads=threads,
             breadcrumbs=breadcrumbs,

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -197,7 +197,8 @@ class Stacktrace(BaseModel):
             text = re.sub(pattern, replacement, text)
         return text
 
-    def _trim_frames(frames: list[StacktraceFrame], frame_allowance=1):  # TODO make 16
+    @staticmethod
+    def _trim_frames(frames: list[StacktraceFrame], frame_allowance=16):
         frames_len = len(frames)
         if frames_len <= frame_allowance:
             return frames
@@ -332,7 +333,7 @@ class EventDetails(BaseModel):
                     breadcrumbs.append(crumb_details)
 
         return cls(
-            title=error_event.get("title"),
+            title=error_event.get("title") if error_event.get("title") else "Error",
             exceptions=exceptions,
             threads=threads,
             breadcrumbs=breadcrumbs,

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -92,7 +92,7 @@ class Stacktrace(BaseModel):
             else:
                 stacktrace_frames.append(frame)
 
-        return stacktrace_frames
+        return cls._trim_frames(stacktrace_frames)
 
     def to_str(self, max_frames: int = 16, in_app_only: bool = False):
         stack_str = ""
@@ -196,6 +196,36 @@ class Stacktrace(BaseModel):
             pattern, replacement = check
             text = re.sub(pattern, replacement, text)
         return text
+
+    def _trim_frames(frames: list[StacktraceFrame], frame_allowance=1):  # TODO make 16
+        frames_len = len(frames)
+        if frames_len <= frame_allowance:
+            return frames
+
+        app_frames = [frame for frame in frames if frame.in_app]
+        system_frames = [frame for frame in frames if not frame.in_app]
+
+        app_count = len(app_frames)
+        system_allowance = max(frame_allowance - app_count, 0)
+        app_allowance = frame_allowance - system_allowance
+
+        if system_allowance > 0:
+            # prioritize trimming system frames
+            half_system = system_allowance // 2
+            kept_system_frames = system_frames[:half_system] + system_frames[-half_system:]
+        else:
+            kept_system_frames = []
+
+        if app_allowance > 0:
+            half_app = app_allowance // 2
+            kept_app_frames = app_frames[:half_app] + app_frames[-half_app:]
+        else:
+            kept_app_frames = []
+
+        # combine and sort the kept frames based on their original order
+        kept_frames = kept_system_frames + kept_app_frames
+        kept_frames.sort(key=lambda frame: frames.index(frame))
+        return kept_frames
 
 
 class SentryStacktrace(TypedDict):

--- a/tests/automation/autofix/test_models.py
+++ b/tests/automation/autofix/test_models.py
@@ -114,6 +114,30 @@ class TestStacktraceHelpers(unittest.TestCase):
             with self.subTest(text=text):
                 self.assertEqual(stacktrace._scrub_pii(text), expected)
 
+    def test_trim_frames(self):
+        frames = [
+            StacktraceFrame(
+                in_app=True, filename="test", abs_path="test", line_no=1, col_no=1, context=[]
+            )
+            for _ in range(10)
+        ] + [
+            StacktraceFrame(
+                in_app=False, filename="test", abs_path="test", line_no=1, col_no=1, context=[]
+            )
+            for _ in range(10)
+        ]
+        result = Stacktrace._trim_frames(frames, frame_allowance=16)
+
+        # assert the result has the correct length
+        self.assertEqual(len(result), 16)
+        # assert all app frames are kept
+        self.assertEqual(len([f for f in result if f.in_app]), 10)
+        # assert the remaining frames are system frames
+        self.assertEqual(len([f for f in result if not f.in_app]), 6)
+        # assert the first and last system frames are kept
+        self.assertFalse(result[10].in_app)
+        self.assertFalse(result[-1].in_app)
+
 
 class TestRepoDefinition(unittest.TestCase):
     def test_repo_definition_creation(self):


### PR DESCRIPTION
For both Autofix and Issue Summary, limit the number of stacktrace frames we use to 16.
Prioritizes cutting out frames that aren't in-app.

Issue #1056 