### PR TITLE
(issue summary) Make ExceptionDetails value optional to handle issues without error message

### DIFF
--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -224,7 +224,7 @@ class SentryEventData(TypedDict):
 
 class ExceptionDetails(BaseModel):
     type: str
-    value: str
+    value: Optional[str] = ""
     stacktrace: Stacktrace
 
     @field_validator("stacktrace", mode="before")


### PR DESCRIPTION
Issue #1058 

The reason some issues got "Error loading issue summary" was because they had None for an error message, which our Pydantic model didn't accept.