### PR TITLE
fix(autofix): Fix repo confusion + lack of instructions in plan+code

### DIFF
--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -165,7 +165,7 @@ class AutofixContext(PipelineContext):
 
             valid_file_paths = repo_client.get_valid_file_paths()
             for frame in stacktrace.frames:
-                if frame.in_app and frame.repo_id is None:
+                if frame.in_app and frame.repo_name is None:
                     if frame.filename in valid_file_paths:
                         frame.repo_name = repo.full_name
                     else:

--- a/src/seer/automation/autofix/components/coding/component.py
+++ b/src/seer/automation/autofix/components/coding/component.py
@@ -62,10 +62,13 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
             else request.root_cause_and_fix
         )
 
+        state = self.context.state.get()
+
         response = agent.run(
             CodingPrompts.format_fix_discovery_msg(
                 event=simplified_event_details,
                 task_str=task_str,
+                repo_names=[repo.full_name for repo in state.request.repos],
                 instruction=request.instruction,
             ),
             context=self.context,

--- a/src/seer/automation/autofix/components/coding/models.py
+++ b/src/seer/automation/autofix/components/coding/models.py
@@ -1,5 +1,5 @@
 import textwrap
-from typing import Annotated, Optional
+from typing import Annotated
 
 from pydantic import BaseModel, StringConstraints, field_validator
 from pydantic_xml import attr, element
@@ -15,7 +15,7 @@ from seer.automation.models import EventDetails, PromptXmlModel
 class CodingRequest(BaseComponentRequest):
     event_details: EventDetails
     root_cause_and_fix: RootCauseAnalysisItem | str
-    instruction: Optional[str] = None
+    instruction: str | None = None
 
 
 class SnippetXml(PromptXmlModel, tag="snippet"):

--- a/src/seer/automation/autofix/components/coding/prompts.py
+++ b/src/seer/automation/autofix/components/coding/prompts.py
@@ -1,7 +1,7 @@
 import textwrap
 
 from seer.automation.autofix.components.coding.models import PlanStepsPromptXml
-from seer.automation.autofix.prompts import format_instruction
+from seer.automation.autofix.prompts import format_instruction, format_repo_names
 
 
 class CodingPrompts:
@@ -19,12 +19,16 @@ class CodingPrompts:
         )
 
     @staticmethod
-    def format_fix_discovery_msg(event: str, task_str: str, instruction: str | None):
+    def format_fix_discovery_msg(
+        event: str, task_str: str, repo_names: list[str], instruction: str | None
+    ):
         return textwrap.dedent(
             """\
+            {repo_names_str}
+
             Given the issue:
             {event_str}
-
+            {instruction}
             The root cause of the issue has been identified and context about the issue has been provided:
             {task_str}
 
@@ -47,6 +51,7 @@ class CodingPrompts:
         ).format(
             event_str=event,
             task_str=task_str,
+            repo_names_str=format_repo_names(repo_names),
             instruction=format_instruction(instruction),
         )
 

--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -46,10 +46,13 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
         )
         simplified_event_details = event_details_response.content
 
+        state = self.context.state.get()
+
         response = agent.run(
             RootCauseAnalysisPrompts.format_default_msg(
                 event=simplified_event_details,
                 instruction=request.instruction,
+                repo_names=[repo.full_name for repo in state.request.repos],
             ),
             context=self.context,
         )

--- a/src/seer/automation/autofix/components/root_cause/prompts.py
+++ b/src/seer/automation/autofix/components/root_cause/prompts.py
@@ -4,7 +4,7 @@ from typing import Optional
 from seer.automation.autofix.components.root_cause.models import (
     MultipleRootCauseAnalysisOutputPromptXml,
 )
-from seer.automation.autofix.prompts import format_instruction
+from seer.automation.autofix.prompts import format_instruction, format_repo_names
 
 
 class RootCauseAnalysisPrompts:
@@ -32,15 +32,16 @@ class RootCauseAnalysisPrompts:
     @staticmethod
     def format_default_msg(
         event: str,
+        repo_names: list[str],
         instruction: Optional[str] = None,
     ):
         return textwrap.dedent(
             """\
+            {repo_names_str}
             Given the issue:
             {error_str}
 
             {instruction_str}
-
             When ready with your final answer, detail all the potential root causes of the issue.
 
             # Guidelines:
@@ -53,6 +54,7 @@ class RootCauseAnalysisPrompts:
             - You also MUST think step-by-step before giving the final answer."""
         ).format(
             error_str=event,
+            repo_names_str=format_repo_names(repo_names),
             instruction_str=format_instruction(instruction),
         )
 

--- a/src/seer/automation/autofix/prompts.py
+++ b/src/seer/automation/autofix/prompts.py
@@ -2,13 +2,15 @@ import textwrap
 
 
 def format_instruction(instruction: str | None):
-    return textwrap.dedent(  # The leading newline is intentional
-        f"""\
-        \
-        Instructions have been provided. Please ensure that they are reflected in your work:
-        \"{instruction}\"
-        \
-        """
+    return (
+        "\n"
+        + textwrap.dedent(  # The newlines are intentional
+            f"""\
+            Instructions have been provided. Please ensure that they are reflected in your work:
+            \"{instruction}\"
+            """
+        )
+        + "\n"
         if instruction
         else ""
     )

--- a/src/seer/automation/autofix/prompts.py
+++ b/src/seer/automation/autofix/prompts.py
@@ -4,11 +4,20 @@ import textwrap
 def format_instruction(instruction: str | None):
     return textwrap.dedent(  # The leading newline is intentional
         f"""\
-
+        \
         Instructions have been provided. Please ensure that they are reflected in your work:
-        <instruction>
-        {instruction}
-        </instruction>"""
+        \"{instruction}\"
+        \
+        """
         if instruction
         else ""
     )
+
+
+def format_repo_names(repo_names: list[str]):
+    return textwrap.dedent(
+        """\
+        You have the following repositories to work with:
+        {names_list_str}
+        """
+    ).format(names_list_str="\n".join([f"- {repo_name}" for repo_name in repo_names]))

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -38,7 +38,6 @@ class StacktraceFrame(BaseModel):
     col_no: Optional[int]
     context: list[tuple[int, str]]
     repo_name: Optional[str] = None
-    repo_id: Optional[int] = None
     in_app: bool = False
     vars: Optional[dict[str, Any]] = None
     package: Optional[str] = None


### PR DESCRIPTION
1. We weren't passing the original human instructions into the plan+code agent. This fixes that
2. Also, both root cause and plan+code agents will have the list of repos provided to it, to reduce the chance it gets confused over repos
3. Also removes the no-longer-used repo_id field.

![Screenshot 2024-08-27 at 2 37 33 PM](https://github.com/user-attachments/assets/b525c791-014b-4c33-aec4-7c1dc2b84044)
![Screenshot 2024-08-27 at 2 33 03 PM](https://github.com/user-attachments/assets/3a2f9375-5de6-4519-9612-19bf7fa21e75)
