### PR TITLE
feat(issue summary): Add support for trace connected issues

### DIFF
--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -180,7 +180,8 @@ class AutofixContext(PipelineContext):
         Annotate exceptions with the correct repo each frame is pointing to and fix the filenames
         """
         for exception in event.exceptions:
-            self._process_stacktrace_paths(exception.stacktrace)
+            if exception.stacktrace:
+                self._process_stacktrace_paths(exception.stacktrace)
         for thread in event.threads:
             if thread.stacktrace:
                 self._process_stacktrace_paths(thread.stacktrace)

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -42,6 +42,24 @@ class StacktraceFrame(BaseModel):
     vars: Optional[dict[str, Any]] = None
     package: Optional[str] = None
 
+    @field_validator("vars", mode="before")
+    @classmethod
+    def validate_vars(cls, vars: Optional[dict[str, Any]]):
+        if not vars or len(vars.keys()) <= 4:
+            return vars
+        return cls._trim_vars(vars)
+    
+    @staticmethod
+    def _trim_vars(vars: dict[str, Any]):
+        # use rough heuristics to guess which variable values to delete to attempt to trim
+        trimmed_vars = {}
+        for key, val in vars.items():
+            if key.startswith("__") and key.endswith("__"):
+                continue
+            if val.startswith("<") and val.endswith(">"):
+                continue
+            trimmed_vars[key] = val
+        return trimmed_vars
 
 class SentryFrame(TypedDict):
     absPath: Optional[str]

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -56,7 +56,7 @@ class StacktraceFrame(BaseModel):
         for key, val in vars.items():
             if key.startswith("__") and key.endswith("__"):
                 continue
-            if val.startswith("<") and val.endswith(">"):
+            if str(val).startswith("<") and str(val).endswith(">"):
                 continue
             trimmed_vars[key] = val
         return trimmed_vars

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -48,7 +48,7 @@ class StacktraceFrame(BaseModel):
         if not vars or len(vars.keys()) <= 4:
             return vars
         return cls._trim_vars(vars)
-    
+
     @staticmethod
     def _trim_vars(vars: dict[str, Any]):
         # use rough heuristics to guess which variable values to delete to attempt to trim
@@ -60,6 +60,7 @@ class StacktraceFrame(BaseModel):
                 continue
             trimmed_vars[key] = val
         return trimmed_vars
+
 
 class SentryFrame(TypedDict):
     absPath: Optional[str]

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -256,7 +256,7 @@ class SentryEventData(TypedDict):
 class ExceptionDetails(BaseModel):
     type: str
     value: Optional[str] = ""
-    stacktrace: Stacktrace
+    stacktrace: Optional[Stacktrace] = None
 
     @field_validator("stacktrace", mode="before")
     @classmethod

--- a/src/seer/automation/summarize/issue.py
+++ b/src/seer/automation/summarize/issue.py
@@ -102,7 +102,7 @@ def summarize_issue(request: SummarizeIssueRequest, gpt_client: GptClient = inje
 
     res = completion.choices[0].message.parsed
     summary = res.final_summary if connected_event_details else res.summary_of_issue_at_code_level
-    impact = res.functionality_touched
+    impact = res.summary_of_functionality_touched
     headline = res.factual_issue_description_under_10_words
 
     return SummarizeIssueResponse(

--- a/src/seer/automation/summarize/issue.py
+++ b/src/seer/automation/summarize/issue.py
@@ -24,7 +24,11 @@ class IssueSummary(BaseModel):
 def summarize_issue(request: SummarizeIssueRequest, gpt_client: GptClient = injected):
     event_details = EventDetails.from_event(request.issue.events[0])
     connected_event_details = (
-        [EventDetails.from_event(issue.events[0]) for issue in request.connected_issues]
+        [
+            EventDetails.from_event(issue.events[0])
+            for issue in request.connected_issues
+            if issue.events
+        ]
         if request.connected_issues
         else []
     )

--- a/src/seer/automation/summarize/issue.py
+++ b/src/seer/automation/summarize/issue.py
@@ -9,38 +9,55 @@ from seer.automation.models import EventDetails
 from seer.automation.summarize.models import SummarizeIssueRequest, SummarizeIssueResponse
 from seer.dependency_injection import inject, injected
 
-
-class Step(BaseModel):
-    reasoning: str
-    justification: str
-
-
 class IssueSummary(BaseModel):
-    reason_step_by_step: list[Step]
-    summary_of_issue_at_code_level: str
-    summary_of_functionality_affected: str
-    five_to_ten_word_headline: str
+    one_sentence_summary_of_main_issue_at_code_level: str
+    one_sentence_summary_of_connected_issues_at_code_level: str
+    insights_from_trace_at_code_level: str
+    final_summary: str
+    summary_of_affected_functionality: str
+    factual_issue_description_under_10_words: str
+
 
 
 @observe(name="Summarize Issue")
 @inject
 def summarize_issue(request: SummarizeIssueRequest, gpt_client: GptClient = injected):
     event_details = EventDetails.from_event(request.issue.events[0])
+    connected_event_details = [EventDetails.from_event(issue.events[0]) for issue in request.connected_issues] if request.connected_issues else []
+
+    connected_issues_input = ""
+    trace_summary_prompt = ""
+    final_summary_trace_details = ""
+    if connected_event_details:
+        connected_issues = "\n----\n".join([f"Connected Issue:\n{event.format_event()}" for _, event in enumerate(connected_event_details)])
+        connected_issues_input = f"""
+        Also, we know about some other issues that occurred in the same application trace, listed below. This issue occurred somewhere alongside these:
+        {connected_issues}
+        """
+        trace_summary_prompt = "- Describe insights from the trace; i.e. is this issue caused by another issue, or is it causing another issue, or are there other issues following the same pattern with some variations? Specifically mention other issues in the trace if there is anything to conclude. Be specific with code details and how these issues interact if at all."
+        final_summary_trace_details = "Include details from the trace if they will be useful to our engineers in understanding this issue."
 
     prompt = textwrap.dedent(
-        """Our code is broken! Please summarize the issue below in a few short sentences so our engineers can immediately understand what's wrong and respond.
-        {event_details}
+        f'''Our code is broken! Please summarize the issue below in a few short sentences so our engineers can immediately understand what's wrong and respond.
 
-        Your #1 goal is to help our engineers immediately understand the issue and act!
+        The issue: {event_details.format_event()}
 
-        Regarding the issue summary, state clearly and concisely what's going wrong and why. Do not just restate the error message, as that wastes our time! Look deeper into the details provided to paint the full picture and find the key insight of what's going wrong.
+        {connected_issues_input}
 
-        At the code level, our engineers need to get into the nitty gritty mechanical details of what's going wrong.
-
-        Regarding affected functionality, your goal is to help our engineers immediately understand what SPECIFIC application or service functionality is related to this code issue. Do NOT try to conclude root causes or suggest solutions. Don't even talk about the mechanical details, but rather speak more to the overall task that is failing. Get straight to the point without being overconfident."""
-    ).format(event_details=event_details.format_event())
+        Your #1 goal is to help our engineers immediately understand the main issue and act! Follow the below plan, giving detailed yet concise answers:
+        - Summarize the main issue at a code level standalone.
+        - Summarize the connected issues at a code level standalone.
+        {trace_summary_prompt}
+        - Final summary: Write a 1-2 line summary of the specific details of the issue. {final_summary_trace_details}
+        - Write a multi-line-headline-like summary of the specific application functionality or tasks affected by the issue, but don't overconfidently declare something broken or comment broadly on user impact.
+        - Write a headline-like summary of the overall issue.'''
+    )
 
     message_dicts: list[ChatCompletionMessageParam] = [
+        {
+            "content": "You speak only in news headlines (you can use multiple headlines for multiple sentences). Only use words that add value to our engineers who are debugging the issue under a time crunch. The more specific and granular you are, the faster our engineers can act. Handwavy broad talk about the service or application is a waste of time.",
+            "role": "system"
+        },
         {
             "content": prompt,
             "role": "user",
@@ -61,9 +78,9 @@ def summarize_issue(request: SummarizeIssueRequest, gpt_client: GptClient = inje
         raise RuntimeError("Failed to parse message")
 
     res = completion.choices[0].message.parsed
-    summary = res.summary_of_issue_at_code_level
-    impact = res.summary_of_functionality_affected
-    headline = res.five_to_ten_word_headline
+    summary = res.final_summary
+    impact = res.summary_of_affected_functionality
+    headline = res.factual_issue_description_under_10_words
 
     return SummarizeIssueResponse(
         group_id=request.group_id,

--- a/src/seer/automation/summarize/models.py
+++ b/src/seer/automation/summarize/models.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 from pydantic import BaseModel
 
 from seer.automation.models import IssueDetails

--- a/src/seer/automation/summarize/models.py
+++ b/src/seer/automation/summarize/models.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from pydantic import BaseModel
 
 from seer.automation.models import IssueDetails
@@ -9,6 +10,7 @@ class SummarizeIssueRequest(BaseModel):
     organization_id: int | None = None
     organization_slug: str | None = None
     project_id: int | None = None
+    connected_issues: Optional[list[IssueDetails]] = None
 
 
 class SummarizeIssueResponse(BaseModel):

--- a/tests/automation/autofix/test_models.py
+++ b/tests/automation/autofix/test_models.py
@@ -689,7 +689,7 @@ def test_stacktrace_frame_vars_stringify(stacktrace: Stacktrace):
 
     for frame in stacktrace.frames:
         if frame.vars:
-            vars_str = json.dumps(frame.vars, indent=2)
+            vars_str = json.dumps(StacktraceFrame._trim_vars(frame.vars), indent=2)
             assert vars_str in stack_str
         else:
             assert "---\nVariable" not in stack_str

--- a/tests/automation/autofix/test_models.py
+++ b/tests/automation/autofix/test_models.py
@@ -254,6 +254,39 @@ class TestStacktraceHelpers(unittest.TestCase):
         self.assertFalse(result[10].in_app)
         self.assertFalse(result[-1].in_app)
 
+    def test_trim_vars(self):
+        self.assertEqual(StacktraceFrame._trim_vars({}), {})
+
+        input_dict = {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+        self.assertEqual(StacktraceFrame._trim_vars(input_dict), input_dict)
+
+        input_dict = {
+            'a': 1,
+            'b': 2,
+            'c': 3,
+            'd': 4,
+            'e': 5,
+            '__special__': 'ignored',
+            'object': '<object object at 0x...>',
+            'normal_string': 'keep_me'
+        }
+        expected_output = {
+            'a': 1,
+            'b': 2,
+            'c': 3,
+            'd': 4,
+            'e': 5,
+            'normal_string': 'keep_me'
+        }
+        self.assertEqual(StacktraceFrame._trim_vars(input_dict), expected_output)
+
+        input_dict = {
+            '__special1__': 'ignored',
+            '__special2__': 'also_ignored',
+            'object1': '<object object at 0x...>',
+            'object2': '<function func at 0x...>'
+        }
+        self.assertEqual(StacktraceFrame._trim_vars(input_dict), {})
 
 class TestRepoDefinition(unittest.TestCase):
     def test_repo_definition_creation(self):

--- a/tests/automation/autofix/test_models.py
+++ b/tests/automation/autofix/test_models.py
@@ -257,36 +257,30 @@ class TestStacktraceHelpers(unittest.TestCase):
     def test_trim_vars(self):
         self.assertEqual(StacktraceFrame._trim_vars({}), {})
 
-        input_dict = {'a': 1, 'b': 2, 'c': 3, 'd': 4}
+        input_dict = {"a": 1, "b": 2, "c": 3, "d": 4}
         self.assertEqual(StacktraceFrame._trim_vars(input_dict), input_dict)
 
         input_dict = {
-            'a': 1,
-            'b': 2,
-            'c': 3,
-            'd': 4,
-            'e': 5,
-            '__special__': 'ignored',
-            'object': '<object object at 0x...>',
-            'normal_string': 'keep_me'
+            "a": 1,
+            "b": 2,
+            "c": 3,
+            "d": 4,
+            "e": 5,
+            "__special__": "ignored",
+            "object": "<object object at 0x...>",
+            "normal_string": "keep_me",
         }
-        expected_output = {
-            'a': 1,
-            'b': 2,
-            'c': 3,
-            'd': 4,
-            'e': 5,
-            'normal_string': 'keep_me'
-        }
+        expected_output = {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "normal_string": "keep_me"}
         self.assertEqual(StacktraceFrame._trim_vars(input_dict), expected_output)
 
         input_dict = {
-            '__special1__': 'ignored',
-            '__special2__': 'also_ignored',
-            'object1': '<object object at 0x...>',
-            'object2': '<function func at 0x...>'
+            "__special1__": "ignored",
+            "__special2__": "also_ignored",
+            "object1": "<object object at 0x...>",
+            "object2": "<function func at 0x...>",
         }
         self.assertEqual(StacktraceFrame._trim_vars(input_dict), {})
+
 
 class TestRepoDefinition(unittest.TestCase):
     def test_repo_definition_creation(self):

--- a/tests/automation/autofix/test_models.py
+++ b/tests/automation/autofix/test_models.py
@@ -255,31 +255,15 @@ class TestStacktraceHelpers(unittest.TestCase):
         self.assertFalse(result[-1].in_app)
 
     def test_trim_vars(self):
-        self.assertEqual(StacktraceFrame._trim_vars({}), {})
-
-        input_dict = {"a": 1, "b": 2, "c": 3, "d": 4}
-        self.assertEqual(StacktraceFrame._trim_vars(input_dict), input_dict)
+        self.assertEqual(StacktraceFrame._trim_vars({}, "def foo():"), {})
 
         input_dict = {
-            "a": 1,
-            "b": 2,
-            "c": 3,
-            "d": 4,
-            "e": 5,
-            "__special__": "ignored",
-            "object": "<object object at 0x...>",
-            "normal_string": "keep_me",
+            "bar": 1,
+            "baz": 5,
+            "foo": "ignored",
         }
-        expected_output = {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "normal_string": "keep_me"}
-        self.assertEqual(StacktraceFrame._trim_vars(input_dict), expected_output)
-
-        input_dict = {
-            "__special1__": "ignored",
-            "__special2__": "also_ignored",
-            "object1": "<object object at 0x...>",
-            "object2": "<function func at 0x...>",
-        }
-        self.assertEqual(StacktraceFrame._trim_vars(input_dict), {})
+        expected_output = {"bar": 1, "foo": "ignored"}
+        self.assertEqual(StacktraceFrame._trim_vars(input_dict, "def foo(bar):"), expected_output)
 
 
 class TestRepoDefinition(unittest.TestCase):

--- a/tests/automation/summarize/test_issue.py
+++ b/tests/automation/summarize/test_issue.py
@@ -88,7 +88,9 @@ class TestSummarizeIssue:
         mock_event_details.format_event.assert_called_once()
         assert (
             "Formatted event details"
-            in mock_gpt_client.openai_client.beta.chat.completions.parse.call_args[1]["messages"][1]["content"]
+            in mock_gpt_client.openai_client.beta.chat.completions.parse.call_args[1]["messages"][
+                1
+            ]["content"]
         )
 
 

--- a/tests/automation/summarize/test_issue.py
+++ b/tests/automation/summarize/test_issue.py
@@ -27,7 +27,7 @@ class TestSummarizeIssue:
             one_sentence_summary_of_connected_issues_at_code_level="test",
             insights_from_trace_at_code_level="test",
             final_summary="Test summary",
-            summary_of_affected_functionality="Test functionality",
+            summary_of_functionality_touched="Test functionality",
             factual_issue_description_under_10_words="Test headline",
         )
         mock_structured_completion.choices[0].message.refusal = None
@@ -77,7 +77,7 @@ class TestSummarizeIssue:
             one_sentence_summary_of_connected_issues_at_code_level="test",
             insights_from_trace_at_code_level="test",
             final_summary="Test summary",
-            summary_of_affected_functionality="Test functionality",
+            summary_of_functionality_touched="Test functionality",
             factual_issue_description_under_10_words="Test headline",
         )
         mock_structured_completion.choices[0].message.refusal = None

--- a/tests/automation/summarize/test_issue.py
+++ b/tests/automation/summarize/test_issue.py
@@ -20,10 +20,12 @@ class TestSummarizeIssue:
     def test_summarize_issue_success(self, mock_gpt_client, sample_request):
         mock_structured_completion = MagicMock()
         mock_structured_completion.choices[0].message.parsed = MagicMock(
-            reason_step_by_step=[],
-            summary_of_issue_at_code_level="Test summary",
-            summary_of_functionality_affected="Test functionality",
-            five_to_ten_word_headline="Test headline",
+            one_sentence_summary_of_main_issue_at_code_level="test",
+            one_sentence_summary_of_connected_issues_at_code_level="test",
+            insights_from_trace_at_code_level="test",
+            final_summary="Test summary",
+            summary_of_affected_functionality="Test functionality",
+            factual_issue_description_under_10_words="Test headline",
         )
         mock_structured_completion.choices[0].message.refusal = None
         mock_gpt_client.openai_client.beta.chat.completions.parse.return_value = (
@@ -68,10 +70,12 @@ class TestSummarizeIssue:
 
         mock_structured_completion = MagicMock()
         mock_structured_completion.choices[0].message.parsed = MagicMock(
-            reason_step_by_step=[],
-            summary_of_issue_at_code_level="Test summary",
-            summary_of_functionality_affected="Test functionality",
-            five_to_ten_word_headline="Test headline",
+            one_sentence_summary_of_main_issue_at_code_level="test",
+            one_sentence_summary_of_connected_issues_at_code_level="test",
+            insights_from_trace_at_code_level="test",
+            final_summary="Test summary",
+            summary_of_affected_functionality="Test functionality",
+            factual_issue_description_under_10_words="Test headline",
         )
         mock_structured_completion.choices[0].message.refusal = None
         mock_gpt_client.openai_client.beta.chat.completions.parse.return_value = (
@@ -84,9 +88,7 @@ class TestSummarizeIssue:
         mock_event_details.format_event.assert_called_once()
         assert (
             "Formatted event details"
-            in mock_gpt_client.openai_client.beta.chat.completions.parse.call_args[1]["messages"][
-                0
-            ]["content"]
+            in mock_gpt_client.openai_client.beta.chat.completions.parse.call_args[1]["messages"][1]["content"]
         )
 
 

--- a/tests/automation/summarize/test_issue.py
+++ b/tests/automation/summarize/test_issue.py
@@ -23,12 +23,10 @@ class TestSummarizeIssue:
     def test_summarize_issue_success(self, mock_gpt_client, sample_request):
         mock_structured_completion = MagicMock()
         mock_structured_completion.choices[0].message.parsed = MagicMock(
-            one_sentence_summary_of_main_issue_at_code_level="test",
-            one_sentence_summary_of_connected_issues_at_code_level="test",
-            insights_from_trace_at_code_level="test",
-            final_summary="Test summary",
-            summary_of_functionality_touched="Test functionality",
-            factual_issue_description_under_10_words="Test headline",
+            reason_step_by_step=[],
+            summary_of_issue_at_code_level="Test summary",
+            summary_of_functionality_affected="Test functionality",
+            five_to_ten_word_headline="Test headline",
         )
         mock_structured_completion.choices[0].message.refusal = None
         mock_gpt_client.openai_client.beta.chat.completions.parse.return_value = (
@@ -73,12 +71,10 @@ class TestSummarizeIssue:
 
         mock_structured_completion = MagicMock()
         mock_structured_completion.choices[0].message.parsed = MagicMock(
-            one_sentence_summary_of_main_issue_at_code_level="test",
-            one_sentence_summary_of_connected_issues_at_code_level="test",
-            insights_from_trace_at_code_level="test",
-            final_summary="Test summary",
-            summary_of_functionality_touched="Test functionality",
-            factual_issue_description_under_10_words="Test headline",
+            reason_step_by_step=[],
+            summary_of_issue_at_code_level="Test summary",
+            summary_of_functionality_affected="Test functionality",
+            five_to_ten_word_headline="Test headline",
         )
         mock_structured_completion.choices[0].message.refusal = None
         mock_gpt_client.openai_client.beta.chat.completions.parse.return_value = (
@@ -94,19 +90,19 @@ class TestSummarizeIssue:
         assert (
             "foo details"
             in mock_gpt_client.openai_client.beta.chat.completions.parse.call_args[1]["messages"][
-                1
+                0
             ]["content"]
         )
         assert (
             "bar details"
             in mock_gpt_client.openai_client.beta.chat.completions.parse.call_args[1]["messages"][
-                1
+                0
             ]["content"]
         )
         assert (
             "baz details"
             in mock_gpt_client.openai_client.beta.chat.completions.parse.call_args[1]["messages"][
-                1
+                0
             ]["content"]
         )
 


### PR DESCRIPTION
Included in this PR:
1. Optionally takes in trace connected issues for an issue to inform the summary output. (#1071 )
2. Attempts to trim `vars` in a stacktrace frame if they get lengthy.
3. Fixes `ValidationError` for exceptions without a stacktrace by making the stacktrace optional. (#1084 )