### PR TITLE
fix(autofix): Use commit message from plan+code

### DIFF
--- a/src/seer/automation/autofix/components/coding/utils.py
+++ b/src/seer/automation/autofix/components/coding/utils.py
@@ -90,6 +90,8 @@ def task_to_file_create(task: PlanTaskPromptXml) -> FileChange:
         change_type="create",
         path=task.file_path,
         new_snippet=diff_chunks[0].new_chunk,
+        description=task.description,
+        commit_message=task.commit_message,
     )
 
 
@@ -110,6 +112,8 @@ def task_to_file_delete(task: PlanTaskPromptXml) -> FileChange:
     return FileChange(
         change_type="delete",
         path=task.file_path,
+        description=task.description,
+        commit_message=task.commit_message,
     )
 
 
@@ -153,6 +157,7 @@ def task_to_file_change(task: PlanTaskPromptXml, file_content: str) -> list[File
                     reference_snippet=original_snippet,
                     new_snippet=chunk.new_chunk,
                     description=task.description,
+                    commit_message=task.commit_message,
                 )
             )
         else:

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -359,7 +359,7 @@ class RepoClient:
 
             self.repo.update_file(
                 change.path,
-                change.description or "File change",
+                change.commit_message or "File change",
                 new_contents or "",
                 contents.sha,  # FYI: It wants the sha of the content blob here, not a commit sha.
                 branch=branch_ref,

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -540,6 +540,7 @@ class FileChange(BaseModel):
     reference_snippet: Optional[str] = None
     new_snippet: Optional[str] = None
     description: Optional[str] = None
+    commit_message: Optional[str] = None
 
     def apply(self, file_contents: str | None) -> str | None:
         if self.change_type == "create":


### PR DESCRIPTION
We weren't using the commit message output from the plan+code agent