### PR TITLE
(autofix): Pass issue summary to autofix, store raw summary output instead of response

### DIFF
--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -2,8 +2,8 @@ import logging
 import textwrap
 from typing import Mapping, cast
 
-from pydantic import ValidationError
 import sentry_sdk
+from pydantic import ValidationError
 
 from seer.automation.autofix.event_manager import AutofixEventManager
 from seer.automation.autofix.models import (

--- a/src/seer/automation/autofix/components/coding/component.py
+++ b/src/seer/automation/autofix/components/coding/component.py
@@ -4,8 +4,6 @@ from langfuse.decorators import observe
 from sentry_sdk.ai.monitoring import ai_track
 
 from seer.automation.agent.agent import AgentConfig, GptAgent
-from seer.automation.agent.client import GptClient
-from seer.automation.agent.models import Message
 from seer.automation.autofix.autofix_context import AutofixContext
 from seer.automation.autofix.components.coding.models import (
     CodingOutput,
@@ -45,17 +43,6 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
             config=AgentConfig(system_prompt=CodingPrompts.format_system_msg()),
         )
 
-        # preprocess event information
-        event_details_response, _ = GptClient().completion(
-            messages=[
-                Message(
-                    content=f"We have lots of information available for debugging an issue in our code below. Reproduce the info exactly as it is now, but exclude any useless information.\n\n{request.event_details.format_event()}"
-                ),
-            ],
-            model="gpt-4o-mini-2024-07-18",
-        )
-        simplified_event_details = event_details_response.content
-
         task_str = (
             RootCausePlanTaskPromptXml.from_root_cause(request.root_cause_and_fix).to_prompt_str()
             if isinstance(request.root_cause_and_fix, RootCauseAnalysisItem)
@@ -66,8 +53,9 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
 
         response = agent.run(
             CodingPrompts.format_fix_discovery_msg(
-                event=simplified_event_details,
+                event=request.event_details.format_event(),
                 task_str=task_str,
+                summary=request.summary,
                 repo_names=[repo.full_name for repo in state.request.repos],
                 instruction=request.instruction,
             ),

--- a/src/seer/automation/autofix/components/coding/models.py
+++ b/src/seer/automation/autofix/components/coding/models.py
@@ -1,5 +1,5 @@
 import textwrap
-from typing import Annotated
+from typing import Annotated, Optional
 
 from pydantic import BaseModel, StringConstraints, field_validator
 from pydantic_xml import attr, element
@@ -10,12 +10,14 @@ from seer.automation.autofix.components.root_cause.models import (
 )
 from seer.automation.component import BaseComponentOutput, BaseComponentRequest
 from seer.automation.models import EventDetails, PromptXmlModel
+from seer.automation.summarize.issue import IssueSummary
 
 
 class CodingRequest(BaseComponentRequest):
     event_details: EventDetails
     root_cause_and_fix: RootCauseAnalysisItem | str
     instruction: str | None = None
+    summary: Optional[IssueSummary] = None
 
 
 class SnippetXml(PromptXmlModel, tag="snippet"):

--- a/src/seer/automation/autofix/components/coding/prompts.py
+++ b/src/seer/automation/autofix/components/coding/prompts.py
@@ -1,7 +1,9 @@
 import textwrap
+from typing import Optional
 
 from seer.automation.autofix.components.coding.models import PlanStepsPromptXml
-from seer.automation.autofix.prompts import format_instruction, format_repo_names
+from seer.automation.autofix.prompts import format_instruction, format_repo_names, format_summary
+from seer.automation.summarize.issue import IssueSummary
 
 
 class CodingPrompts:
@@ -20,14 +22,18 @@ class CodingPrompts:
 
     @staticmethod
     def format_fix_discovery_msg(
-        event: str, task_str: str, repo_names: list[str], instruction: str | None
+        event: str,
+        task_str: str,
+        repo_names: list[str],
+        instruction: str | None,
+        summary: Optional[IssueSummary] = None,
     ):
         return textwrap.dedent(
             """\
             {repo_names_str}
-
-            Given the issue:
+            Given the issue: {summary_str}
             {event_str}
+
             {instruction}
             The root cause of the issue has been identified and context about the issue has been provided:
             {task_str}
@@ -53,6 +59,7 @@ class CodingPrompts:
             task_str=task_str,
             repo_names_str=format_repo_names(repo_names),
             instruction=format_instruction(instruction),
+            summary_str=format_summary(summary),
         )
 
     @staticmethod

--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -51,6 +51,7 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
         response = agent.run(
             RootCauseAnalysisPrompts.format_default_msg(
                 event=simplified_event_details,
+                summary=request.summary,
                 instruction=request.instruction,
                 repo_names=[repo.full_name for repo in state.request.repos],
             ),

--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -4,8 +4,6 @@ from langfuse.decorators import observe
 from sentry_sdk.ai.monitoring import ai_track
 
 from seer.automation.agent.agent import AgentConfig, GptAgent
-from seer.automation.agent.client import GptClient
-from seer.automation.agent.models import Message
 from seer.automation.autofix.autofix_context import AutofixContext
 from seer.automation.autofix.components.root_cause.models import (
     RootCauseAnalysisOutput,
@@ -35,22 +33,11 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
             ),
         )
 
-        # preprocess event information
-        event_details_response, _ = GptClient().completion(
-            messages=[
-                Message(
-                    content=f"We have lots of information available for debugging an issue in our code below. Reproduce the info exactly as it is now, but exclude any useless information.\n\n{request.event_details.format_event()}"
-                ),
-            ],
-            model="gpt-4o-mini-2024-07-18",
-        )
-        simplified_event_details = event_details_response.content
-
         state = self.context.state.get()
 
         response = agent.run(
             RootCauseAnalysisPrompts.format_default_msg(
-                event=simplified_event_details,
+                event=request.event_details.format_event(),
                 summary=request.summary,
                 instruction=request.instruction,
                 repo_names=[repo.full_name for repo in state.request.repos],

--- a/src/seer/automation/autofix/components/root_cause/models.py
+++ b/src/seer/automation/autofix/components/root_cause/models.py
@@ -7,6 +7,7 @@ from pydantic_xml import attr, element
 
 from seer.automation.component import BaseComponentOutput, BaseComponentRequest
 from seer.automation.models import EventDetails, PromptXmlModel
+from seer.automation.summarize.issue import IssueSummary
 
 
 class SnippetPromptXml(PromptXmlModel, tag="code"):
@@ -152,8 +153,8 @@ class RootCauseAnalysisOutputPromptXml(PromptXmlModel, tag="root"):
 
 class RootCauseAnalysisRequest(BaseComponentRequest):
     event_details: EventDetails
-
     instruction: Optional[str] = None
+    summary: Optional[IssueSummary] = None
 
 
 class RootCauseAnalysisOutput(BaseComponentOutput):

--- a/src/seer/automation/autofix/components/root_cause/prompts.py
+++ b/src/seer/automation/autofix/components/root_cause/prompts.py
@@ -4,7 +4,8 @@ from typing import Optional
 from seer.automation.autofix.components.root_cause.models import (
     MultipleRootCauseAnalysisOutputPromptXml,
 )
-from seer.automation.autofix.prompts import format_instruction, format_repo_names
+from seer.automation.autofix.prompts import format_instruction, format_repo_names, format_summary
+from seer.automation.summarize.issue import IssueSummary
 
 
 class RootCauseAnalysisPrompts:
@@ -34,11 +35,12 @@ class RootCauseAnalysisPrompts:
         event: str,
         repo_names: list[str],
         instruction: Optional[str] = None,
+        summary: Optional[IssueSummary] = None,
     ):
         return textwrap.dedent(
             """\
             {repo_names_str}
-            Given the issue:
+            Given the issue: {summary_str}
             {error_str}
 
             {instruction_str}
@@ -56,6 +58,7 @@ class RootCauseAnalysisPrompts:
             error_str=event,
             repo_names_str=format_repo_names(repo_names),
             instruction_str=format_instruction(instruction),
+            summary_str=format_summary(summary),
         )
 
     @staticmethod

--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -12,6 +12,7 @@ from seer.automation.agent.models import Usage
 from seer.automation.autofix.components.root_cause.models import RootCauseAnalysisItem
 from seer.automation.autofix.config import AUTOFIX_HARD_TIME_OUT_MINS, AUTOFIX_UPDATE_TIMEOUT_SECS
 from seer.automation.models import FileChange, FilePatch, IssueDetails, RepoDefinition
+from seer.automation.summarize.issue import IssueSummary
 
 
 class FileChangeError(Exception):
@@ -249,6 +250,7 @@ class AutofixRequest(BaseModel):
     issue: IssueDetails
     invoking_user: Optional[AutofixUserDetails] = None
     instruction: Optional[str] = Field(default=None, validation_alias="additional_context")
+    issue_summary: Optional[IssueSummary] = None
 
     options: AutofixRequestOptions = Field(default_factory=AutofixRequestOptions)
 

--- a/src/seer/automation/autofix/prompts.py
+++ b/src/seer/automation/autofix/prompts.py
@@ -1,5 +1,7 @@
 import textwrap
 
+from seer.automation.summarize.issue import IssueSummary
+
 
 def format_instruction(instruction: str | None):
     return (
@@ -23,3 +25,20 @@ def format_repo_names(repo_names: list[str]):
         {names_list_str}
         """
     ).format(names_list_str="\n".join([f"- {repo_name}" for repo_name in repo_names]))
+
+
+def format_summary(summary: IssueSummary | None) -> str:
+    if not summary:
+        return ""
+
+    return textwrap.dedent(
+        """\
+        {details}
+        {analysis}
+        """
+    ).format(
+        details=summary.summary_of_the_issue_based_on_your_step_by_step_reasoning,
+        analysis="\n".join(
+            [f"- {step.reasoning} {step.justification}" for step in summary.reason_step_by_step]
+        ),
+    )

--- a/src/seer/automation/autofix/steps/coding_step.py
+++ b/src/seer/automation/autofix/steps/coding_step.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from langfuse.decorators import observe
+from pydantic import ValidationError
 from sentry_sdk.ai.monitoring import ai_track
 
 from celery_app.app import celery_app
@@ -18,6 +19,8 @@ from seer.automation.autofix.steps.change_describer_step import (
 from seer.automation.autofix.steps.steps import AutofixPipelineStep
 from seer.automation.models import EventDetails
 from seer.automation.pipeline import PipelineStepTaskRequest
+from seer.automation.summarize.issue import IssueSummary
+from seer.db import DbIssueSummary, Session
 
 
 class AutofixCodingStepRequest(PipelineStepTaskRequest):
@@ -67,11 +70,23 @@ class AutofixCodingStep(AutofixPipelineStep):
         event_details = EventDetails.from_event(state.request.issue.events[0])
         self.context.process_event_paths(event_details)
 
+        group_id = state.request.issue.id
+        summary = state.request.issue_summary
+        if not summary:
+            with Session() as session:
+                group_summary = session.get(DbIssueSummary, group_id)
+                if group_summary:
+                    try:
+                        summary = IssueSummary.model_validate(group_summary.summary)
+                    except ValidationError:
+                        pass
+
         coding_output = CodingComponent(self.context).invoke(
             CodingRequest(
                 event_details=event_details,
                 root_cause_and_fix=root_cause_and_fix,
                 instruction=state.request.instruction,
+                summary=summary,
             )
         )
 

--- a/src/seer/automation/autofix/steps/coding_step.py
+++ b/src/seer/automation/autofix/steps/coding_step.py
@@ -70,16 +70,9 @@ class AutofixCodingStep(AutofixPipelineStep):
         event_details = EventDetails.from_event(state.request.issue.events[0])
         self.context.process_event_paths(event_details)
 
-        group_id = state.request.issue.id
         summary = state.request.issue_summary
         if not summary:
-            with Session() as session:
-                group_summary = session.get(DbIssueSummary, group_id)
-                if group_summary:
-                    try:
-                        summary = IssueSummary.model_validate(group_summary.summary)
-                    except ValidationError:
-                        pass
+            summary = self.context.get_issue_summary()
 
         coding_output = CodingComponent(self.context).invoke(
             CodingRequest(

--- a/src/seer/automation/autofix/steps/coding_step.py
+++ b/src/seer/automation/autofix/steps/coding_step.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from langfuse.decorators import observe
-from pydantic import ValidationError
 from sentry_sdk.ai.monitoring import ai_track
 
 from celery_app.app import celery_app
@@ -19,8 +18,6 @@ from seer.automation.autofix.steps.change_describer_step import (
 from seer.automation.autofix.steps.steps import AutofixPipelineStep
 from seer.automation.models import EventDetails
 from seer.automation.pipeline import PipelineStepTaskRequest
-from seer.automation.summarize.issue import IssueSummary
-from seer.db import DbIssueSummary, Session
 
 
 class AutofixCodingStepRequest(PipelineStepTaskRequest):

--- a/src/seer/automation/autofix/steps/root_cause_step.py
+++ b/src/seer/automation/autofix/steps/root_cause_step.py
@@ -58,14 +58,15 @@ class RootCauseStep(AutofixPipelineStep):
         self.context.process_event_paths(event_details)
 
         group_id = state.request.issue.id
-        summary = None
-        with Session() as session:
-            group_summary = session.get(DbIssueSummary, group_id)
-            if group_summary:
-                try:
-                    summary = IssueSummary.model_validate(group_summary.summary)
-                except ValidationError:
-                    pass
+        summary = state.request.issue_summary
+        if not summary:
+            with Session() as session:
+                group_summary = session.get(DbIssueSummary, group_id)
+                if group_summary:
+                    try:
+                        summary = IssueSummary.model_validate(group_summary.summary)
+                    except ValidationError:
+                        pass
 
         root_cause_output = RootCauseAnalysisComponent(self.context).invoke(
             RootCauseAnalysisRequest(

--- a/src/seer/automation/autofix/steps/root_cause_step.py
+++ b/src/seer/automation/autofix/steps/root_cause_step.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from langfuse.decorators import observe
-from pydantic import ValidationError
 from sentry_sdk.ai.monitoring import ai_track
 
 from celery_app.app import celery_app
@@ -14,8 +13,6 @@ from seer.automation.autofix.config import (
 from seer.automation.autofix.steps.steps import AutofixPipelineStep
 from seer.automation.models import EventDetails
 from seer.automation.pipeline import PipelineStepTaskRequest
-from seer.automation.summarize.issue import IssueSummary
-from seer.db import DbIssueSummary, Session
 
 
 class RootCauseStepRequest(PipelineStepTaskRequest):

--- a/src/seer/automation/autofix/steps/root_cause_step.py
+++ b/src/seer/automation/autofix/steps/root_cause_step.py
@@ -57,16 +57,9 @@ class RootCauseStep(AutofixPipelineStep):
         event_details = EventDetails.from_event(state.request.issue.events[0])
         self.context.process_event_paths(event_details)
 
-        group_id = state.request.issue.id
         summary = state.request.issue_summary
         if not summary:
-            with Session() as session:
-                group_summary = session.get(DbIssueSummary, group_id)
-                if group_summary:
-                    try:
-                        summary = IssueSummary.model_validate(group_summary.summary)
-                    except ValidationError:
-                        pass
+            summary = self.context.get_issue_summary()
 
         root_cause_output = RootCauseAnalysisComponent(self.context).invoke(
             RootCauseAnalysisRequest(

--- a/tests/automation/autofix/components/test_root_cause.py
+++ b/tests/automation/autofix/components/test_root_cause.py
@@ -3,7 +3,6 @@ from xml.etree.ElementTree import ParseError
 
 import pytest
 
-from seer.automation.agent.models import Message
 from seer.automation.autofix.autofix_context import AutofixContext
 from seer.automation.autofix.components.root_cause.component import RootCauseAnalysisComponent
 from seer.automation.autofix.components.root_cause.models import (
@@ -27,18 +26,10 @@ class TestRootCauseComponent:
         with patch("seer.automation.autofix.components.root_cause.component.GptAgent") as mock:
             yield mock
 
-    @pytest.fixture
-    def mock_gpt_client(self):
-        with patch("seer.automation.autofix.components.root_cause.component.GptClient") as mock:
-            yield mock
-
-    def test_root_cause_simple_response_parsing(self, component, mock_gpt_agent, mock_gpt_client):
+    def test_root_cause_simple_response_parsing(self, component, mock_gpt_agent):
         mock_gpt_agent.return_value.run.side_effect = [
             "Anything really",
             "<potential_root_causes><potential_cause likelihood='0.9' actionability='1.0'><title>Missing Null Check</title><description>The root cause of the issue is ...</description></potential_cause></potential_root_causes>",
-        ]
-        mock_gpt_client.return_value.completion.side_effect = [
-            (Message(content="some response"), None)
         ]
 
         output = component.invoke(MagicMock())
@@ -51,15 +42,10 @@ class TestRootCauseComponent:
         assert output.causes[0].actionability == 1.0
         assert output.causes[0].code_context is None
 
-    def test_root_cause_code_context_response_parsing(
-        self, component, mock_gpt_agent, mock_gpt_client
-    ):
+    def test_root_cause_code_context_response_parsing(self, component, mock_gpt_agent):
         mock_gpt_agent.return_value.run.side_effect = [
             "Anything really",
             "<potential_root_causes><potential_cause likelihood='0.9' actionability='1.0'><title>Missing Null Check</title><description>The root cause of the issue is ...</description><code_context><code_snippet><title>Add Null Check</title><description>This fix involves adding ...</description><code file_path='some/app/path.py' repo_name='owner/repo'>def foo():</code></code_snippet></code_context></potential_cause></potential_root_causes>",
-        ]
-        mock_gpt_client.return_value.completion.side_effect = [
-            (Message(content="some response"), None)
         ]
 
         output = component.invoke(MagicMock())
@@ -78,17 +64,11 @@ class TestRootCauseComponent:
         assert output.causes[0].code_context[0].snippet.repo_name == "owner/repo"
         assert output.causes[0].code_context[0].snippet.snippet == "def foo():"
 
-    def test_root_cause_multiple_causes_response_parsing(
-        self, component, mock_gpt_agent, mock_gpt_client
-    ):
+    def test_root_cause_multiple_causes_response_parsing(self, component, mock_gpt_agent):
         mock_gpt_agent.return_value.run.side_effect = [
             "Anything really",
             "<potential_root_causes><potential_cause likelihood='0.9' actionability='1.0'><title>Missing Null Check</title><description>The root cause of the issue is ...</description></potential_cause><potential_cause likelihood='0.5' actionability='0.5'><title>Incorrect API Usage</title><description>Another potential cause is ...</description></potential_cause></potential_root_causes>",
         ]
-        mock_gpt_client.return_value.completion.side_effect = [
-            (Message(content="some response"), None)
-        ]
-
         output = component.invoke(MagicMock())
 
         assert output is not None
@@ -96,64 +76,47 @@ class TestRootCauseComponent:
         assert output.causes[0].title == "Missing Null Check"
         assert output.causes[1].title == "Incorrect API Usage"
 
-    def test_root_cause_empty_response_parsing(self, component, mock_gpt_agent, mock_gpt_client):
+    def test_root_cause_empty_response_parsing(self, component, mock_gpt_agent):
         mock_gpt_agent.return_value.run.side_effect = [
             "Anything really",
             "<potential_root_causes></potential_root_causes>",
-        ]
-        mock_gpt_client.return_value.completion.side_effect = [
-            (Message(content="some response"), None)
         ]
 
         output = component.invoke(MagicMock())
 
         assert output is None
 
-    def test_root_cause_invalid_xml_response(self, component, mock_gpt_agent, mock_gpt_client):
+    def test_root_cause_invalid_xml_response(self, component, mock_gpt_agent):
         mock_gpt_agent.return_value.run.side_effect = [
             "Anything really",
             "<potential_root_causes><invalid_xml></potential_root_causes>",
-        ]
-        mock_gpt_client.return_value.completion.side_effect = [
-            (Message(content="some response"), None)
         ]
 
         with pytest.raises(ParseError):
             component.invoke(MagicMock())
 
-    def test_root_cause_missing_required_fields(self, component, mock_gpt_agent, mock_gpt_client):
+    def test_root_cause_missing_required_fields(self, component, mock_gpt_agent):
         mock_gpt_agent.return_value.run.side_effect = [
             "Anything really",
             "<potential_root_causes><potential_cause likelihood='0.9'><title>Missing Null Check</title></potential_cause></potential_root_causes>",
         ]
-        mock_gpt_client.return_value.completion.side_effect = [
-            (Message(content="some response"), None)
-        ]
 
         with pytest.raises(ValueError):
             component.invoke(MagicMock())
 
-    def test_root_cause_invalid_likelihood_actionability(
-        self, component, mock_gpt_agent, mock_gpt_client
-    ):
+    def test_root_cause_invalid_likelihood_actionability(self, component, mock_gpt_agent):
         mock_gpt_agent.return_value.run.side_effect = [
             "Anything really",
             "<potential_root_causes><potential_cause likelihood='2.0' actionability='-0.5'><title>Invalid Values</title><description>Test</description></potential_cause></potential_root_causes>",
         ]
-        mock_gpt_client.return_value.completion.side_effect = [
-            (Message(content="some response"), None)
-        ]
 
         with pytest.raises(ValueError):
             component.invoke(MagicMock())
 
-    def test_root_cause_no_formatter_response(self, component, mock_gpt_agent, mock_gpt_client):
+    def test_root_cause_no_formatter_response(self, component, mock_gpt_agent):
         mock_gpt_agent.return_value.run.side_effect = [
             "<potential_root_causes><potential_cause likelihood='0.9' actionability='1.0'><title>Test</title><description>Test</description></potential_cause></potential_root_causes>",
             None,
-        ]
-        mock_gpt_client.return_value.completion.side_effect = [
-            (Message(content="some response"), None)
         ]
 
         output = component.invoke(MagicMock())
@@ -201,11 +164,8 @@ class TestRootCauseComponent:
                 assert output.causes[0].code_context[0].snippet.snippet == "def test():\n    pass"
                 assert output.causes[0].code_context[0].snippet.repo_name == "owner/repo"
 
-    def test_no_root_causes_response(self, component, mock_gpt_agent, mock_gpt_client):
+    def test_no_root_causes_response(self, component, mock_gpt_agent):
         mock_gpt_agent.return_value.run.return_value = "<NO_ROOT_CAUSES>"
-        mock_gpt_client.return_value.completion.side_effect = [
-            (Message(content="some response"), None)
-        ]
 
         output = component.invoke(MagicMock())
 

--- a/tests/automation/autofix/steps/test_root_cause_step.py
+++ b/tests/automation/autofix/steps/test_root_cause_step.py
@@ -31,7 +31,7 @@ class TestRootCauseStep(unittest.TestCase):
                     summary_of_the_issue_based_on_your_step_by_step_reasoning="summary",
                     summary_of_the_functionality_affected="impact",
                     five_to_ten_word_headline="headline",
-                )
+                ),
             )
         )
 

--- a/tests/automation/autofix/steps/test_root_cause_step.py
+++ b/tests/automation/autofix/steps/test_root_cause_step.py
@@ -7,6 +7,7 @@ from seer.automation.autofix.components.root_cause.models import RootCauseAnalys
 from seer.automation.autofix.models import AutofixContinuation, AutofixRequest
 from seer.automation.autofix.steps.root_cause_step import RootCauseStep
 from seer.automation.models import IssueDetails, SentryEventData
+from seer.automation.summarize.issue import IssueSummary
 
 
 class TestRootCauseStep(unittest.TestCase):
@@ -25,6 +26,12 @@ class TestRootCauseStep(unittest.TestCase):
                 project_id=1,
                 repos=[],
                 issue=IssueDetails(id=0, title="", events=[error_event]),
+                issue_summary=IssueSummary(
+                    reason_step_by_step=[],
+                    summary_of_the_issue_based_on_your_step_by_step_reasoning="summary",
+                    summary_of_the_functionality_affected="impact",
+                    five_to_ten_word_headline="headline",
+                )
             )
         )
 

--- a/tests/automation/autofix/test_autofix_context.py
+++ b/tests/automation/autofix/test_autofix_context.py
@@ -26,7 +26,8 @@ from seer.automation.models import (
     ThreadDetails,
 )
 from seer.automation.state import LocalMemoryState
-from seer.db import DbPrIdToAutofixRunIdMapping, Session
+from seer.automation.summarize.issue import IssueSummary
+from seer.db import DbIssueSummary, DbPrIdToAutofixRunIdMapping, Session
 
 
 class TestAutofixContext(unittest.TestCase):
@@ -123,6 +124,39 @@ class TestAutofixContext(unittest.TestCase):
         self.autofix_context._process_stacktrace_paths.assert_any_call(
             mock_event.threads[0].stacktrace
         )
+
+    def test_get_issue_summary(self):
+        with Session() as session:
+            valid_summary_data = {
+                "summary_of_the_issue_based_on_your_step_by_step_reasoning": "summary",
+                "summary_of_the_functionality_affected": "impact",
+                "reason_step_by_step": [],
+                "five_to_ten_word_headline": "headline",
+            }
+            db_issue_summary = DbIssueSummary(group_id=0, summary=valid_summary_data)
+            session.add(db_issue_summary)
+            session.commit()
+
+        instance = self.autofix_context
+
+        result = instance.get_issue_summary()
+
+        self.assertIsNotNone(result)
+        self.assertIsInstance(result, IssueSummary)
+        self.assertEqual(
+            result.summary_of_the_issue_based_on_your_step_by_step_reasoning, "summary"
+        )
+        self.assertEqual(result.summary_of_the_functionality_affected, "impact")
+        self.assertEqual(result.five_to_ten_word_headline, "headline")
+
+        with Session() as session:
+            invalid_summary_data = {"bad data": "uh oh"}
+            db_issue_summary = DbIssueSummary(group_id=0, summary=invalid_summary_data)
+            session.merge(db_issue_summary)
+            session.commit()
+
+        result = instance.get_issue_summary()
+        self.assertIsNone(result)
 
 
 class TestAutofixContextPrCommit(unittest.TestCase):

--- a/tests/automation/summarize/test_issue.py
+++ b/tests/automation/summarize/test_issue.py
@@ -4,7 +4,7 @@ import pytest
 from johen import generate
 
 from seer.automation.models import IssueDetails
-from seer.automation.summarize.issue import run_summarize_issue, summarize_issue
+from seer.automation.summarize.issue import IssueSummary, run_summarize_issue, summarize_issue
 from seer.automation.summarize.models import SummarizeIssueRequest, SummarizeIssueResponse
 
 
@@ -22,24 +22,26 @@ class TestSummarizeIssue:
 
     def test_summarize_issue_success(self, mock_gpt_client, sample_request):
         mock_structured_completion = MagicMock()
-        mock_structured_completion.choices[0].message.parsed = MagicMock(
+        mock_raw_summary = MagicMock(
             reason_step_by_step=[],
             summary_of_the_issue_based_on_your_step_by_step_reasoning="Test summary",
             summary_of_the_functionality_affected="Test functionality",
             five_to_ten_word_headline="Test headline",
         )
+        mock_structured_completion.choices[0].message.parsed = mock_raw_summary
         mock_structured_completion.choices[0].message.refusal = None
         mock_gpt_client.openai_client.beta.chat.completions.parse.return_value = (
             mock_structured_completion
         )
 
-        result = summarize_issue(sample_request, gpt_client=mock_gpt_client)
+        result, raw_result = summarize_issue(sample_request, gpt_client=mock_gpt_client)
 
         assert isinstance(result, SummarizeIssueResponse)
         assert result.group_id == 1
         assert result.summary == "Test summary"
         assert result.impact == "Test functionality"
         assert result.headline == "Test headline"
+        assert raw_result == mock_raw_summary
 
     def test_summarize_issue_refusal(self, mock_gpt_client, sample_request):
         mock_structured_completion = MagicMock()
@@ -112,6 +114,11 @@ class TestRunSummarizeIssue:
     def test_run_summarize_issue_langfuse_metadata(self, mock_summarize_issue):
         mock_summarize_issue.return_value = SummarizeIssueResponse(
             group_id=1, headline="headline", summary="summary", impact="impact"
+        ), IssueSummary(
+            reason_step_by_step=[],
+            summary_of_the_issue_based_on_your_step_by_step_reasoning="summary",
+            summary_of_the_functionality_affected="impact",
+            five_to_ten_word_headline="headline",
         )
 
         # Create a sample request
@@ -138,6 +145,11 @@ class TestRunSummarizeIssue:
     def test_run_summarize_issue_langfuse_metadata_no_org_slug(self, mock_summarize_issue):
         mock_summarize_issue.return_value = SummarizeIssueResponse(
             group_id=1, headline="headline", summary="summary", impact="impact"
+        ), IssueSummary(
+            reason_step_by_step=[],
+            summary_of_the_issue_based_on_your_step_by_step_reasoning="summary",
+            summary_of_the_functionality_affected="impact",
+            five_to_ten_word_headline="headline",
         )
 
         # Create a sample request without organization_slug


### PR DESCRIPTION
This PR includes:

1. Changing the issue summary storage logic to store the raw output `IssueSummary` from GPT, rather than the trimmed `SummarizeIssueResponse` as before. The extra info, such as `reason_step_by_step` is useful.
2. Pass the issue summary to Autofix as additional context. (part of #998) Remove pre-processing step on event details as well. Improvement in evals: 0.48/0.52 -> 0.51/0.55
3. Allow optional issue summary in `AutofixRequest` to support new eval dataset