### PR TITLE
Making codecov super token available for the moment

### DIFF
--- a/src/seer/configuration.py
+++ b/src/seer/configuration.py
@@ -69,6 +69,9 @@ class AppConfig(BaseModel):
 
     SMOKE_CHECK: ParseBool = False
 
+    # Super access token for developing against, won't be available in final production setup.
+    CODECOV_SUPER_TOKEN: str = ""
+
     @cached_property
     def smoke_test_id(self) -> str:
         return str(uuid.uuid4())


### PR DESCRIPTION
I'll share 1password links to add this to your local environments, and I'll get this in staging
In production we'll have IAP which I'm working on.