### PR TITLE
chore(anomaly_detection) Handle timeseries with very low variance

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -16,6 +16,9 @@ coverage:
       trend_detection:
         paths:
           - 'src/seer/trend_detection/'
+      anomaly_detection:
+        paths:
+          - 'src/seer/anomaly_detection/'
       app:
         paths:
           - 'src/seer/app.py'

--- a/src/seer/anomaly_detection/anomaly_detection_di.py
+++ b/src/seer/anomaly_detection/anomaly_detection_di.py
@@ -1,8 +1,8 @@
 from seer.anomaly_detection.accessors import AlertDataAccessor, DbAlertDataAccessor
 from seer.anomaly_detection.detectors import (
     MinMaxNormalizer,
+    MPCascadingScorer,
     MPConfig,
-    MPIRQScorer,
     MPScorer,
     MPUtils,
     Normalizer,
@@ -22,7 +22,7 @@ def alert_data_accessor_provider() -> AlertDataAccessor:
 
 @anomaly_detection_module.provider
 def mp_scorer_provider() -> MPScorer:
-    return MPIRQScorer()
+    return MPCascadingScorer()
 
 
 @anomaly_detection_module.provider

--- a/src/seer/anomaly_detection/detectors/__init__.py
+++ b/src/seer/anomaly_detection/detectors/__init__.py
@@ -16,7 +16,7 @@ WindowSizeSelector = window_size_selectors.WindowSizeSelector
 SuSSWindowSizeSelector = window_size_selectors.SuSSWindowSizeSelector
 FlagsAndScores = mp_scorers.FlagsAndScores
 MPScorer = mp_scorers.MPScorer
-MPIRQScorer = mp_scorers.MPIRQScorer
+MPIRQScorer = mp_scorers.MPIQRScorer
 MPCascadingScorer = mp_scorers.MPCascadingScorer
 
 Normalizer = normalizers.Normalizer

--- a/src/seer/anomaly_detection/detectors/__init__.py
+++ b/src/seer/anomaly_detection/detectors/__init__.py
@@ -8,16 +8,16 @@ from seer.anomaly_detection.detectors import (
 )
 
 AnomalyDetector = anomaly_detectors.AnomalyDetector
-DummyAnomalyDetector = anomaly_detectors.DummyAnomalyDetector
 MPConfig = mp_config.MPConfig
 MPBatchAnomalyDetector = anomaly_detectors.MPBatchAnomalyDetector
 MPStreamAnomalyDetector = anomaly_detectors.MPStreamAnomalyDetector
 
 WindowSizeSelector = window_size_selectors.WindowSizeSelector
 SuSSWindowSizeSelector = window_size_selectors.SuSSWindowSizeSelector
-
+FlagsAndScores = mp_scorers.FlagsAndScores
 MPScorer = mp_scorers.MPScorer
 MPIRQScorer = mp_scorers.MPIRQScorer
+MPCascadingScorer = mp_scorers.MPCascadingScorer
 
 Normalizer = normalizers.Normalizer
 MinMaxNormalizer = normalizers.MinMaxNormalizer

--- a/src/seer/anomaly_detection/detectors/mp_scorers.py
+++ b/src/seer/anomaly_detection/detectors/mp_scorers.py
@@ -54,7 +54,7 @@ class LowVarianceScorer(MPScorer):
     """
 
     variance_threshold: float = Field(
-        0.0001, description="Minimum variance required in order to use IRQ based scoring"
+        0.0001, description="Minimum variance required in order to use IQR based scoring"
     )
 
     def _to_flag_and_score(
@@ -108,7 +108,7 @@ class LowVarianceScorer(MPScorer):
         return FlagsAndScores(flags=[flag], scores=[score])
 
 
-class MPIRQScorer(MPScorer):
+class MPIQRScorer(MPScorer):
 
     def batch_score(
         self,
@@ -266,11 +266,11 @@ class MPIRQScorer(MPScorer):
 
 class MPCascadingScorer(MPScorer):
     """
-    This class combines the results of the LowVarianceScorer and the MPIRQScorer.
+    This class combines the results of the LowVarianceScorer and the MPIQRScorer.
     """
 
     scorers: list[MPScorer] = Field(
-        [LowVarianceScorer(), MPIRQScorer()], description="The list of scorers to cascade"
+        [LowVarianceScorer(), MPIQRScorer()], description="The list of scorers to cascade"
     )
 
     def batch_score(

--- a/src/seer/anomaly_detection/detectors/mp_scorers.py
+++ b/src/seer/anomaly_detection/detectors/mp_scorers.py
@@ -1,13 +1,21 @@
 import abc
 import logging
+from typing import Optional
 
 import numpy as np
 import numpy.typing as npt
-from pydantic import BaseModel
+import sentry_sdk
+from pydantic import BaseModel, Field
 
 from seer.anomaly_detection.models import AnomalyFlags, Directions, Sensitivities
+from seer.tags import AnomalyDetectionTags
 
 logger = logging.getLogger(__name__)
+
+
+class FlagsAndScores(BaseModel):
+    flags: list[AnomalyFlags]
+    scores: list[float]
 
 
 class MPScorer(BaseModel, abc.ABC):
@@ -23,21 +31,81 @@ class MPScorer(BaseModel, abc.ABC):
         sensitivity: Sensitivities,
         direction: Directions,
         window_size: int,
-    ) -> tuple:
+    ) -> Optional[FlagsAndScores]:
         return NotImplemented
 
     @abc.abstractmethod
     def stream_score(
         self,
-        ts_value: float,
-        mp_dist: float,
+        ts_streamed: np.float64,
+        mp_dist_streamed: np.float64,
+        ts_history: npt.NDArray[np.float64],
+        mp_dist_history: npt.NDArray[np.float64],
         sensitivity: Sensitivities,
         direction: Directions,
         window_size: int,
-        ts_baseline: npt.NDArray[np.float64],
-        mp_dist_baseline: npt.NDArray[np.float64],
-    ) -> tuple:
+    ) -> Optional[FlagsAndScores]:
         return NotImplemented
+
+
+class LowVarianceScorer(MPScorer):
+    """
+    This class scores anomalies using mean if the series has a low variance.
+    """
+
+    variance_threshold: float = Field(
+        0.0001, description="Minimum variance required in order to use IRQ based scoring"
+    )
+
+    def _to_flag_and_score(
+        self, val: np.float64, ts_mean: np.float64
+    ) -> tuple[AnomalyFlags, float]:
+        if abs(val) >= 2 * abs(ts_mean):
+            return "anomaly_higher_confidence", 0.9
+        return "none", 0.0
+
+    def batch_score(
+        self,
+        ts: npt.NDArray[np.float64],
+        mp_dist: npt.NDArray[np.float64],
+        sensitivity: Sensitivities,
+        direction: Directions,
+        window_size: int,
+    ) -> Optional[FlagsAndScores]:
+        ts_variance = ts.var()
+        ts_mean = ts.mean()
+        scores = []
+        flags = []
+        if ts_variance > self.variance_threshold:
+            sentry_sdk.set_tag(AnomalyDetectionTags.LOW_VARIANCE_TS, 0)
+            return None
+
+        sentry_sdk.set_tag(AnomalyDetectionTags.LOW_VARIANCE_TS, 1)
+        for val in ts:
+            # if current value is significantly higher or lower than the mean then mark it as high anomaly else mark it as no anomaly
+            flag, score = self._to_flag_and_score(val, ts_mean)
+            flags.append(flag)
+            scores.append(score)
+        return FlagsAndScores(flags=flags, scores=scores)
+
+    def stream_score(
+        self,
+        ts_streamed: np.float64,
+        mp_dist_streamed: np.float64,
+        ts_history: npt.NDArray[np.float64],
+        mp_dist_history: npt.NDArray[np.float64],
+        sensitivity: Sensitivities,
+        direction: Directions,
+        window_size: int,
+    ) -> Optional[FlagsAndScores]:
+        context = ts_history[-2 * window_size :]
+        context_var = context.var()
+        if context_var > self.variance_threshold:
+            return None
+        # if current value is significantly higher or lower than the mean then mark it as high anomaly else mark it as no anomaly
+        flag, score = self._to_flag_and_score(ts_streamed, context.mean())
+
+        return FlagsAndScores(flags=[flag], scores=[score])
 
 
 class MPIRQScorer(MPScorer):
@@ -49,7 +117,7 @@ class MPIRQScorer(MPScorer):
         sensitivity: Sensitivities,
         direction: Directions,
         window_size: int,
-    ) -> tuple:
+    ) -> FlagsAndScores:
         """
         Scores anomalies by computing the distance of the relevant MP distance from quartiles. This approach is not swayed by
         extreme values in MP distances. It also converts the score to a flag with a more meaningful interpretation of score.
@@ -71,6 +139,9 @@ class MPIRQScorer(MPScorer):
             * "anomaly_lower_confidence" - indicating anomaly but only with a lower threshold
             * "anomaly_higher_confidence" - indicating anomaly with a higher threshold
         """
+        scores: list[float] = []
+        flags: list[AnomalyFlags] = []
+
         # Stumpy returns inf for the first timeseries[0:window_size - 2] entries. We just need to ignore those before scoring.
         mp_dist_baseline_finite = mp_dist[np.isfinite(mp_dist)]
 
@@ -84,8 +155,6 @@ class MPIRQScorer(MPScorer):
         threshold_upper = Q3 + (1.5 * IQR_L)
 
         # Compute score and anomaly flags
-        scores = []
-        flags = []
         for i, val in enumerate(mp_dist):
             scores.append(0.0 if np.isnan(val) or np.isinf(val) else val - threshold_upper)
             flag = self._to_flag(val, threshold_lower, threshold_upper)
@@ -95,18 +164,18 @@ class MPIRQScorer(MPScorer):
                 )
             flags.append(flag)
 
-        return scores, flags
+        return FlagsAndScores(flags=flags, scores=scores)
 
     def stream_score(
         self,
-        ts_value: float,
-        mp_dist: float,
+        ts_streamed: np.float64,
+        mp_dist_streamed: np.float64,
+        ts_history: npt.NDArray[np.float64],
+        mp_dist_history: npt.NDArray[np.float64],
         sensitivity: Sensitivities,
         direction: Directions,
         window_size: int,
-        ts_baseline: npt.NDArray[np.float64],
-        mp_dist_baseline: npt.NDArray[np.float64],
-    ) -> tuple:
+    ) -> FlagsAndScores:
         """
         Scores anomalies by computing the distance of the relevant MP distance from quartiles. This approach is not swayed by
         extreme values in MP distances. It also converts the score to a flag with a more meaningful interpretation of score.
@@ -131,7 +200,7 @@ class MPIRQScorer(MPScorer):
             * "anomaly_higher_confidence" - indicating anomaly with a higher threshold
         """
         # Stumpy returns inf for the first timeseries[0:window_size - 2] entries. We just need to ignore those before scoring.
-        mp_dist_baseline_finite = mp_dist_baseline[np.isfinite(mp_dist_baseline)]
+        mp_dist_baseline_finite = mp_dist_history[np.isfinite(mp_dist_history)]
 
         # Compute the quantiles for two different threshold levels
         [Q1, Q3] = np.quantile(mp_dist_baseline_finite, [0.25, 0.75])
@@ -143,13 +212,18 @@ class MPIRQScorer(MPScorer):
         threshold_upper = Q3 + (1.5 * IQR_L)
 
         # Compute score and anomaly flags
-        score = 0.0 if np.isnan(mp_dist) or np.isinf(mp_dist) else mp_dist - threshold_upper
-        flag = self._to_flag(mp_dist, threshold_lower, threshold_upper)
+        score = (
+            0.0
+            if np.isnan(mp_dist_streamed) or np.isinf(mp_dist_streamed)
+            else mp_dist_streamed - threshold_upper
+        )
+        flag = self._to_flag(mp_dist_streamed, threshold_lower, threshold_upper)
         # anomaly identified. apply logic to check for peak and trough
-        flag = self._adjust_flag_for_vicinity(ts_value, flag, ts_baseline[-2 * window_size :])
-        return [score], [flag]
+        flag = self._adjust_flag_for_vicinity(ts_streamed, flag, ts_history[-2 * window_size :])
 
-    def _to_flag(self, mp_dist: float, threshold_lower: float, threshold_upper: float):
+        return FlagsAndScores(flags=[flag], scores=[score])
+
+    def _to_flag(self, mp_dist: np.float64, threshold_lower: float, threshold_upper: float):
         if np.isnan(mp_dist):
             return "none"
         if mp_dist < threshold_lower:
@@ -159,7 +233,7 @@ class MPIRQScorer(MPScorer):
         return "anomaly_higher_confidence"
 
     def _adjust_flag_for_vicinity(
-        self, ts_value: float, flag: AnomalyFlags, context: npt.NDArray[np.float64]
+        self, ts_value: np.float64, flag: AnomalyFlags, context: npt.NDArray[np.float64]
     ) -> AnomalyFlags:
         """
         This method adjusts the severity of a detected anomaly based on the underlying time step's proximity to peaks and troughs.
@@ -188,3 +262,51 @@ class MPIRQScorer(MPScorer):
         #     else:
         #         flag = "anomaly_higher_confidence"
         return flag
+
+
+class MPCascadingScorer(MPScorer):
+    """
+    This class combines the results of the LowVarianceScorer and the MPIRQScorer.
+    """
+
+    scorers: list[MPScorer] = Field(
+        [LowVarianceScorer(), MPIRQScorer()], description="The list of scorers to cascade"
+    )
+
+    def batch_score(
+        self,
+        ts: npt.NDArray[np.float64],
+        mp_dist: npt.NDArray[np.float64],
+        sensitivity: Sensitivities,
+        direction: Directions,
+        window_size: int,
+    ) -> Optional[FlagsAndScores]:
+        for scorer in self.scorers:
+            flags_and_scores = scorer.batch_score(ts, mp_dist, sensitivity, direction, window_size)
+            if flags_and_scores is not None:
+                return flags_and_scores
+        return None
+
+    def stream_score(
+        self,
+        ts_streamed: np.float64,
+        mp_dist_streamed: np.float64,
+        ts_history: npt.NDArray[np.float64],
+        mp_dist_history: npt.NDArray[np.float64],
+        sensitivity: Sensitivities,
+        direction: Directions,
+        window_size: int,
+    ) -> Optional[FlagsAndScores]:
+        for scorer in self.scorers:
+            flags_and_scores = scorer.stream_score(
+                ts_streamed,
+                mp_dist_streamed,
+                ts_history,
+                mp_dist_history,
+                sensitivity,
+                direction,
+                window_size,
+            )
+            if flags_and_scores is not None:
+                return flags_and_scores
+        return None

--- a/src/seer/anomaly_detection/detectors/normalizers.py
+++ b/src/seer/anomaly_detection/detectors/normalizers.py
@@ -18,4 +18,9 @@ class Normalizer(BaseModel, abc.ABC):
 class MinMaxNormalizer(Normalizer):
     def normalize(self, array: npt.NDArray) -> npt.NDArray:
         """Applies min-max normalization to input array"""
+        if array.var() == 0:
+            if array[0] == 0:
+                return array
+            else:
+                return np.full_like(array, 1.0)
         return (array - np.min(array)) / (np.max(array) - np.min(array))

--- a/src/seer/tags.py
+++ b/src/seer/tags.py
@@ -1,0 +1,14 @@
+from enum import StrEnum
+
+
+class AnomalyDetectionTags(StrEnum):
+    ALERT_ID = "alert_id"
+    MODE = "mode"
+    LOW_VARIANCE_TS = "low_variance_ts"
+    WINDOW_SEARCH_FAILED = "window_search_failed"
+
+
+class AnomalyDetectionModes(StrEnum):
+    STREAMING_ALERT = "streaming.alert"
+    STREAMING_TS_WITH_HISTORY = "streaming.ts_with_history"
+    BATCH_TS_FULL = "batch.ts_full"

--- a/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
+++ b/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
@@ -3,14 +3,21 @@ from unittest.mock import MagicMock, patch
 
 import numpy as np
 
+from seer.anomaly_detection.detectors import (
+    FlagsAndScores,
+    MPCascadingScorer,
+    MPConfig,
+    MPUtils,
+    SuSSWindowSizeSelector,
+)
 from seer.anomaly_detection.detectors.anomaly_detectors import (
     MPBatchAnomalyDetector,
     MPStreamAnomalyDetector,
 )
-from seer.anomaly_detection.detectors.mp_config import MPConfig
 from seer.anomaly_detection.models import MPTimeSeriesAnomalies
 from seer.anomaly_detection.models.external import AnomalyDetectionConfig
 from seer.anomaly_detection.models.timeseries import TimeSeries
+from seer.exceptions import ServerError
 from tests.seer.anomaly_detection.test_utils import convert_synthetic_ts
 
 
@@ -34,9 +41,9 @@ class TestMPBatchAnomalyDetector(unittest.TestCase):
         # Mock to return dummy values
         mock_stump.return_value = np.array([1, 2, 3, 4])
         self.scorer.batch_score = MagicMock(
-            return_value=(
-                [0.1, 6.5, 4.8, 0.2],
-                ["none", "anomaly_higher_confidence", "anomaly_higher_confidence", "none"],
+            return_value=FlagsAndScores(
+                scores=[0.1, 6.5, 4.8, 0.2],
+                flags=["none", "anomaly_higher_confidence", "anomaly_higher_confidence", "none"],
             )
         )
 
@@ -76,6 +83,27 @@ class TestMPBatchAnomalyDetector(unittest.TestCase):
         self.ws_selector.optimal_window_size.assert_called_once()
         self.mp_utils.get_mp_dist_from_mp.assert_called_once()
 
+    def test_invalid_window_size(self):
+
+        timeseries, mp_dists, window_sizes = convert_synthetic_ts(
+            "tests/seer/anomaly_detection/test_data/synthetic_series", as_ts_datatype=False
+        )
+
+        ts_values, _, _ = timeseries[0], mp_dists[0], window_sizes[0]
+        ts = TimeSeries(timestamps=np.array([]), values=ts_values)
+
+        self.ws_selector.optimal_window_size = MagicMock(return_value=-1)
+
+        with self.assertRaises(ServerError, msg="Invalid window size"):
+            self.detector._compute_matrix_profile(
+                ts,
+                self.config,
+                ws_selector=self.ws_selector,
+                mp_config=self.mp_config,
+                scorer=self.scorer,
+                mp_utils=self.mp_utils,
+            )
+
 
 class TestMPStreamAnomalyDetector(unittest.TestCase):
 
@@ -92,6 +120,7 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
         self.config = AnomalyDetectionConfig(
             time_period=15, sensitivity="low", direction="up", expected_seasonality="auto"
         )  # TODO: Placeholder values as not used in detection yet
+        self.mp_config = MPConfig(ignore_trivial=False, normalize_mp=False)
 
     @patch("stumpy.stumpi")
     @patch("seer.anomaly_detection.detectors.MPScorer")
@@ -109,7 +138,7 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
 
         mock_utils.get_mp_dist_from_mp.return_value = np.array([0.1, 0.2])
 
-        mock_scorer.stream_score.return_value = ([0.5], ["none"])
+        mock_scorer.stream_score.return_value = FlagsAndScores(scores=[0.5], flags=["none"])
 
         anomalies = self.detector.detect(self.timeseries, self.config, mock_scorer, mock_utils)
 
@@ -123,3 +152,117 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
         assert len(anomalies.matrix_profile) == 3
         mock_scorer.stream_score.assert_called()
         mock_stream.update.assert_called()
+
+    def _detect_anomalies(self, history_ts, stream_ts):
+        batch_detector = MPBatchAnomalyDetector()
+        history_ts_timestamps = np.arange(1.0, len(history_ts) + 1)
+        stream_ts_timestamps = np.array(list(range(1, len(stream_ts) + 1))) + len(history_ts)
+        batch_anomalies = batch_detector._compute_matrix_profile(
+            timeseries=TimeSeries(timestamps=history_ts_timestamps, values=np.array(history_ts)),
+            config=self.config,
+            ws_selector=SuSSWindowSizeSelector(),
+            mp_config=self.mp_config,
+            scorer=MPCascadingScorer(),
+            mp_utils=MPUtils(),
+        )
+        stream_detector = MPStreamAnomalyDetector(
+            base_timestamps=np.array(history_ts_timestamps),
+            base_values=np.array(history_ts),
+            base_mp=batch_anomalies.matrix_profile,
+            window_size=batch_anomalies.window_size,
+        )
+        stream_anomalies = stream_detector.detect(
+            timeseries=TimeSeries(timestamps=stream_ts_timestamps, values=np.array(stream_ts)),
+            config=self.config,
+            scorer=MPCascadingScorer(),
+            mp_utils=MPUtils(),
+        )
+        return batch_anomalies, stream_anomalies
+
+    def test_stream_detect_spiked_history_spiked_stream_long_ts(self):
+        history_ts = [0.5] * 200
+        history_ts[-115] = 1.0
+        stream_ts = [0.5, 0.5, 1.2, *[0.5] * 10]
+        expected_stream_flags = [
+            "none",
+            "none",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "none",
+            "none",
+            "none",
+            "none",
+            "none",
+            "none",
+            "none",
+        ]
+        history_anomalies, stream_anomalies = self._detect_anomalies(history_ts, stream_ts)
+        assert history_anomalies.window_size == 90
+        assert stream_anomalies.flags == expected_stream_flags
+
+    def test_stream_detect_spiked_history_spiked_stream(self):
+        history_ts = [0.5] * 20
+        history_ts[-15] = 1.0  # Spiked history
+        stream_ts = [0.5, 0.5, 1.0, *[0.5] * 10]  # Spiked stream
+        expected_stream_flags = [
+            "none",
+            "none",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "none",
+            "none",
+            "none",
+            "none",
+        ]
+        history_anomalies, stream_anomalies = self._detect_anomalies(history_ts, stream_ts)
+        assert history_anomalies.window_size == 3
+        assert stream_anomalies.flags == expected_stream_flags
+
+    def test_stream_detect_flat_history_flat_stream(self):
+        history_ts = [0.5] * 200  # Flat history
+        stream_ts = [0.5] * 10  # Flat stream
+        expected_stream_flags = ["none"] * len(stream_ts)
+
+        history_anomalies, stream_anomalies = self._detect_anomalies(history_ts, stream_ts)
+        assert history_anomalies.window_size == 3
+        assert stream_anomalies.flags == expected_stream_flags
+
+    def test_stream_detect_flat_history_spiked_stream(self):
+        history_ts = [0.5] * 200  # Flat history
+        stream_ts = [0.5, 0.5, 1.0, *[0.5] * 10]  # Spiked stream
+        expected_stream_flags = [
+            "none",
+            "none",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "none",
+            "none",
+            "none",
+            "none",
+        ]
+
+        history_anomalies, stream_anomalies = self._detect_anomalies(history_ts, stream_ts)
+        assert history_anomalies.window_size == 3
+        assert stream_anomalies.flags == expected_stream_flags
+
+    def test_stream_detect_spliked_history_flat_stream(self):
+        history_ts = [0.5] * 200
+        history_ts[-15] = 1.0  # Spiked history
+        stream_ts = [0.5] * 10  # Flat stream
+        expected_stream_flags = ["none"] * 10
+
+        history_anomalies, stream_anomalies = self._detect_anomalies(history_ts, stream_ts)
+        assert history_anomalies.window_size == 132
+        assert stream_anomalies.flags == expected_stream_flags

--- a/tests/seer/anomaly_detection/detectors/test_mp_scorers.py
+++ b/tests/seer/anomaly_detection/detectors/test_mp_scorers.py
@@ -1,13 +1,13 @@
 import unittest
 
-from seer.anomaly_detection.detectors.mp_scorers import MPIRQScorer
+from seer.anomaly_detection.detectors.mp_scorers import MPCascadingScorer
 from tests.seer.anomaly_detection.test_utils import convert_synthetic_ts
 
 
 class TestMPScorers(unittest.TestCase):
 
     def setUp(self):
-        self.scorer = MPIRQScorer()
+        self.scorer = MPCascadingScorer()
 
     def test_batch_score_synthetic_data(self):
 
@@ -29,9 +29,11 @@ class TestMPScorers(unittest.TestCase):
             expected_types, timeseries, mp_dists, window_sizes, window_starts, window_ends
         ):
 
-            _, actual_flags = self.scorer.batch_score(
+            flags_and_scores = self.scorer.batch_score(
                 ts, mp_dist, sensitivity, direction, window_size
             )
+            assert flags_and_scores is not None
+            actual_flags = flags_and_scores.flags
 
             # Calculate percentage of anomaly flags in given range
             num_anomalies_detected = 0
@@ -63,14 +65,16 @@ class TestMPScorers(unittest.TestCase):
                 test_ts_val = ts_baseline[-1] * multiplier
                 test_mp_dist = mp_dist_baseline[-1] * abs(multiplier)
 
-                _, flag = self.scorer.stream_score(
+                flags_and_scores = self.scorer.stream_score(
                     test_ts_val,
                     test_mp_dist,
+                    ts_baseline,
+                    mp_dist_baseline,
                     sensitivity,
                     direction,
                     window_size,
-                    ts_baseline,
-                    mp_dist_baseline,
                 )
+                assert flags_and_scores is not None
+                actual_flags = flags_and_scores.flags
 
-                assert flag[0] == expected_flags[i]
+                assert actual_flags[0] == expected_flags[i]

--- a/tests/seer/anomaly_detection/detectors/test_nomalizers.py
+++ b/tests/seer/anomaly_detection/detectors/test_nomalizers.py
@@ -18,8 +18,14 @@ class TestNormalizer(unittest.TestCase):
         np.testing.assert_equal(result, expected)
 
     def test_normalize_identical_values(self):
-        array = np.array([3, 3, 3, 3])
-        expected = np.array([np.nan, np.nan, np.nan, np.nan])
+        array = np.array([3] * 4)
+        expected = np.array([1.0] * 4)
+        result = self.normalizer.normalize(array)
+        np.testing.assert_equal(result, expected)
+
+    def test_normalize_zeroes(self):
+        array = np.array([0] * 4)
+        expected = np.array([0.0] * 4)
         result = self.normalizer.normalize(array)
         np.testing.assert_equal(result, expected)
 
@@ -29,6 +35,6 @@ class TestNormalizer(unittest.TestCase):
 
     def test_single_element_array(self):
         array = np.array([10])
-        expected = np.array([np.nan])
+        expected = np.array([1.0])
         result = self.normalizer.normalize(array)
         np.testing.assert_equal(result, expected)

--- a/tests/seer/anomaly_detection/detectors/test_window_size_selectors.py
+++ b/tests/seer/anomaly_detection/detectors/test_window_size_selectors.py
@@ -13,8 +13,8 @@ class TestSuSSWindowSizeSelector(unittest.TestCase):
 
     def test_optimal_window_size_constant_series(self):
         ts = np.array([5.0] * 700)
-        with self.assertRaises(Exception, msg="Search for optimal window failed."):
-            self.selector.optimal_window_size(ts)
+        window_size = self.selector.optimal_window_size(ts)
+        assert window_size == 3
 
     def test_optimal_window_size_linear_series(self):
         ts = np.linspace(1, 100, 100)
@@ -25,8 +25,8 @@ class TestSuSSWindowSizeSelector(unittest.TestCase):
 
     def test_optimal_window_size_short_series(self):
         ts = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
-        with self.assertRaises(Exception, msg="Search for optimal window failed."):
-            self.selector.optimal_window_size(ts)
+        window_size = self.selector.optimal_window_size(ts)
+        assert window_size == 3
 
     def test_optimal_window_size(self):
 


### PR DESCRIPTION
This PR fixes two issues with anomaly detection logic with regards to time series with zero variance:
* SuSS logic for window size selection fails
* the interquartile range based scoring logic results in false positives

These two issues are fixed by
* defaulting the window size to 3 if SuSS logic fails
* using mean of a context window instead of IRQ for time series with low variance

It also includes additional changes to increase test coverage of anomaly detection code and additional tags to track frequency of low variance time series.