### PR TITLE
Adds per deployment beat configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
             - .env
         environment:
             - DEV=1
+            - AUTOFIX_ENABLED=1
             - SEVERITY_ENABLED=1
             - GROUPING_ENABLED=1
             - ANOMALY_DETECTION_ENABLED=1

--- a/src/celery_app/app.py
+++ b/src/celery_app/app.py
@@ -24,6 +24,9 @@ def init_celery_app(*args: Any, sender: Celery, config: CeleryConfig = injected,
     for k, v in config.items():
         setattr(sender.conf, k, v)
     bootup(start_model_loading=False, integrations=[CeleryIntegration(propagate_traces=True)])
+    from celery_app.tasks import setup_periodic_tasks
+
+    sender.on_after_finalize.connect(setup_periodic_tasks)
 
 
 setup_celery_entrypoint(celery_app)

--- a/src/celery_app/tasks.py
+++ b/src/celery_app/tasks.py
@@ -11,7 +11,6 @@ from seer.configuration import AppConfig
 from seer.dependency_injection import inject, injected
 
 
-@celery.on_after_finalize.connect
 @inject
 def setup_periodic_tasks(sender, config: AppConfig = injected, **kwargs):
     if config.is_autofix_enabled:

--- a/src/celery_app/tasks.py
+++ b/src/celery_app/tasks.py
@@ -7,18 +7,22 @@ from celery_app.app import celery_app as celery  # noqa: F401
 from celery_app.config import CeleryQueues
 from seer.automation.autofix.tasks import check_and_mark_recent_autofix_runs
 from seer.automation.tasks import delete_data_for_ttl
+from seer.configuration import AppConfig
+from seer.dependency_injection import inject, injected
 
 
 @celery.on_after_finalize.connect
-def setup_periodic_tasks(sender, **kwargs):
-    sender.add_periodic_task(
-        crontab(minute="0", hour="*"),
-        check_and_mark_recent_autofix_runs.signature(kwargs={}, queue=CeleryQueues.DEFAULT),
-        name="Check and mark recent autofix runs every hour",
-    )
+@inject
+def setup_periodic_tasks(sender, config: AppConfig = injected, **kwargs):
+    if config.is_autofix_enabled:
+        sender.add_periodic_task(
+            crontab(minute="0", hour="*"),
+            check_and_mark_recent_autofix_runs.signature(kwargs={}, queue=CeleryQueues.DEFAULT),
+            name="Check and mark recent autofix runs every hour",
+        )
 
-    sender.add_periodic_task(
-        crontab(minute="0", hour="0"),  # run once a day
-        delete_data_for_ttl.signature(kwargs={}, queue=CeleryQueues.DEFAULT),
-        name="Delete old Automation runs for 90 day time-to-live",
-    )
+        sender.add_periodic_task(
+            crontab(minute="0", hour="0"),  # run once a day
+            delete_data_for_ttl.signature(kwargs={}, queue=CeleryQueues.DEFAULT),
+            name="Delete old Automation runs for 90 day time-to-live",
+        )

--- a/src/seer/configuration.py
+++ b/src/seer/configuration.py
@@ -4,6 +4,7 @@ import uuid
 from functools import cached_property
 from typing import Annotated
 
+from celery.utils.nodenames import gethostname
 from pydantic import BaseModel, BeforeValidator, Field
 
 from seer.dependency_injection import Module
@@ -71,6 +72,37 @@ class AppConfig(BaseModel):
 
     # Super access token for developing against, won't be available in final production setup.
     CODECOV_SUPER_TOKEN: str = ""
+
+    ANOMALY_DETECTION_ENABLED: ParseBool = False
+    GROUPING_ENABLED: ParseBool = False
+    SEVERITY_ENABLED: ParseBool = False
+    AUTOFIX_ENABLED: ParseBool = False
+    HOSTNAME: str = Field(default_factory=gethostname)
+
+    # Test utility that disables deployment conditional behavior.
+    # Update this to reflect new kinds of conditional behavior by adding
+    # more test coverage and locking them in.
+    def disable_all(self):
+        self.ANOMALY_DETECTION_ENABLED = False
+        self.GROUPING_ENABLED = False
+        self.SEVERITY_ENABLED = False
+        self.AUTOFIX_ENABLED = False
+
+    @property
+    def is_severity_enabled(self):
+        return self.SEVERITY_ENABLED or "severity" in self.HOSTNAME
+
+    @property
+    def is_grouping_enabled(self):
+        return self.GROUPING_ENABLED
+
+    @property
+    def is_autofix_enabled(self):
+        return self.AUTOFIX_ENABLED or "autofix" in self.HOSTNAME
+
+    @property
+    def is_anomaly_detection_enabled(self):
+        return self.ANOMALY_DETECTION_ENABLED or "breakpoint" in self.HOSTNAME
 
     @cached_property
     def smoke_test_id(self) -> str:

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -4,69 +4,73 @@ import celery_app.tasks
 from celery_app.app import celery_app, setup_celery_entrypoint
 from celery_app.config import CeleryConfig
 from seer.configuration import AppConfig
-from seer.dependency_injection import resolve
+from seer.dependency_injection import Module, resolve
 
 
 # Validates the total sum of all celery jobs with the broadest configuration.
 def test_detected_celery_jobs():
-    assert set(k for k in celery_app.tasks.keys() if not k.startswith("celery.")) == set(
-        [
-            "seer.automation.autofix.steps.change_describer_step.autofix_change_describer_task",
-            "seer.automation.autofix.steps.coding_step.autofix_coding_task",
-            "seer.automation.autofix.steps.root_cause_step.root_cause_task",
-            "seer.automation.autofix.steps.steps.autofix_parallelized_chain_step_task",
-            "seer.automation.autofix.steps.steps.autofix_parallelized_conditional_step_task",
-            "seer.automation.autofix.tasks.run_autofix_evaluation_on_item",
-            "seer.automation.autofix.tasks.check_and_mark_recent_autofix_runs",
-            "seer.automation.codegen.unittest_step.unittest_task",
-            "seer.automation.tasks.delete_data_for_ttl",
-            "seer.smoke_test.smoke_test",
-        ]
-    )
+    with Module():
+        assert set(k for k in celery_app.tasks.keys() if not k.startswith("celery.")) == set(
+            [
+                "seer.automation.autofix.steps.change_describer_step.autofix_change_describer_task",
+                "seer.automation.autofix.steps.coding_step.autofix_coding_task",
+                "seer.automation.autofix.steps.root_cause_step.root_cause_task",
+                "seer.automation.autofix.steps.steps.autofix_parallelized_chain_step_task",
+                "seer.automation.autofix.steps.steps.autofix_parallelized_conditional_step_task",
+                "seer.automation.autofix.tasks.run_autofix_evaluation_on_item",
+                "seer.automation.autofix.tasks.check_and_mark_recent_autofix_runs",
+                "seer.automation.codegen.unittest_step.unittest_task",
+                "seer.automation.tasks.delete_data_for_ttl",
+                "seer.smoke_test.smoke_test",
+            ]
+        )
 
-    assert set(k for k in celery_app.conf.beat_schedule.keys()) == set(
-        [
-            "Check and mark recent autofix runs every hour",
-            "Delete old Automation runs for 90 day time-to-live",
-        ]
-    )
+        assert set(k for k in celery_app.conf.beat_schedule.keys()) == set(
+            [
+                "Check and mark recent autofix runs every hour",
+                "Delete old Automation runs for 90 day time-to-live",
+            ]
+        )
 
 
 def test_anomaly_beat_jobs():
-    app = Celery(__name__)
-    setup_celery_entrypoint(app)
-    app_config = resolve(AppConfig)
-    app_config.disable_all()
-    app_config.ANOMALY_DETECTION_ENABLED = True
-    app.finalize()
+    with Module():
+        app = Celery(__name__)
+        setup_celery_entrypoint(app)
+        app_config = resolve(AppConfig)
+        app_config.disable_all()
+        app_config.ANOMALY_DETECTION_ENABLED = True
+        app.finalize()
 
-    assert set(k for k in app.conf.beat_schedule.keys()) == set([])
+        assert set(k for k in app.conf.beat_schedule.keys()) == set([])
 
 
 def test_autofix_beat_jobs():
-    app = Celery(__name__)
-    setup_celery_entrypoint(app)
-    app_config = resolve(AppConfig)
-    app_config.disable_all()
-    app_config.AUTOFIX_ENABLED = True
-    app.finalize()
+    with Module():
+        app = Celery(__name__)
+        setup_celery_entrypoint(app)
+        app_config = resolve(AppConfig)
+        app_config.disable_all()
+        app_config.AUTOFIX_ENABLED = True
+        app.finalize()
 
-    assert set(k for k in app.conf.beat_schedule.keys()) == set(
-        [
-            "Check and mark recent autofix runs every hour",
-            "Delete old Automation runs for 90 day time-to-live",
-        ]
-    )
+        assert set(k for k in app.conf.beat_schedule.keys()) == set(
+            [
+                "Check and mark recent autofix runs every hour",
+                "Delete old Automation runs for 90 day time-to-live",
+            ]
+        )
 
 
 def test_celery_app_configuration():
-    app = Celery(__name__)
-    setup_celery_entrypoint(app)
-    assert not app.finalized
+    with Module():
+        app = Celery(__name__)
+        setup_celery_entrypoint(app)
+        assert not app.finalized
 
-    app.finalize()
-    celery_app.finalize()
-    assert app.conf.task_queues == resolve(CeleryConfig)["task_queues"]
-    assert celery_app.conf.task_queues == app.conf.task_queues
+        app.finalize()
+        celery_app.finalize()
+        assert app.conf.task_queues == resolve(CeleryConfig)["task_queues"]
+        assert celery_app.conf.task_queues == app.conf.task_queues
 
-    assert app.finalized
+        assert app.finalized


### PR DESCRIPTION
1.  Abstract the notion of deployment questions into the `AppConfig` object with new properties.  NOTE:  Deployments are not considered discrete, they can overlap, as per local development.
2.  Check for deployment type either by explicit environment variable or by the hostname (confirmed the deployment name in our k8s config reflects in production host names).
3.  Conditionalize beat tasks by deployments.
4.  Tests.  Add your new beat job to the anomaly detect test to validate it becomes a condiational beat task.