### PR TITLE
fix(autofix): PlanCode snippet and new file quick fixes

### DIFF
--- a/src/seer/automation/autofix/components/coding/models.py
+++ b/src/seer/automation/autofix/components/coding/models.py
@@ -28,7 +28,7 @@ class SnippetXml(PromptXmlModel, tag="snippet"):
 class CodeContextXml(PromptXmlModel, tag="code_context"):
     title: str = element()
     description: str = element()
-    snippet: SnippetXml = element()
+    snippet: SnippetXml | None = element(default=None)
 
     @classmethod
     def from_root_cause_context(cls, context: RootCauseRelevantContext):

--- a/src/seer/automation/autofix/components/coding/prompts.py
+++ b/src/seer/automation/autofix/components/coding/prompts.py
@@ -78,6 +78,7 @@ class CodingPrompts:
             - No placeholders are allowed, the steps must be clear and detailed.
             - Make sure you use the tools provided to look through the codebase and at the files you are changing before outputting the steps.
             - The plan must be comprehensive. Do not provide temporary examples, placeholders or incomplete steps.
+            - Make sure any new files you create don't already exist, if they do, modify the existing file.
             - EVERY TIME before you use a tool, think step-by-step each time before using the tools provided to you.
             - You also MUST think step-by-step before giving the final answer."""
         ).format(steps_example_str=PlanStepsPromptXml.get_example().to_prompt_str())


### PR DESCRIPTION
Two quick but impactful fixes for plan+code
1. Some root causes don't have a code snippet now, that was causing a lot of the errors
2. It often likes to create files that already exist, this is a preliminary prompting fix, will have more robust follow up fix

Reduces error rate in plan+code, but not all just yet

Before:
![CleanShot 2024-09-26 at 11 31 50](https://github.com/user-attachments/assets/6e04c50d-fc16-415a-bfb1-a56cb47ccbe7)
After:
![CleanShot 2024-09-26 at 11 29 48](https://github.com/user-attachments/assets/ab4c56d6-dbd1-445a-9a03-e02ca22a84ee)
