### PR TITLE
feat(autofix): Disable insights in evals

### DIFF
--- a/src/seer/automation/autofix/components/coding/component.py
+++ b/src/seer/automation/autofix/components/coding/component.py
@@ -37,10 +37,14 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
     @ai_track(description="Plan+Code")
     def invoke(self, request: CodingRequest) -> CodingOutput | None:
         tools = BaseTools(self.context)
+        state = self.context.state.get()
 
         agent = ClaudeAgent(
             tools=tools.get_tools(),
-            config=AgentConfig(system_prompt=CodingPrompts.format_system_msg(), interactive=True),
+            config=AgentConfig(
+                system_prompt=CodingPrompts.format_system_msg(),
+                interactive=not state.request.options.disable_interactive,
+            ),
         )
 
         task_str = (
@@ -48,8 +52,6 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
             if isinstance(request.root_cause_and_fix, RootCauseAnalysisItem)
             else request.root_cause_and_fix
         )
-
-        state = self.context.state.get()
 
         response = agent.run(
             CodingPrompts.format_fix_discovery_msg(

--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -31,17 +31,16 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
         self, request: RootCauseAnalysisRequest, gpt_client: GptClient = injected
     ) -> RootCauseAnalysisOutput | None:
         tools = BaseTools(self.context)
+        state = self.context.state.get()
 
         agent = GptAgent(
             tools=tools.get_tools(),
             config=AgentConfig(
                 system_prompt=RootCauseAnalysisPrompts.format_system_msg(),
                 max_iterations=24,
-                interactive=True,
+                interactive=not state.request.options.disable_interactive,
             ),
         )
-
-        state = self.context.state.get()
 
         try:
             response = agent.run(

--- a/src/seer/automation/autofix/evaluations.py
+++ b/src/seer/automation/autofix/evaluations.py
@@ -52,7 +52,7 @@ def sync_run_root_cause(item: DatasetItemClient):
 
     request = AutofixRequest.model_validate(item.input.get("request"))
 
-    request.options = AutofixRequestOptions(disable_codebase_indexing=True)
+    request.options = AutofixRequestOptions(disable_interactive=True)
 
     state = create_initial_autofix_run(request)
     with state.update() as cur:
@@ -78,7 +78,8 @@ def sync_run_root_cause(item: DatasetItemClient):
 @observe(name="Sync run execution evaluation on item")
 def sync_run_execution(item: DatasetItemClient):
     request = AutofixRequest.model_validate(item.input.get("request"))
-    request.options = AutofixRequestOptions(disable_codebase_indexing=True)
+
+    request.options = AutofixRequestOptions(disable_interactive=True)
 
     expected_output = RootCauseExpectedOutput.model_validate(
         {
@@ -154,7 +155,7 @@ def sync_run_evaluation_on_item(item: DatasetItemClient):
 
     request = AutofixRequest.model_validate(item.input.get("request"))
 
-    request.options = AutofixRequestOptions(disable_codebase_indexing=True)
+    request.options = AutofixRequestOptions(disable_interactive=True)
 
     state = create_initial_autofix_run(request)
     with state.update() as cur:

--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -248,7 +248,7 @@ class AutofixStepUpdateArgs(BaseModel):
 
 
 class AutofixRequestOptions(BaseModel):
-    disable_codebase_indexing: bool = False
+    disable_interactive: bool = False
 
 
 class AutofixRequest(BaseModel):


### PR DESCRIPTION
As we don't use insights in evals and it doesn't affect the end result, we disable them in evals via a request option to save both money and time