### PR TITLE
fix: update seer gocd script to update seer-gpu

### DIFF
--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -8,6 +8,12 @@ eval "$(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}
   --image="us-central1-docker.pkg.dev/sentryio/seer/image:${GO_REVISION_SEER_REPO}" \
   --container-name="seer"
 
+  /devinfra/scripts/k8s/k8stunnel \
+  && /devinfra/scripts/k8s/k8s-deploy.py \
+  --label-selector="service=seer-gpu" \
+  --image="us-central1-docker.pkg.dev/sentryio/seer/image:${GO_REVISION_SEER_REPO}" \
+  --container-name="seer-gpu"
+
 /devinfra/scripts/k8s/k8stunnel \
   && /devinfra/scripts/k8s/k8s-deploy.py \
   --label-selector="service=seer-autofix" \


### PR DESCRIPTION
right now i don't think our deploy script is updating the seer-gpu service. this should fix it.