### PR TITLE
feat(autofix): Plan+Code file handling and diff fixer

### DIFF
--- a/src/seer/automation/autofix/components/coding/component.py
+++ b/src/seer/automation/autofix/components/coding/component.py
@@ -88,7 +88,6 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
 
     @observe(name="Plan+Code")
     @ai_track(description="Plan+Code")
-    @inject
     def invoke(self, request: CodingRequest) -> CodingOutput | None:
         tools = BaseTools(self.context)
 

--- a/src/seer/automation/autofix/components/coding/models.py
+++ b/src/seer/automation/autofix/components/coding/models.py
@@ -148,3 +148,11 @@ class FuzzyDiffChunk(BaseModel):
     header: str
     original_chunk: str
     new_chunk: str
+    diff_content: str
+
+
+class FileMissingObj(BaseModel):
+    file_path: str
+    file_content: str
+    diff_chunks: list[FuzzyDiffChunk]
+    task: PlanTaskPromptXml

--- a/src/seer/automation/autofix/components/coding/prompts.py
+++ b/src/seer/automation/autofix/components/coding/prompts.py
@@ -1,7 +1,7 @@
 import textwrap
 from typing import Optional
 
-from seer.automation.autofix.components.coding.models import PlanStepsPromptXml
+from seer.automation.autofix.components.coding.models import FuzzyDiffChunk, PlanStepsPromptXml
 from seer.automation.autofix.prompts import format_instruction, format_repo_names, format_summary
 from seer.automation.summarize.issue import IssueSummary
 
@@ -83,3 +83,36 @@ class CodingPrompts:
             - EVERY TIME before you use a tool, think step-by-step each time before using the tools provided to you.
             - You also MUST think step-by-step before giving the final answer."""
         ).format(steps_example_str=PlanStepsPromptXml.get_example().to_prompt_str())
+
+    @staticmethod
+    def format_incorrect_diff_fixer(
+        file_path: str, diff_chunks: list[FuzzyDiffChunk], file_content: str
+    ):
+        return textwrap.dedent(
+            """\
+            Given the below file content:
+            <file path="{file_path}">
+            {file_content}
+            </file>
+
+            The following diffs were found to be incorrect:
+            {diff_chunks}
+
+            Provide the corrected unified diffs inside a <corrected_diffs></corrected_diffs> block:
+            """
+        ).format(
+            file_path=file_path,
+            file_content=file_content,
+            diff_chunks="\n".join([chunk.diff_content for chunk in diff_chunks]),
+        )
+
+    @staticmethod
+    def format_missing_msg(missing_files: list[str], existing_files: list[str]):
+        text = ""
+
+        if missing_files:
+            text += f"The following files don't exist: {', '.join(missing_files)}\n"
+        if existing_files:
+            text += f"The following files already exist: {', '.join(existing_files)}\n"
+
+        return text

--- a/src/seer/automation/autofix/components/coding/utils.py
+++ b/src/seer/automation/autofix/components/coding/utils.py
@@ -26,7 +26,7 @@ def extract_diff_chunks(diff_text: str) -> list[FuzzyDiffChunk]:
     current_original: list[str] = []
     current_new: list[str] = []
     current_header = ""
-    current_diff_contents = []
+    current_diff_contents: list[str] = []
 
     lines = diff_text.split("\n")
 

--- a/src/seer/automation/autofix/components/coding/utils.py
+++ b/src/seer/automation/autofix/components/coding/utils.py
@@ -26,6 +26,7 @@ def extract_diff_chunks(diff_text: str) -> list[FuzzyDiffChunk]:
     current_original: list[str] = []
     current_new: list[str] = []
     current_header = ""
+    current_diff_contents = []
 
     lines = diff_text.split("\n")
 
@@ -41,6 +42,7 @@ def extract_diff_chunks(diff_text: str) -> list[FuzzyDiffChunk]:
                         header=current_header,
                         original_chunk="\n".join(current_original),
                         new_chunk="\n".join(current_new),
+                        diff_content="\n".join(current_diff_contents),
                     )
                 )
                 current_original = []
@@ -53,6 +55,7 @@ def extract_diff_chunks(diff_text: str) -> list[FuzzyDiffChunk]:
         else:
             current_original.append(line[1:])
             current_new.append(line[1:])
+        current_diff_contents.append(line)
 
     if current_original or current_new:
         chunks.append(
@@ -60,6 +63,7 @@ def extract_diff_chunks(diff_text: str) -> list[FuzzyDiffChunk]:
                 header=current_header,
                 original_chunk="\n".join(current_original),
                 new_chunk="\n".join(current_new),
+                diff_content="\n".join(current_diff_contents),
             )
         )
 
@@ -118,7 +122,9 @@ def task_to_file_delete(task: PlanTaskPromptXml) -> FileChange:
 
 
 @observe(name="Convert task to file change")
-def task_to_file_change(task: PlanTaskPromptXml, file_content: str) -> list[FileChange]:
+def task_to_file_change(
+    task: PlanTaskPromptXml, file_content: str
+) -> tuple[list[FileChange], list[FuzzyDiffChunk]]:
     """
     Convert a PlanTaskPromptXml to a list of FileChange objects for file changes.
 
@@ -133,6 +139,7 @@ def task_to_file_change(task: PlanTaskPromptXml, file_content: str) -> list[File
         raise ValueError(f"Expected file_change task, got: {task.type}")
 
     changes = []
+    missing_changes: list[FuzzyDiffChunk] = []
     diff_chunks = extract_diff_chunks(task.diff)
 
     for chunk in diff_chunks:
@@ -163,5 +170,6 @@ def task_to_file_change(task: PlanTaskPromptXml, file_content: str) -> list[File
         else:
             logger.info(f"Original snippet not found in file {task.file_path}")
             append_langfuse_trace_tags(["skipped_file_change:snippet_not_found"])
+            missing_changes.append(chunk)
 
-    return changes
+    return changes, missing_changes

--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -36,7 +36,7 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
             config=AgentConfig(
                 system_prompt=RootCauseAnalysisPrompts.format_system_msg(),
                 max_iterations=24,
-                interactive=True,
+                interactive=False,
             ),
             memory=request.initial_memory,
         )

--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -36,7 +36,7 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
             config=AgentConfig(
                 system_prompt=RootCauseAnalysisPrompts.format_system_msg(),
                 max_iterations=24,
-                interactive=False,
+                interactive=True,
             ),
             memory=request.initial_memory,
         )

--- a/src/seer/automation/autofix/utils.py
+++ b/src/seer/automation/autofix/utils.py
@@ -1,11 +1,15 @@
 import difflib
 import random
 import re
+from functools import lru_cache
+
+from langfuse.decorators import observe
 
 VALID_BRANCH_NAME_CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-"
 
 
-def compute_similarity(text1: str, text2: str, ignore_whitespace=True) -> float:
+@lru_cache(maxsize=1024)
+def compute_similarity_cached(text1: str, text2: str, ignore_whitespace=True) -> float:
     """
     This function computes the similarity between two pieces of text using the difflib.SequenceMatcher class.
 
@@ -43,6 +47,7 @@ def get_last_non_empty_line(text: str) -> str:
     return ""
 
 
+@observe(name="Find original snippet")
 def find_original_snippet(
     snippet: str, file_contents: str, threshold=0.8, initial_line_threshold=0.9
 ) -> tuple[str, int, int] | None:
@@ -75,8 +80,8 @@ def find_original_snippet(
 
     # Search for a matching initial line in the file
     for start_index, file_line in enumerate(file_lines):
-        if compute_similarity(first_snippet_line, file_line) >= initial_line_threshold:
-            accumulated_snippet = ""
+        if compute_similarity_cached(first_snippet_line, file_line) >= initial_line_threshold:
+            accumulated_snippet = []
             snippet_index = 0
             file_index = start_index
 
@@ -87,9 +92,9 @@ def find_original_snippet(
                     file_index += 1
                     continue
 
-                accumulated_snippet += file_line + "\n"
-                similarity = compute_similarity(
-                    "\n".join(snippet_lines[: snippet_index + 1]), accumulated_snippet
+                accumulated_snippet.append(file_line)
+                similarity = compute_similarity_cached(
+                    "\n".join(snippet_lines[: snippet_index + 1]), "\n".join(accumulated_snippet)
                 )
 
                 if similarity >= threshold:

--- a/src/seer/langfuse.py
+++ b/src/seer/langfuse.py
@@ -38,4 +38,22 @@ def append_langfuse_trace_tags(new_tags: list[str], langfuse: Langfuse = injecte
         logger.exception(e)
 
 
+@inject
+def append_langfuse_observation_metadata(new_metadata: dict, langfuse: Langfuse = injected):
+    """
+    Appends metadata to the current observation in the context.
+    MUST BE RUN WITHIN A LANGFUSE OBSERVATION!
+    """
+    try:
+        observation_id = langfuse_context.get_current_observation_id()
+        if observation_id:
+            observation = langfuse.get_observation(observation_id)
+
+            langfuse_context.update_current_observation(
+                metadata=(observation.metadata or {}) | new_metadata,
+            )
+    except Exception as e:
+        logger.exception(e)
+
+
 langfuse_module.enable()

--- a/tests/automation/autofix/components/coding/test_coding_component.py
+++ b/tests/automation/autofix/components/coding/test_coding_component.py
@@ -1,0 +1,203 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from seer.automation.agent.client import ClaudeClient
+from seer.automation.autofix.autofix_context import AutofixContext
+from seer.automation.autofix.components.coding.component import CodingComponent
+from seer.automation.autofix.components.coding.models import (
+    FileMissingObj,
+    FuzzyDiffChunk,
+    PlanTaskPromptXml,
+)
+from seer.automation.models import FileChange
+from seer.dependency_injection import Module
+
+
+class TestCodingComponent:
+    @pytest.fixture
+    def component(self):
+        mock_context = MagicMock(spec=AutofixContext)
+        mock_context.state = MagicMock()
+        mock_context.skip_loading_codebase = True
+        component = CodingComponent(mock_context)
+        component._append_file_change = MagicMock()
+        return component
+
+    @pytest.fixture
+    def mock_claude_client(self):
+        return MagicMock(spec=ClaudeClient)
+
+    def test_handle_missing_file_changes_success(self, component, mock_claude_client):
+        missing_changes = {
+            "file1.py": FileMissingObj(
+                file_path="file1.py",
+                file_content="original content",
+                diff_chunks=[
+                    FuzzyDiffChunk(
+                        header="chunk1",
+                        original_chunk="original content",
+                        new_chunk="new content",
+                        diff_content="diff content",
+                    )
+                ],
+                task=PlanTaskPromptXml(
+                    description="description",
+                    commit_message="commit message",
+                    file_path="file1.py",
+                    repo_name="test_repo",
+                    type="file_change",
+                    diff="old diff",
+                ),
+            )
+        }
+
+        mock_claude_client.completion.return_value = (
+            MagicMock(content="<corrected_diffs>new diff</corrected_diffs>"),
+            MagicMock(),
+        )
+
+        mock_repo_client = MagicMock()
+        mock_repo_client.repo_external_id = "test_repo_id"
+        component.context.get_repo_client.return_value = mock_repo_client
+
+        with patch(
+            "seer.automation.autofix.components.coding.component.task_to_file_change"
+        ) as mock_task_to_file_change:
+            mock_task_to_file_change.return_value = (
+                [
+                    FileChange(
+                        path="file1.py",
+                        change_type="edit",
+                        reference_snippet="old",
+                        new_snippet="new",
+                    )
+                ],
+                [],
+            )
+
+            module = Module()
+            module.constant(ClaudeClient, mock_claude_client)
+            with module:
+                component._handle_missing_file_changes(missing_changes)
+
+        component.context.state.update.assert_called()
+        mock_claude_client.completion.assert_called_once()
+        mock_task_to_file_change.assert_called_once()
+        component._append_file_change.assert_called_once_with(
+            "test_repo_id",
+            FileChange(
+                path="file1.py", change_type="edit", reference_snippet="old", new_snippet="new"
+            ),
+        )
+
+    def test_handle_missing_file_changes_no_content(self, component, mock_claude_client):
+        missing_changes = {
+            "file1.py": FileMissingObj(
+                file_path="file1.py",
+                file_content="original content",
+                diff_chunks=[
+                    FuzzyDiffChunk(
+                        header="chunk1",
+                        original_chunk="original content",
+                        new_chunk="new content",
+                        diff_content="diff content",
+                    )
+                ],
+                task=PlanTaskPromptXml(
+                    description="description",
+                    commit_message="commit message",
+                    file_path="file1.py",
+                    repo_name="test_repo",
+                    type="file_change",
+                    diff="old diff",
+                ),
+            )
+        }
+
+        mock_claude_client.completion.return_value = (MagicMock(content=None), MagicMock())
+
+        module = Module()
+        module.constant(ClaudeClient, mock_claude_client)
+        with module:
+            component._handle_missing_file_changes(missing_changes)
+
+        component.context.state.update.assert_called()
+        mock_claude_client.completion.assert_called_once()
+        component._append_file_change.assert_not_called()
+
+    def test_handle_missing_file_changes_with_remaining_missing_changes(
+        self, component, mock_claude_client
+    ):
+        missing_changes = {
+            "file1.py": FileMissingObj(
+                file_path="file1.py",
+                file_content="original content",
+                diff_chunks=[
+                    FuzzyDiffChunk(
+                        header="chunk1",
+                        original_chunk="original content",
+                        new_chunk="new content",
+                        diff_content="diff content",
+                    )
+                ],
+                task=PlanTaskPromptXml(
+                    description="description",
+                    commit_message="commit message",
+                    file_path="file1.py",
+                    repo_name="test_repo",
+                    type="file_change",
+                    diff="old diff",
+                ),
+            )
+        }
+
+        mock_claude_client.completion.return_value = (
+            MagicMock(content="<corrected_diffs>new diff</corrected_diffs>"),
+            MagicMock(),
+        )
+
+        mock_repo_client = MagicMock()
+        mock_repo_client.repo_external_id = "test_repo_id"
+        component.context.get_repo_client.return_value = mock_repo_client
+
+        with (
+            patch(
+                "seer.automation.autofix.components.coding.component.task_to_file_change"
+            ) as mock_task_to_file_change,
+            patch(
+                "seer.automation.autofix.components.coding.component.append_langfuse_observation_metadata"
+            ) as mock_append_metadata,
+            patch(
+                "seer.automation.autofix.components.coding.component.append_langfuse_trace_tags"
+            ) as mock_append_tags,
+        ):
+
+            mock_task_to_file_change.return_value = (
+                [
+                    FileChange(
+                        path="file1.py",
+                        change_type="edit",
+                        reference_snippet="old",
+                        new_snippet="new",
+                    )
+                ],
+                ["remaining_chunk"],
+            )
+
+            module = Module()
+            module.constant(ClaudeClient, mock_claude_client)
+            with module:
+                component._handle_missing_file_changes(missing_changes)
+
+        component.context.state.update.assert_called()
+        mock_claude_client.completion.assert_called_once()
+        mock_task_to_file_change.assert_called_once()
+        component._append_file_change.assert_called_once_with(
+            "test_repo_id",
+            FileChange(
+                path="file1.py", change_type="edit", reference_snippet="old", new_snippet="new"
+            ),
+        )
+        mock_append_metadata.assert_called_once_with({"missing_changes_count": 1})
+        mock_append_tags.assert_called_once_with(["missing_changes_count:1"])

--- a/tests/automation/autofix/components/coding/test_coding_utils.py
+++ b/tests/automation/autofix/components/coding/test_coding_utils.py
@@ -211,7 +211,7 @@ class TestTaskToFileChange:
             commit_message="Modify existing_function in existing_file.py",
         )
         file_content = "def existing_function():\n    return 'Hello'\n"
-        result = task_to_file_change(task, file_content)
+        result = task_to_file_change(task, file_content)[0]
         assert len(result) == 1
         assert isinstance(result[0], FileChange)
         assert result[0].change_type == "edit"
@@ -238,7 +238,7 @@ class TestTaskToFileChange:
                     print("Hello")
             """
         )
-        result = task_to_file_change(task, file_content)
+        result = task_to_file_change(task, file_content)[0]
         assert len(result) == 1
         assert isinstance(result[0], FileChange)
         assert result[0].change_type == "edit"
@@ -269,7 +269,7 @@ class TestTaskToFileChange:
         )
         file_content = "def existing_function():\n    return 'Hello'\n"
         result = task_to_file_change(task, file_content)
-        assert len(result) == 0
+        assert len(result[0]) == 0
 
     def test_multiple_chunks(self):
         task = PlanTaskPromptXml(
@@ -282,6 +282,6 @@ class TestTaskToFileChange:
         )
         file_content = "def func1():\n    return 'Old1'\n\ndef func2():\n    return 'Old2'\n"
         result = task_to_file_change(task, file_content)
-        assert len(result) == 2
-        assert result[0].new_snippet == "def func1():\n    return 'New1'"
-        assert result[1].new_snippet == "def func2():\n    return 'New2'"
+        assert len(result[0]) == 2
+        assert result[0][0].new_snippet == "def func1():\n    return 'New1'"
+        assert result[0][1].new_snippet == "def func2():\n    return 'New2'"


### PR DESCRIPTION
Makes plan+code agent much more reliable with
1. Handle incorrect file operations (edit file that doesn't exist, create file that already exists, etc)
2. Fix incorrect diffs

We now have a 0% plan/code error rate and much lower missing change rate

Before:
![CleanShot 2024-09-27 at 10 53 22@2x](https://github.com/user-attachments/assets/fadb3b42-c998-4191-8a70-6c26e915d607)
After:
![CleanShot 2024-09-27 at 10 50 51@2x](https://github.com/user-attachments/assets/50ac9240-3989-4fd6-81b5-15273a598f38)
