### PR TITLE
(autofix): Generate insight cards on separate thread async

### DIFF
--- a/src/seer/automation/agent/agent.py
+++ b/src/seer/automation/agent/agent.py
@@ -86,11 +86,14 @@ class LlmAgent(ABC):
             )
         )
         if insight_card:
-            with context.state.update() as cur:
-                if cur.steps and isinstance(cur.steps[-1], DefaultStep):
-                    step = cur.steps[-1]
-                    step.insights.append(insight_card)
-                    cur.steps[-1] = step
+            if len(context.state.get().get_all_insights()) == len(
+                past_insights
+            ):  # in case something else was added in parallel, don't add this insight
+                with context.state.update() as cur:
+                    if cur.steps and isinstance(cur.steps[-1], DefaultStep):
+                        step = cur.steps[-1]
+                        step.insights.append(insight_card)
+                        cur.steps[-1] = step
 
     def run_iteration(self, context: Optional[AutofixContext] = None):
         logger.debug(f"----[{self.name}] Running Iteration {self.iterations}----")

--- a/tests/automation/agent/test_agent.py
+++ b/tests/automation/agent/test_agent.py
@@ -159,7 +159,8 @@ class TestGptAgent:
         return context
 
     @patch("seer.automation.agent.agent.InsightSharingComponent")
-    def test_run_iteration(self, mock_insight_sharing, agent, mock_context):
+    @patch("seer.automation.agent.agent.threading.Thread")
+    def test_run_iteration(self, mock_thread, mock_insight_sharing, agent, mock_context):
         # Mock the message and usage
         mock_message = Message(role="assistant", content="Test response")
         mock_usage = Usage(completion_tokens=10, prompt_tokens=20, total_tokens=30)
@@ -170,7 +171,10 @@ class TestGptAgent:
         mock_insight_sharing_instance = MagicMock()
         mock_insight_sharing_instance.invoke.return_value = mock_insight_card
         mock_insight_sharing.return_value = mock_insight_sharing_instance
-        agent.call_tool = MagicMock(return_value=None)
+
+        # Mock the threading.Thread
+        mock_thread_instance = MagicMock()
+        mock_thread.return_value = mock_thread_instance
 
         # Run the method
         agent.run_iteration(context=mock_context)
@@ -181,18 +185,25 @@ class TestGptAgent:
         assert agent.memory[0] == mock_message
         assert agent.usage == mock_usage
 
+        # Check if a new thread was created for insight sharing
+        mock_thread.assert_called_once()
+        assert mock_thread.call_args[1]["target"] == agent.share_insights
+        assert isinstance(mock_thread.call_args[1]["args"][0], AutofixContext)
+        assert isinstance(mock_thread.call_args[1]["args"][1], str)
+
+        # Check if the thread was started
+        mock_thread_instance.start.assert_called_once()
+
+        # To test the share insights method, we need to call it directly
+        agent.share_insights(mock_context, "Test response")
+
         # Check if insight sharing was called
         mock_insight_sharing.assert_called_once_with(mock_context)
         mock_insight_sharing_instance.invoke.assert_called_once()
         assert isinstance(
             mock_insight_sharing_instance.invoke.call_args[0][0], InsightSharingRequest
         )
-
-        # Check if the insight was added to the step
-        assert mock_context.state.get().steps[-1].insights[-1] == mock_insight_card
-
-        # Check if tool calls were not made
-        agent.call_tool.assert_not_called()
+        mock_context.state.update.assert_called_once()
 
     def test_run_iteration_with_queued_user_messages(self, agent, mock_client, mock_context):
         # Create a mock step with queued_user_messages as a list of strings

--- a/tests/automation/agent/test_agent.py
+++ b/tests/automation/agent/test_agent.py
@@ -159,7 +159,7 @@ class TestGptAgent:
         return context
 
     @patch("seer.automation.agent.agent.InsightSharingComponent")
-    @patch("seer.automation.agent.agent.threading.Thread")
+    @patch("seer.automation.agent.agent.LlmAgent.run_in_thread")
     def test_run_iteration(self, mock_thread, mock_insight_sharing, agent, mock_context):
         # Mock the message and usage
         mock_message = Message(role="assistant", content="Test response")
@@ -172,10 +172,6 @@ class TestGptAgent:
         mock_insight_sharing_instance.invoke.return_value = mock_insight_card
         mock_insight_sharing.return_value = mock_insight_sharing_instance
 
-        # Mock the threading.Thread
-        mock_thread_instance = MagicMock()
-        mock_thread.return_value = mock_thread_instance
-
         # Run the method
         agent.run_iteration(context=mock_context)
 
@@ -187,12 +183,9 @@ class TestGptAgent:
 
         # Check if a new thread was created for insight sharing
         mock_thread.assert_called_once()
-        assert mock_thread.call_args[1]["target"] == agent.share_insights
+        assert mock_thread.call_args[1]["func"] == agent.share_insights
         assert isinstance(mock_thread.call_args[1]["args"][0], AutofixContext)
         assert isinstance(mock_thread.call_args[1]["args"][1], str)
-
-        # Check if the thread was started
-        mock_thread_instance.start.assert_called_once()
 
         # To test the share insights method, we need to call it directly
         agent.share_insights(mock_context, "Test response")

--- a/tests/automation/autofix/components/test_insight_sharing.py
+++ b/tests/automation/autofix/components/test_insight_sharing.py
@@ -48,11 +48,14 @@ class TestInsightSharingComponent:
         )
         mock_completion_2.choices[0].message.refusal = None
 
-        mock_gpt_client.openai_client.chat.completions.create.return_value = mock_completion_1
-        mock_gpt_client.openai_client.beta.chat.completions.parse.return_value = mock_completion_2
+        mock_gpt_client.return_value.openai_client.chat.completions.create.return_value = (
+            mock_completion_1
+        )
+        mock_gpt_client.return_value.openai_client.beta.chat.completions.parse.return_value = (
+            mock_completion_2
+        )
 
-        result = component.invoke(request, gpt_client=mock_gpt_client)
-
+        result = component.invoke(request)
         assert isinstance(result, InsightSharingOutput)
         assert result.insight == "New insight"
         assert result.justification == "Test explanation"
@@ -72,9 +75,11 @@ class TestInsightSharingComponent:
         mock_completion = MagicMock()
         mock_completion.choices[0].message.content = "<NO_INSIGHT/>"
 
-        mock_gpt_client.openai_client.chat.completions.create.return_value = mock_completion
+        mock_gpt_client.return_value.openai_client.chat.completions.create.return_value = (
+            mock_completion
+        )
 
-        result = component.invoke(request, gpt_client=mock_gpt_client)
+        result = component.invoke(request)
 
         assert result is None
 
@@ -93,8 +98,12 @@ class TestInsightSharingComponent:
         mock_completion_2 = MagicMock()
         mock_completion_2.choices[0].message.refusal = "Test refusal"
 
-        mock_gpt_client.openai_client.chat.completions.create.return_value = mock_completion_1
-        mock_gpt_client.openai_client.beta.chat.completions.parse.return_value = mock_completion_2
+        mock_gpt_client.return_value.openai_client.chat.completions.create.return_value = (
+            mock_completion_1
+        )
+        mock_gpt_client.return_value.openai_client.beta.chat.completions.parse.return_value = (
+            mock_completion_2
+        )
 
         # make sure no error is raised
-        component.invoke(request, gpt_client=mock_gpt_client)
+        component.invoke(request)

--- a/tests/automation/autofix/components/test_insight_sharing.py
+++ b/tests/automation/autofix/components/test_insight_sharing.py
@@ -48,14 +48,10 @@ class TestInsightSharingComponent:
         )
         mock_completion_2.choices[0].message.refusal = None
 
-        mock_gpt_client.return_value.openai_client.chat.completions.create.return_value = (
-            mock_completion_1
-        )
-        mock_gpt_client.return_value.openai_client.beta.chat.completions.parse.return_value = (
-            mock_completion_2
-        )
+        mock_gpt_client.openai_client.chat.completions.create.return_value = mock_completion_1
+        mock_gpt_client.openai_client.beta.chat.completions.parse.return_value = mock_completion_2
 
-        result = component.invoke(request)
+        result = component.invoke(request, mock_gpt_client)
         assert isinstance(result, InsightSharingOutput)
         assert result.insight == "New insight"
         assert result.justification == "Test explanation"
@@ -75,11 +71,9 @@ class TestInsightSharingComponent:
         mock_completion = MagicMock()
         mock_completion.choices[0].message.content = "<NO_INSIGHT/>"
 
-        mock_gpt_client.return_value.openai_client.chat.completions.create.return_value = (
-            mock_completion
-        )
+        mock_gpt_client.openai_client.chat.completions.create.return_value = mock_completion
 
-        result = component.invoke(request)
+        result = component.invoke(request, mock_gpt_client)
 
         assert result is None
 
@@ -98,12 +92,8 @@ class TestInsightSharingComponent:
         mock_completion_2 = MagicMock()
         mock_completion_2.choices[0].message.refusal = "Test refusal"
 
-        mock_gpt_client.return_value.openai_client.chat.completions.create.return_value = (
-            mock_completion_1
-        )
-        mock_gpt_client.return_value.openai_client.beta.chat.completions.parse.return_value = (
-            mock_completion_2
-        )
+        mock_gpt_client.openai_client.chat.completions.create.return_value = mock_completion_1
+        mock_gpt_client.openai_client.beta.chat.completions.parse.return_value = mock_completion_2
 
         # make sure no error is raised
-        component.invoke(request)
+        component.invoke(request, mock_gpt_client)


### PR DESCRIPTION
Before, insight cards would be generated on every iteration synchronously, slowing down the whole experience. Now, they're generated in a separate thread, so it's a lot faster.

Also, a smattering of prompt engineering is included in this PR.