### PR TITLE
feat(autofix): Add unit test to root cause output

### DIFF
--- a/src/seer/automation/autofix/components/coding/models.py
+++ b/src/seer/automation/autofix/components/coding/models.py
@@ -9,6 +9,7 @@ from seer.automation.autofix.components.root_cause.models import (
     RootCauseAnalysisItem,
     RootCauseRelevantContext,
 )
+from seer.automation.autofix.utils import remove_code_backticks
 from seer.automation.component import BaseComponentOutput, BaseComponentRequest
 from seer.automation.models import EventDetails, PromptXmlModel
 from seer.automation.summarize.issue import IssueSummary
@@ -85,12 +86,7 @@ class PlanTaskPromptXml(PromptXmlModel, tag="step"):
     @field_validator("diff")
     @classmethod
     def clean_diff(cls, v: str) -> str:
-        lines = v.split("\n")
-        if lines and lines[0].startswith("```"):
-            lines = lines[1:]
-        if lines and lines[-1].strip() == "```":
-            lines = lines[:-1]
-        return "\n".join(lines).strip()
+        return remove_code_backticks(v)
 
     @classmethod
     def get_example(

--- a/src/seer/automation/autofix/components/root_cause/models.py
+++ b/src/seer/automation/autofix/components/root_cause/models.py
@@ -1,9 +1,10 @@
 from typing import Annotated, Optional
 
-from pydantic import BaseModel, StringConstraints
+from pydantic import BaseModel, StringConstraints, field_validator
 from pydantic_xml import attr
 
 from seer.automation.agent.models import Message
+from seer.automation.autofix.utils import remove_code_backticks
 from seer.automation.component import BaseComponentOutput, BaseComponentRequest
 from seer.automation.models import EventDetails, PromptXmlModel
 from seer.automation.summarize.issue import IssueSummary
@@ -36,22 +37,41 @@ class RootCauseRelevantContext(BaseModel):
     snippet: Optional[RootCauseRelevantCodeSnippet]
 
 
+class RootCauseAnalysisRelevantContext(BaseModel):
+    snippets: list[RootCauseRelevantContext]
+
+
+class UnitTestSnippetPrompt(BaseModel):
+    file_path: str
+    code_snippet: str
+    description: str
+
+    @field_validator("code_snippet")
+    @classmethod
+    def clean_code_snippet(cls, v: str) -> str:
+        return remove_code_backticks(v)
+
+
+class UnitTestSnippet(BaseModel):
+    file_path: str
+    snippet: str
+    description: str
+
+
 class RootCauseAnalysisItem(BaseModel):
     id: int = -1
     title: str
     description: str
-    reproduction: str
+    unit_test: UnitTestSnippet | None = None
+    reproduction: str | None = None
     code_context: Optional[list[RootCauseRelevantContext]] = None
-
-
-class RootCauseAnalysisRelevantContext(BaseModel):
-    snippets: list[RootCauseRelevantContext]
 
 
 class RootCauseAnalysisItemPrompt(BaseModel):
     title: str
     description: str
-    reproduction: str
+    reproduction_instructions: str | None = None
+    unit_test: UnitTestSnippetPrompt | None = None
     relevant_code: Optional[RootCauseAnalysisRelevantContext]
 
     @classmethod
@@ -59,7 +79,16 @@ class RootCauseAnalysisItemPrompt(BaseModel):
         return cls(
             title=model.title,
             description=model.description,
-            reproduction=model.reproduction,
+            reproduction_instructions=model.reproduction,
+            unit_test=(
+                UnitTestSnippetPrompt(
+                    file_path=model.unit_test.file_path,
+                    code_snippet=model.unit_test.snippet,
+                    description=model.unit_test.description,
+                )
+                if model.unit_test
+                else None
+            ),
             relevant_code=(
                 RootCauseAnalysisRelevantContext(
                     snippets=[
@@ -81,6 +110,16 @@ class RootCauseAnalysisItemPrompt(BaseModel):
         return RootCauseAnalysisItem.model_validate(
             {
                 **self.model_dump(),
+                "reproduction": self.reproduction_instructions,
+                "unit_test": (
+                    {
+                        "file_path": self.unit_test.file_path,
+                        "snippet": self.unit_test.code_snippet,
+                        "description": self.unit_test.description,
+                    }
+                    if self.unit_test
+                    else None
+                ),
                 "code_context": (
                     self.relevant_code.model_dump()["snippets"] if self.relevant_code else None
                 ),

--- a/src/seer/automation/autofix/components/root_cause/prompts.py
+++ b/src/seer/automation/autofix/components/root_cause/prompts.py
@@ -69,8 +69,9 @@ class RootCauseAnalysisPrompts:
     def reproduction_prompt_msg():
         return textwrap.dedent(
             """\
-            Given all the above potential root causes you just gave, please provide 1-2 sentence instructions on how to reproduce the issue, then turn it into a concise unit test that reproduces the issue for each root cause. Make sure you follow any existing testing framework and patterns.
+            Given all the above potential root causes you just gave, please provide 1-2 sentence instructions on how to reproduce the issue, then turn it into a concise unit test that tests for the issue for each root cause.
             - This test should intentionally fail if the issue is not fixed. It will pass if the issue is fixed.
+            - Look through the codebase to find the most relevant tests to the root cause. Make sure you follow any existing testing framework and patterns.
             - For the reproduction instructions, assume the user is an experienced developer well-versed in the codebase, simply give a concise explanation of how to reproduce the issue.
             - Do not mention the unit test in the reproduction instructions, they are separate.
             - You must use the local variables provided to you in the stacktrace to give your reproduction steps.

--- a/src/seer/automation/autofix/components/root_cause/prompts.py
+++ b/src/seer/automation/autofix/components/root_cause/prompts.py
@@ -69,8 +69,10 @@ class RootCauseAnalysisPrompts:
     def reproduction_prompt_msg():
         return textwrap.dedent(
             """\
-            Given all the above potential root causes you just gave, please provide a 1-2 sentence concise instruction on how to reproduce the issue for each root cause.
-            - Assume the user is an experienced developer well-versed in the codebase, simply give the reproduction steps.
+            Given all the above potential root causes you just gave, please provide 1-2 sentence instructions on how to reproduce the issue, then turn it into a concise unit test that reproduces the issue for each root cause. Make sure you follow any existing testing framework and patterns.
+            - This test should intentionally fail if the issue is not fixed. It will pass if the issue is fixed.
+            - For the reproduction instructions, assume the user is an experienced developer well-versed in the codebase, simply give a concise explanation of how to reproduce the issue.
+            - Do not mention the unit test in the reproduction instructions, they are separate.
             - You must use the local variables provided to you in the stacktrace to give your reproduction steps.
             - Try to be open ended to allow for the most flexibility in reproducing the issue. Avoid being too confident.
             - This step is optional, if you're not sure about the reproduction steps for a root cause, just skip it."""

--- a/src/seer/automation/autofix/utils.py
+++ b/src/seer/automation/autofix/utils.py
@@ -122,3 +122,13 @@ def sanitize_branch_name(title: str) -> str:
 def generate_random_string(n=6) -> str:
     """Generate a random n character string."""
     return "".join(random.choice(VALID_BRANCH_NAME_CHARS) for _ in range(n))
+
+
+def remove_code_backticks(text: str) -> str:
+    """Remove code backticks from a string."""
+    lines = text.split("\n")
+    if lines and lines[0].strip().startswith("```"):
+        lines = lines[1:]
+    if lines and lines[-1].strip().startswith("```"):
+        lines = lines[:-1]
+    return "\n".join(lines).strip()

--- a/tests/automation/autofix/components/test_root_cause.py
+++ b/tests/automation/autofix/components/test_root_cause.py
@@ -48,7 +48,7 @@ class TestRootCauseComponent:
                                 cause=RootCauseAnalysisItemPrompt(
                                     title="Missing Null Check",
                                     description="The root cause of the issue is ...",
-                                    reproduction="Steps to reproduce",
+                                    reproduction_instructions="Steps to reproduce",
                                     relevant_code=None,
                                 )
                             ),


### PR DESCRIPTION
Adds a simple unit test that reproduces (intentionally failing) to the root cause output. The goal for this is to easily be copied.

![CleanShot 2024-10-01 at 14 59 26@2x](https://github.com/user-attachments/assets/ca55a20b-d0be-49c9-8f99-86c855208e10)
