### PR TITLE
[fix] Increase Anthropic max output size and fix test generation output

### DIFF
--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -186,7 +186,7 @@ class ClaudeClient(LlmClient):
         params: dict[str, Any] = {
             "model": model,
             "temperature": 0.0,
-            "max_tokens": 4096,
+            "max_tokens": 8192,
             "messages": claude_messages,
         }
         if system_prompt:

--- a/src/seer/automation/autofix/components/coding/prompts.py
+++ b/src/seer/automation/autofix/components/coding/prompts.py
@@ -69,7 +69,7 @@ class CodingPrompts:
             """\
             Break down the task of fixing the issue into steps. Your list of steps should be detailed enough so that following it exactly will lead to a fully complete solution.
 
-            When ready with your final answer, detail the precise plan to accomplish the task wrapped with a <plan_steps></plan_steps> block. Your output must follow the format properly according to the following guidelines:
+            Enclose this plan between <plan_steps> and </plan_steps> tags. Make sure to strictly follow this format and include all necessary details within the tags. Your output must follow the format properly according to the following guidelines:
 
             {steps_example_str}
 

--- a/src/seer/automation/codegen/unit_test_coding_component.py
+++ b/src/seer/automation/codegen/unit_test_coding_component.py
@@ -101,7 +101,6 @@ class UnitTestCodingComponent(BaseComponent[CodeUnitTestRequest, CodeUnitTestOut
 
         if not coding_output.tasks:
             raise ValueError("No tasks found in coding output")
-
         file_changes: list[FileChange] = []
         for task in coding_output.tasks:
             repo_client = self.context.get_repo_client(task.repo_name)
@@ -111,8 +110,9 @@ class UnitTestCodingComponent(BaseComponent[CodeUnitTestRequest, CodeUnitTestOut
                     logger.warning(f"Failed to get content for {task.file_path}")
                     continue
 
-                for change in task_to_file_change(task, file_content):
-                    file_changes.append(change)
+                # TODO: Handle missing changes
+                changes, _ = task_to_file_change(task, file_content)
+                file_changes += changes
             elif task.type == "file_delete":
                 change = task_to_file_delete(task)
                 file_changes.append(change)
@@ -121,5 +121,4 @@ class UnitTestCodingComponent(BaseComponent[CodeUnitTestRequest, CodeUnitTestOut
                 file_changes.append(change)
             else:
                 logger.warning(f"Unsupported task type: {task.type}")
-
         return CodeUnitTestOutput(diffs=file_changes)


### PR DESCRIPTION
The response from Claude was being truncated due to the smaller token size. 

This PR also fixes an issue where the incorrect type was being passed into `CodeUnitTestOutput`. It should only take in a list of `FileChange` types. 