### PR TITLE
feat(autofix): Add controllable insights chain

### DIFF
--- a/src/seer/app.py
+++ b/src/seer/app.py
@@ -30,6 +30,7 @@ from seer.automation.autofix.tasks import (
     get_autofix_state,
     get_autofix_state_from_pr_id,
     receive_user_message,
+    restart_from_point_with_feedback,
     run_autofix_create_pr,
     run_autofix_evaluation,
     run_autofix_execution,
@@ -181,6 +182,8 @@ def autofix_update_endpoint(
         run_autofix_create_pr(data)
     elif data.payload.type == AutofixUpdateType.USER_MESSAGE:
         receive_user_message(data)
+    elif data.payload.type == AutofixUpdateType.RESTART_FROM_POINT_WITH_FEEDBACK:
+        restart_from_point_with_feedback(data)
     return AutofixEndpointResponse(started=True, run_id=data.run_id)
 
 

--- a/src/seer/automation/agent/agent.py
+++ b/src/seer/automation/agent/agent.py
@@ -71,7 +71,16 @@ class LlmAgent(ABC):
         # adds any queued user messages to the memory
         user_msgs = context.state.get().steps[-1].queued_user_messages
         if user_msgs:
-            self.memory.append(Message(content="\n".join(user_msgs), role="user"))
+            # enforce alternating user/assistant messages
+            msg = "\n".join(user_msgs)
+            for item in reversed(self.memory):
+                if item.role == "user":
+                    self.memory.append(Message(content=".", role="assistant"))
+                    break
+                elif item.role == "assistant":
+                    break
+            self.memory.append(Message(content=msg, role="user"))
+
             with context.state.update() as cur:
                 cur.steps[-1].queued_user_messages = []
             context.event_manager.add_log("Thanks for the input. I'm thinking through it now...")

--- a/src/seer/automation/autofix/components/coding/component.py
+++ b/src/seer/automation/autofix/components/coding/component.py
@@ -118,6 +118,7 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
                 else None
             ),
             context=self.context,
+            name="plan_and_code",
         )
 
         prev_usage = agent.usage

--- a/src/seer/automation/autofix/components/insight_sharing/component.py
+++ b/src/seer/automation/autofix/components/insight_sharing/component.py
@@ -125,6 +125,7 @@ class InsightSharingComponent(BaseComponent[InsightSharingRequest, InsightSharin
                 codebase_context=res.codebase_context,
                 stacktrace_context=res.stacktrace_context,
                 breadcrumb_context=res.event_log_context,
+                generated_at_memory_index=request.generated_at_memory_index,
             )
             return response
         except Exception:

--- a/src/seer/automation/autofix/components/insight_sharing/models.py
+++ b/src/seer/automation/autofix/components/insight_sharing/models.py
@@ -41,6 +41,7 @@ class InsightSharingRequest(BaseComponentRequest):
     task_description: str
     memory: list[Message]
     past_insights: list[str]
+    generated_at_memory_index: int
 
 
 class InsightSharingOutput(BaseComponentOutput):
@@ -50,3 +51,4 @@ class InsightSharingOutput(BaseComponentOutput):
     stacktrace_context: list[StacktraceContext]
     breadcrumb_context: list[BreadcrumbContext]
     justification: str
+    generated_at_memory_index: int

--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -67,12 +67,14 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
                 return None
 
             # Ask for reproduction
+            self.context.event_manager.add_log("Thinking about how to reproduce the issue...")
             agent.run(
                 RootCauseAnalysisPrompts.reproduction_prompt_msg(),
             )
 
             self.context.store_memory("root_cause_analysis", agent.memory)
 
+            self.context.event_manager.add_log("Cleaning up my findings...")
             response = gpt_client.openai_client.beta.chat.completions.parse(
                 messages=[
                     message.to_message()

--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -56,6 +56,7 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
                     else None
                 ),
                 context=self.context,
+                name="root_cause_analysis",
             )
 
             if not response:

--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -65,6 +65,8 @@ class AutofixEventManager:
         with self.state.update() as cur:
             cur_step = cur.find_or_add(step)
             cur_step.status = AutofixStatus.PROCESSING
+            cur_step.progress = []
+            cur_step.completedMessage = None
             cur.status = AutofixStatus.PROCESSING
 
     def send_root_cause_analysis_will_start(self):

--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -66,7 +66,7 @@ class AutofixEventManager:
             cur_step = cur.find_or_add(step)
             cur_step.status = AutofixStatus.PROCESSING
             cur_step.progress = []
-            cur_step.completedMessage = None
+            cur_step.completedMessage = None  # type: ignore[assignment]
             cur.status = AutofixStatus.PROCESSING
 
     def send_root_cause_analysis_will_start(self):

--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -1,5 +1,6 @@
 import dataclasses
 import logging
+import time
 
 from seer.automation.autofix.components.coding.models import CodingOutput
 from seer.automation.autofix.components.root_cause.models import RootCauseAnalysisOutput
@@ -18,6 +19,7 @@ from seer.automation.autofix.models import (
     Step,
 )
 from seer.automation.state import State
+from seer.automation.utils import make_kill_signal
 
 logger = logging.getLogger(__name__)
 
@@ -206,3 +208,30 @@ class AutofixEventManager:
     def clear_file_changes(self):
         with self.state.update() as cur:
             cur.clear_file_changes()
+
+    def reset_steps_to_point(
+        self, last_step_to_retain_index: int, last_insight_to_retain_index: int | None
+    ) -> bool:
+        with self.state.update() as cur:
+            cur.kill_all_processing_steps()  # mark any processing steps for killing
+            cur.delete_all_steps_after_index(
+                last_step_to_retain_index
+            )  # delete all steps after specified step
+            step = cur.find_step(
+                index=last_step_to_retain_index
+            )  # delete all insights after specified insight
+            if isinstance(step, DefaultStep):
+                step.insights = (
+                    step.insights[: last_insight_to_retain_index + 1]
+                    if last_insight_to_retain_index is not None
+                    else []
+                )
+                cur.steps[-1] = step
+
+        count = 0
+        while make_kill_signal() in self.state.get().signals:
+            time.sleep(0.5)  # wait for all steps to be killed
+            count += 1
+            if count > 5:
+                return False  # could not kill steps
+        return True  # successfully killed steps

--- a/src/seer/automation/autofix/steps/change_describer_step.py
+++ b/src/seer/automation/autofix/steps/change_describer_step.py
@@ -94,4 +94,4 @@ class AutofixChangeDescriberStep(AutofixPipelineStep):
         self.context.event_manager.send_coding_complete(codebase_changes)
         self.context.event_manager.add_log(
             "Above are some code changes that I think fix the issue."
-        )  # TODO: add 'Feel free to edit them or tell me what I should change.' once those features are in
+        )

--- a/src/seer/automation/autofix/steps/coding_step.py
+++ b/src/seer/automation/autofix/steps/coding_step.py
@@ -20,6 +20,7 @@ from seer.automation.autofix.steps.change_describer_step import (
 from seer.automation.autofix.steps.steps import AutofixPipelineStep
 from seer.automation.models import EventDetails
 from seer.automation.pipeline import PipelineStepTaskRequest
+from seer.automation.utils import make_kill_signal
 
 
 class AutofixCodingStepRequest(PipelineStepTaskRequest):
@@ -64,7 +65,7 @@ class AutofixCodingStep(AutofixPipelineStep):
                 "Figuring out a fix for the root cause of this issue..."
             )
         else:
-            self.context.event_manager.add_log("Thanks, continuing to analyze...")
+            self.context.event_manager.add_log("Continuing to analyze...")
 
         state = self.context.state.get()
         root_cause_and_fix = state.get_selected_root_cause_and_fix()
@@ -91,6 +92,8 @@ class AutofixCodingStep(AutofixPipelineStep):
 
         state = self.context.state.get()
         if state.steps[-1].status == AutofixStatus.WAITING_FOR_USER_RESPONSE:
+            return
+        if make_kill_signal() in state.signals:
             return
 
         self.context.event_manager.send_coding_result(coding_output)

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -369,7 +369,15 @@ def restart_from_point_with_feedback(request: AutofixUpdateRequest):
 
     # add feedback to memory and to insights
     if request.payload.message:
+        # enforce alternating user/assistant messages
+        for item in reversed(memory):
+            if item.role == "user":
+                memory.append(Message(content=".", role="assistant"))
+                break
+            elif item.role == "assistant":
+                break
         memory.append(Message(content=request.payload.message, role="user"))
+
         with state.update() as cur:
             if isinstance(cur.steps[-1], DefaultStep):
                 cur.steps[-1].insights.append(

--- a/src/seer/automation/pipeline.py
+++ b/src/seer/automation/pipeline.py
@@ -73,6 +73,7 @@ class PipelineStep(abc.ABC, Generic[_RequestType, _ContextType]):
     def invoke(self) -> Any:
         try:
             if not self._pre_invoke():
+                self._cleanup()
                 return
             result = self._invoke(**self._get_extra_invoke_kwargs())
             self._post_invoke(result)
@@ -80,6 +81,8 @@ class PipelineStep(abc.ABC, Generic[_RequestType, _ContextType]):
         except Exception as e:
             self._handle_exception(e)
             raise e
+        finally:
+            self._cleanup()
 
     def _get_extra_invoke_kwargs(self) -> dict[str, Any]:
         return {}
@@ -88,6 +91,9 @@ class PipelineStep(abc.ABC, Generic[_RequestType, _ContextType]):
         return True
 
     def _post_invoke(self, result: Any) -> Any:
+        pass
+
+    def _cleanup(self):
         pass
 
     @property

--- a/src/seer/automation/utils.py
+++ b/src/seer/automation/utils.py
@@ -88,6 +88,10 @@ def make_done_signal(id: str | int) -> str:
     return f"done:{id}"
 
 
+def make_kill_signal() -> str:
+    return "kill-all-steps"
+
+
 def make_retry_prefix(step_id: int) -> str:
     return f"retry:{step_id}:"
 

--- a/tests/automation/agent/test_agent.py
+++ b/tests/automation/agent/test_agent.py
@@ -189,7 +189,7 @@ class TestGptAgent:
         assert isinstance(mock_thread.call_args[1]["args"][1], str)
 
         # To test the share insights method, we need to call it directly
-        agent.share_insights(mock_context, "Test response")
+        agent.share_insights(mock_context, "Test response", -1)
 
         # Check if insight sharing was called
         mock_insight_sharing.assert_called_once_with(mock_context)

--- a/tests/automation/autofix/components/test_insight_sharing.py
+++ b/tests/automation/autofix/components/test_insight_sharing.py
@@ -32,6 +32,7 @@ class TestInsightSharingComponent:
             latest_thought="Latest thought",
             past_insights=["Past insight 1", "Past insight 2"],
             memory=[Message(role="user", content="Test memory")],
+            generated_at_memory_index=0,
         )
 
         mock_completion_1 = MagicMock()
@@ -66,6 +67,7 @@ class TestInsightSharingComponent:
             latest_thought="Latest thought",
             past_insights=["Past insight 1", "Past insight 2"],
             memory=[Message(role="user", content="Test memory")],
+            generated_at_memory_index=0,
         )
 
         mock_completion = MagicMock()
@@ -83,6 +85,7 @@ class TestInsightSharingComponent:
             latest_thought="Latest thought",
             past_insights=["Past insight 1"],
             memory=[Message(role="user", content="Test memory")],
+            generated_at_memory_index=0,
         )
 
         mock_completion_1 = MagicMock()

--- a/tests/automation/autofix/components/test_root_cause.py
+++ b/tests/automation/autofix/components/test_root_cause.py
@@ -16,7 +16,7 @@ from seer.dependency_injection import Module
 class TestRootCauseComponent:
     @pytest.fixture
     def component(self):
-        mock_context = MagicMock(spec=AutofixContext)
+        mock_context = MagicMock(spec=AutofixContext, event_manager=MagicMock(add_log=MagicMock()))
         mock_context.state = MagicMock()
         mock_context.skip_loading_codebase = True
         return RootCauseAnalysisComponent(mock_context)

--- a/tests/automation/autofix/test_autofix_event_manager.py
+++ b/tests/automation/autofix/test_autofix_event_manager.py
@@ -1,15 +1,20 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
 from johen import generate
 
+from seer.automation.autofix.components.insight_sharing.models import InsightSharingOutput
 from seer.automation.autofix.event_manager import AutofixEventManager
 from seer.automation.autofix.models import (
     AutofixContinuation,
     AutofixRequest,
     AutofixStatus,
+    DefaultStep,
     ProgressType,
     RootCauseStep,
 )
 from seer.automation.state import LocalMemoryState
+from seer.automation.utils import make_kill_signal
 
 
 class TestAutofixEventManager:
@@ -80,3 +85,109 @@ class TestAutofixEventManager:
         event_manager.add_log("Test log message")
 
         assert state.get().steps == []
+
+    @patch("time.sleep")
+    def test_reset_steps_to_point(self, mock_time, event_manager, state):
+        with state.update() as cur:
+            cur.steps = [
+                RootCauseStep(id="1", title="Step 1", status=AutofixStatus.COMPLETED),
+                DefaultStep(
+                    id="2",
+                    title="Step 2",
+                    status=AutofixStatus.COMPLETED,
+                    insights=[
+                        MagicMock(spec=InsightSharingOutput, id="insight1"),
+                        MagicMock(spec=InsightSharingOutput, id="insight2"),
+                        MagicMock(spec=InsightSharingOutput, id="insight3"),
+                    ],
+                ),
+                RootCauseStep(id="3", title="Step 3", status=AutofixStatus.PROCESSING),
+                DefaultStep(id="4", title="Step 4", status=AutofixStatus.PROCESSING),
+            ]
+
+        # Test case 1: Reset to second step, before any insights
+        with patch.object(state, "get", wraps=state.get) as mock_get:
+            mock_get.side_effect = [
+                state.get(),  # First call returns state with kill signal
+                MagicMock(signals=[]),  # Second call returns state without kill signal
+            ]
+            result = event_manager.reset_steps_to_point(1, None)
+
+        assert result is True
+        assert len(state.get().steps) == 2
+        assert state.get().steps[-1].id == "2"
+        assert len(state.get().steps[-1].insights) == 0
+
+        # Test case 2: Reset to second step, keep only first insight
+        with state.update() as cur:
+            cur.steps = [
+                RootCauseStep(id="1", title="Step 1", status=AutofixStatus.COMPLETED),
+                DefaultStep(
+                    id="2",
+                    title="Step 2",
+                    status=AutofixStatus.COMPLETED,
+                    insights=[
+                        MagicMock(spec=InsightSharingOutput, id="insight1"),
+                        MagicMock(spec=InsightSharingOutput, id="insight2"),
+                        MagicMock(spec=InsightSharingOutput, id="insight3"),
+                    ],
+                ),
+                RootCauseStep(id="3", title="Step 3", status=AutofixStatus.PROCESSING),
+            ]
+
+        with patch.object(state, "get", wraps=state.get) as mock_get:
+            mock_get.side_effect = [
+                state.get(),  # First call returns state with kill signal
+                MagicMock(signals=[]),  # Second call returns state without kill signal
+            ]
+            result = event_manager.reset_steps_to_point(1, 0)
+
+        assert result is True
+        assert len(state.get().steps) == 2
+        assert state.get().steps[-1].id == "2"
+        assert len(state.get().steps[-1].insights) == 1
+        assert state.get().steps[-1].insights[0].id == "insight1"
+
+        # Test case 3: Reset to first step (RootCauseStep)
+        with state.update() as cur:
+            cur.steps = [
+                RootCauseStep(id="1", title="Step 1", status=AutofixStatus.COMPLETED),
+                DefaultStep(id="2", title="Step 2", status=AutofixStatus.PROCESSING),
+            ]
+
+        with patch.object(state, "get", wraps=state.get) as mock_get:
+            mock_get.side_effect = [
+                state.get(),  # First call returns state with kill signal
+                MagicMock(signals=[]),  # Second call returns state without kill signal
+            ]
+            result = event_manager.reset_steps_to_point(0, None)
+
+        assert result is True
+        assert len(state.get().steps) == 1
+        assert state.get().steps[-1].id == "1"
+
+        # Test case 4: Timeout while waiting for steps to be killed
+        with patch.object(state, "get", wraps=state.get) as mock_get:
+            mock_get.return_value = MagicMock(signals=[make_kill_signal()])
+            mock_time.side_effect = [None] * 6  # Simulate timeout
+            result = event_manager.reset_steps_to_point(0, None)
+
+        assert result is False
+        mock_time.assert_called_with(0.5)
+        assert mock_time.call_count == 6
+
+        # Test case 5: Successfully kill steps before timeout
+        with patch.object(state, "get", wraps=state.get) as mock_get:
+            mock_get.side_effect = [
+                MagicMock(signals=[make_kill_signal()]),
+                MagicMock(signals=[make_kill_signal()]),
+                MagicMock(signals=[make_kill_signal()]),
+                MagicMock(signals=[]),
+            ]
+            mock_time.reset_mock()
+            mock_time.side_effect = [None, None, None]  # Simulate successful kill after 3 attempts
+            result = event_manager.reset_steps_to_point(0, None)
+
+        assert result is True
+        mock_time.assert_called_with(0.5)
+        assert mock_time.call_count == 2  # Called twice before signals are cleared

--- a/tests/test_seer.py
+++ b/tests/test_seer.py
@@ -543,6 +543,10 @@ class TestSeer(unittest.TestCase):
             (AutofixUpdateType.SELECT_ROOT_CAUSE, "seer.app.run_autofix_execution"),
             (AutofixUpdateType.CREATE_PR, "seer.app.run_autofix_create_pr"),
             (AutofixUpdateType.USER_MESSAGE, "seer.app.receive_user_message"),
+            (
+                AutofixUpdateType.RESTART_FROM_POINT_WITH_FEEDBACK,
+                "seer.app.restart_from_point_with_feedback",
+            ),
         ]
 
         for autofix_type, expected_func in test_cases:


### PR DESCRIPTION
When an certain update request is received, we jump back to the selected point in the steps/insights chain, delete any steps, insights, and memory after that, add the user feedback to the memory, and continue analyzing.

This allows the user full control over the model's reasoning, and let's them rethink and guide the model at any point. This also allows restarting from errored/no-root cause states, and jumping back to previous steps.