### PR TITLE
[feat] Auto create a PR after the unit test task completes

### DIFF
--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import tarfile
 import tempfile
-from typing import Literal
+from typing import Literal, Optional
 
 import requests
 import sentry_sdk
@@ -364,9 +364,11 @@ class RepoClient:
             )
 
     def create_branch_from_changes(
-        self, pr_title: str, file_changes: list[FileChange]
+        self, pr_title: str, file_changes: list[FileChange], branch_name: Optional[str]
     ) -> GitRef | None:
-        new_branch_name = f"autofix/{sanitize_branch_name(pr_title)}/{generate_random_string(n=6)}"
+        new_branch_name = (
+            branch_name or f"autofix/{sanitize_branch_name(pr_title)}/{generate_random_string(n=6)}"
+        )
         branch_ref = self._create_branch(new_branch_name)
 
         for change in file_changes:
@@ -398,11 +400,12 @@ class RepoClient:
         branch: GitRef,
         title: str,
         description: str,
+        provided_base: Optional[str],
     ):
         return self.repo.create_pull(
             title=title,
             body=description,
-            base=self.get_default_branch(),
+            base=provided_base or self.get_default_branch(),
             head=branch.ref,
             draft=True,
         )

--- a/src/seer/automation/codegen/unit_test_github_pr_creator.py
+++ b/src/seer/automation/codegen/unit_test_github_pr_creator.py
@@ -29,6 +29,7 @@ class GeneratedTestsPullRequestCreator:
         branch_ref = self.repo_client.create_branch_from_changes(
             pr_title, self.file_changes_payload, branch_name
         )
+
         if not branch_ref:
             logger.warning("Failed to create branch from changes")
             return
@@ -36,6 +37,7 @@ class GeneratedTestsPullRequestCreator:
         description = f"This PR adds tests for #{self.pr.number}\n\n" "### Commits:\n" + "\n".join(
             commit_messages
         )
+
         self.repo_client.create_pr_from_branch(
             branch=branch_ref,
             title=pr_title,

--- a/src/seer/automation/codegen/unit_test_github_pr_creator.py
+++ b/src/seer/automation/codegen/unit_test_github_pr_creator.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 class GeneratedTestsPullRequestCreator:
     def __init__(
-        self, file_changes_payload: List[FileChange], pr: PullRequest, repo_client: RepoClient
+        self, file_changes_payload: list[FileChange], pr: PullRequest, repo_client: RepoClient
     ):
         self.file_changes_payload = file_changes_payload
         self.pr = pr

--- a/src/seer/automation/codegen/unit_test_github_pr_creator.py
+++ b/src/seer/automation/codegen/unit_test_github_pr_creator.py
@@ -1,0 +1,44 @@
+import logging
+import time
+from typing import List
+
+from seer.automation.codebase.repo_client import RepoClient
+from seer.automation.models import FileChange
+from github.PullRequest import PullRequest
+
+logger = logging.getLogger(__name__)
+
+
+class GeneratedTestsPullRequestCreator:
+    def __init__(
+        self, file_changes_payload: List[FileChange], pr: PullRequest, repo_client: RepoClient
+    ):
+        self.file_changes_payload = file_changes_payload
+        self.pr = pr
+        self.repo_client = repo_client
+
+    def create_github_pull_request(self):
+        self.repo_client.base_commit_sha = self.pr.head.sha
+
+        branch_name = f"ai_tests_for_pr{self.pr.number}_{int(time.time())}"
+        pr_title = f"Add Tests for PR#{self.pr.number}"
+
+        commit_messages = []
+        for change in self.file_changes_payload:
+            commit_messages.append(f"- {change.commit_message}")
+        branch_ref = self.repo_client.create_branch_from_changes(
+            pr_title, self.file_changes_payload, branch_name
+        )
+        if not branch_ref:
+            logger.warning("Failed to create branch from changes")
+            return
+
+        description = f"This PR adds tests for #{self.pr.number}\n\n" "### Commits:\n" + "\n".join(
+            commit_messages
+        )
+        self.repo_client.create_pr_from_branch(
+            branch=branch_ref,
+            title=pr_title,
+            description=description,
+            provided_base=self.pr.base.ref,
+        )

--- a/src/seer/automation/codegen/unittest_step.py
+++ b/src/seer/automation/codegen/unittest_step.py
@@ -75,7 +75,7 @@ class UnittestStep(CodegenStep):
         if unittest_output:
             for file_change in unittest_output.diffs:
                 self.context.event_manager.append_file_change(file_change)
+            generator = GeneratedTestsPullRequestCreator(unittest_output.diffs, pr, repo_client)
+            generator.create_github_pull_request()
 
-        generator = GeneratedTestsPullRequestCreator(unittest_output.diffs, pr, repo_client)
-        generator.create_github_pull_request()
         self.context.event_manager.mark_completed()

--- a/src/seer/automation/codegen/unittest_step.py
+++ b/src/seer/automation/codegen/unittest_step.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from langfuse.decorators import observe
+from seer.automation.codegen.unit_test_github_pr_creator import GeneratedTestsPullRequestCreator
 from sentry_sdk.ai.monitoring import ai_track
 
 from celery_app.app import celery_app
@@ -75,4 +76,6 @@ class UnittestStep(CodegenStep):
             for file_change in unittest_output.diffs:
                 self.context.event_manager.append_file_change(file_change)
 
+        generator = GeneratedTestsPullRequestCreator(unittest_output.diffs, pr, repo_client)
+        generator.create_github_pull_request()
         self.context.event_manager.mark_completed()

--- a/tests/automation/codegen/test_unit_test_step.py
+++ b/tests/automation/codegen/test_unit_test_step.py
@@ -1,24 +1,23 @@
 import unittest
 from unittest.mock import patch, MagicMock
 
+from seer.automation.codebase.repo_client import RepoClient
 from seer.automation.codegen.models import CodeUnitTestRequest
+from seer.automation.codegen.unit_test_github_pr_creator import GeneratedTestsPullRequestCreator
 from seer.automation.codegen.unittest_step import UnittestStep, UnittestStepRequest
-from seer.automation.models import RepoDefinition
+from seer.automation.models import FileChange, RepoDefinition
 
 import unittest
 from unittest.mock import MagicMock
 
 from seer.automation.models import RepoDefinition
 
+
 class TestUnittestStep(unittest.TestCase):
     @patch("seer.automation.codegen.unit_test_coding_component.UnitTestCodingComponent.invoke")
     @patch("seer.automation.pipeline.PipelineStep", new_callable=MagicMock)
     @patch("seer.automation.codegen.step.CodegenStep._instantiate_context", new_callable=MagicMock)
-    def test_invoke_happy_path(self, 
-                    mock_instantiate_context,
-                    _, 
-                    mock_invoke_unit_test_component):
-
+    def test_invoke_happy_path(self, mock_instantiate_context, _, mock_invoke_unit_test_component):
         mock_repo_client = MagicMock()
         mock_pr = MagicMock()
         mock_diff_content = "diff content"
@@ -32,7 +31,9 @@ class TestUnittestStep(unittest.TestCase):
         request_data = {
             "run_id": 1,
             "pr_id": 123,
-            "repo_definition": RepoDefinition(name="repo1", owner="owner1", provider="github", external_id="123123")
+            "repo_definition": RepoDefinition(
+                name="repo1", owner="owner1", provider="github", external_id="123123"
+            ),
         }
         request = UnittestStepRequest(**request_data)
         step = UnittestStep(request=request)
@@ -55,3 +56,61 @@ class TestUnittestStep(unittest.TestCase):
             "owner_username": request.repo_definition.owner,
             "head_sha": mock_latest_commit_sha,
         }
+
+    @patch("time.time", return_value=1234567890)
+    def test_create_github_pull_request_success(self, mock_time):
+        file_changes_payload = [MagicMock(spec=FileChange), MagicMock(spec=FileChange)]
+        pr = MagicMock()
+        pr.head.sha = "head_sha"
+        pr.number = 123
+        pr.base.ref = "main"
+        repo_client = MagicMock(spec=RepoClient)
+
+        creator = GeneratedTestsPullRequestCreator(
+            file_changes_payload=file_changes_payload, pr=pr, repo_client=repo_client
+        )
+
+        branch_name = "ai_tests_for_pr123_1234567890"
+        pr_title = "Add Tests for PR#123"
+        file_changes_payload[0].commit_message = "commit message 1"
+        file_changes_payload[1].commit_message = "commit message 2"
+
+        repo_client.create_branch_from_changes.return_value = "branch_ref"
+
+        creator.create_github_pull_request()
+
+        repo_client.create_branch_from_changes.assert_called_once_with(
+            pr_title, file_changes_payload, branch_name
+        )
+        repo_client.create_pr_from_branch.assert_called_once_with(
+            branch="branch_ref",
+            title=pr_title,
+            description="This PR adds tests for #123\n\n### Commits:\n- commit message 1\n- commit message 2",
+            provided_base="main",
+        )
+        self.assertEqual(repo_client.base_commit_sha, pr.head.sha)
+
+    def test_create_github_pull_request_failure(self):
+        file_changes_payload = [MagicMock(spec=FileChange), MagicMock(spec=FileChange)]
+        pr = MagicMock()
+        pr.head.sha = "head_sha"
+        pr.number = 123
+        pr.base.ref = "main"
+        repo_client = MagicMock(spec=RepoClient)
+
+        creator = GeneratedTestsPullRequestCreator(
+            file_changes_payload=file_changes_payload, pr=pr, repo_client=repo_client
+        )
+
+        file_changes_payload[0].commit_message = "commit message 1"
+        file_changes_payload[1].commit_message = "commit message 2"
+
+        repo_client.create_branch_from_changes.return_value = None
+
+        with self.assertLogs(
+            "seer.automation.codegen.unit_test_github_pr_creator", level="WARNING"
+        ) as cm:
+            creator.create_github_pull_request()
+
+        self.assertIn("Failed to create branch from changes", cm.output[0])
+        repo_client.create_pr_from_branch.assert_not_called()

--- a/tests/automation/codegen/test_unit_test_step.py
+++ b/tests/automation/codegen/test_unit_test_step.py
@@ -90,7 +90,10 @@ class TestUnittestStep(unittest.TestCase):
         )
         self.assertEqual(repo_client.base_commit_sha, pr.head.sha)
 
-    def test_create_github_pull_request_failure(self):
+
+class TestUnittestStep(unittest.TestCase):
+    @patch("seer.automation.codegen.unit_test_github_pr_creator.logging.getLogger")
+    def test_create_github_pull_request_failure(self, mock_get_logger):
         file_changes_payload = [MagicMock(spec=FileChange), MagicMock(spec=FileChange)]
         pr = MagicMock()
         pr.head.sha = "head_sha"
@@ -107,10 +110,9 @@ class TestUnittestStep(unittest.TestCase):
 
         repo_client.create_branch_from_changes.return_value = None
 
-        with self.assertLogs(
-            "seer.automation.codegen.unit_test_github_pr_creator", level="WARNING"
-        ) as cm:
-            creator.create_github_pull_request()
+        mock_logger = mock_get_logger.return_value
 
-        self.assertIn("Failed to create branch from changes", cm.output[0])
+        creator.create_github_pull_request()
+
+        mock_logger.warning.assert_called_once_with("Failed to create branch from changes")
         repo_client.create_pr_from_branch.assert_not_called()

--- a/tests/automation/codegen/test_unit_test_step.py
+++ b/tests/automation/codegen/test_unit_test_step.py
@@ -58,7 +58,7 @@ class TestUnittestStep(unittest.TestCase):
         }
 
     @patch("time.time", return_value=1234567890)
-    def test_create_github_pull_request_success(self, mock_time):
+    def test_create_github_pull_request_success(self, _):
         file_changes_payload = [MagicMock(spec=FileChange), MagicMock(spec=FileChange)]
         pr = MagicMock()
         pr.head.sha = "head_sha"
@@ -90,10 +90,8 @@ class TestUnittestStep(unittest.TestCase):
         )
         self.assertEqual(repo_client.base_commit_sha, pr.head.sha)
 
-
-class TestUnittestStep(unittest.TestCase):
-    @patch("seer.automation.codegen.unit_test_github_pr_creator.logging.getLogger")
-    def test_create_github_pull_request_failure(self, mock_get_logger):
+    @patch("seer.automation.codegen.unit_test_github_pr_creator.logger")
+    def test_create_github_pull_request_failure(self, mock_logger):
         file_changes_payload = [MagicMock(spec=FileChange), MagicMock(spec=FileChange)]
         pr = MagicMock()
         pr.head.sha = "head_sha"
@@ -109,8 +107,6 @@ class TestUnittestStep(unittest.TestCase):
         file_changes_payload[1].commit_message = "commit message 2"
 
         repo_client.create_branch_from_changes.return_value = None
-
-        mock_logger = mock_get_logger.return_value
 
         creator.create_github_pull_request()
 


### PR DESCRIPTION
This change creates a new PR with the `base` set to the PR where unit tests are generated.

The user can kick off this flow by hitting the `/v1/automation/codegen/unit-tests` endpoint. 

Example PR created using this flow: https://github.com/rohitvinnakota-codecov/hello-world-sunday/pull/2




