### PR TITLE
feat(autofix): Keyword search only downloads repo once

### DIFF
--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -38,7 +38,6 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
                     max_iterations=24,
                     interactive=True,
                 ),
-                name="root_cause_analysis",
                 memory=request.initial_memory,
             )
 
@@ -57,6 +56,7 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
                         else None
                     ),
                     context=self.context,
+                    name="root_cause_analysis",
                 )
 
                 if not response:

--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -30,77 +30,77 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
     def invoke(
         self, request: RootCauseAnalysisRequest, gpt_client: GptClient = injected
     ) -> RootCauseAnalysisOutput | None:
-        tools = BaseTools(self.context)
-        agent = GptAgent(
-            tools=tools.get_tools(),
-            config=AgentConfig(
-                system_prompt=RootCauseAnalysisPrompts.format_system_msg(),
-                max_iterations=24,
-                interactive=True,
-            ),
-            memory=request.initial_memory,
-        )
-
-        state = self.context.state.get()
-
-        try:
-            response = agent.run(
-                (
-                    RootCauseAnalysisPrompts.format_default_msg(
-                        event=request.event_details.format_event(),
-                        summary=request.summary,
-                        instruction=request.instruction,
-                        repo_names=[repo.full_name for repo in state.request.repos],
-                    )
-                    if not request.initial_memory
-                    else None
+        with BaseTools(self.context) as tools:
+            agent = GptAgent(
+                tools=tools.get_tools(),
+                config=AgentConfig(
+                    system_prompt=RootCauseAnalysisPrompts.format_system_msg(),
+                    max_iterations=24,
+                    interactive=True,
                 ),
-                context=self.context,
                 name="root_cause_analysis",
+                memory=request.initial_memory,
             )
 
-            if not response:
+            state = self.context.state.get()
+
+            try:
+                response = agent.run(
+                    (
+                        RootCauseAnalysisPrompts.format_default_msg(
+                            event=request.event_details.format_event(),
+                            summary=request.summary,
+                            instruction=request.instruction,
+                            repo_names=[repo.full_name for repo in state.request.repos],
+                        )
+                        if not request.initial_memory
+                        else None
+                    ),
+                    context=self.context,
+                )
+
+                if not response:
+                    self.context.store_memory("root_cause_analysis", agent.memory)
+                    return None
+
+                if "<NO_ROOT_CAUSES>" in response:
+                    return None
+
+                # Ask for reproduction
+                self.context.event_manager.add_log("Thinking about how to reproduce the issue...")
+                agent.run(
+                    RootCauseAnalysisPrompts.reproduction_prompt_msg(),
+                )
+
                 self.context.store_memory("root_cause_analysis", agent.memory)
-                return None
 
-            if "<NO_ROOT_CAUSES>" in response:
-                return None
+                self.context.event_manager.add_log("Cleaning up my findings...")
+                response = gpt_client.openai_client.beta.chat.completions.parse(
+                    messages=[
+                        message.to_message()
+                        for message in gpt_client.clean_tool_call_assistant_messages(agent.memory)
+                    ]
+                    + [
+                        Message(
+                            role="user",
+                            content=RootCauseAnalysisPrompts.root_cause_formatter_msg(),
+                        ).to_message(),
+                    ],
+                    model="gpt-4o-2024-08-06",
+                    response_format=MultipleRootCauseAnalysisOutputPrompt,
+                )
 
-            # Ask for reproduction
-            self.context.event_manager.add_log("Thinking about how to reproduce the issue...")
-            agent.run(
-                RootCauseAnalysisPrompts.reproduction_prompt_msg(),
-            )
+                parsed = extract_parsed_model(response)
 
-            self.context.store_memory("root_cause_analysis", agent.memory)
+                # Assign the ids to be the numerical indices of the causes and relevant code context
+                cause_model = parsed.cause.to_model()
+                cause_model.id = 0
+                if cause_model.code_context:
+                    for j, snippet in enumerate(cause_model.code_context):
+                        snippet.id = j
 
-            self.context.event_manager.add_log("Cleaning up my findings...")
-            response = gpt_client.openai_client.beta.chat.completions.parse(
-                messages=[
-                    message.to_message()
-                    for message in gpt_client.clean_tool_call_assistant_messages(agent.memory)
-                ]
-                + [
-                    Message(
-                        role="user",
-                        content=RootCauseAnalysisPrompts.root_cause_formatter_msg(),
-                    ).to_message(),
-                ],
-                model="gpt-4o-2024-08-06",
-                response_format=MultipleRootCauseAnalysisOutputPrompt,
-            )
-
-            parsed = extract_parsed_model(response)
-
-            # Assign the ids to be the numerical indices of the causes and relevant code context
-            cause_model = parsed.cause.to_model()
-            cause_model.id = 0
-            if cause_model.code_context:
-                for j, snippet in enumerate(cause_model.code_context):
-                    snippet.id = j
-
-            causes = [cause_model]
-            return RootCauseAnalysisOutput(causes=causes)
-        finally:
-            with self.context.state.update() as cur:
-                cur.usage += agent.usage
+                causes = [cause_model]
+                return RootCauseAnalysisOutput(causes=causes)
+            finally:
+                with self.context.state.update() as cur:
+                    cur.usage += agent.usage

--- a/src/seer/automation/autofix/tools.py
+++ b/src/seer/automation/autofix/tools.py
@@ -173,6 +173,9 @@ class BaseTools:
         else:
             append_langfuse_observation_metadata({"keyword_search_download": False})
 
+        if not self.tmp_repo_dir:
+            raise ValueError("tmp_repo_dir is not set")
+
         searcher = CodeSearcher(
             directory=self.tmp_repo_dir,
             supported_extensions=set(supported_extensions),

--- a/src/seer/automation/autofix/tools.py
+++ b/src/seer/automation/autofix/tools.py
@@ -12,6 +12,7 @@ from seer.automation.codebase.code_search import CodeSearcher
 from seer.automation.codebase.models import MatchXml
 from seer.automation.codebase.utils import cleanup_dir
 from seer.automation.codegen.codegen_context import CodegenContext
+from seer.langfuse import append_langfuse_observation_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -19,10 +20,18 @@ logger = logging.getLogger(__name__)
 class BaseTools:
     context: AutofixContext | CodegenContext
     retrieval_top_k: int
+    tmp_dir: str | None = None
+    tmp_repo_dir: str | None = None
 
     def __init__(self, context: AutofixContext | CodegenContext, retrieval_top_k: int = 8):
         self.context = context
         self.retrieval_top_k = retrieval_top_k
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.cleanup()
 
     @observe(name="Expand Document")
     @ai_track(description="Expand Document")
@@ -135,6 +144,12 @@ class BaseTools:
                 files.append(child)
         return dirs, files
 
+    def cleanup(self):
+        if self.tmp_dir:
+            cleanup_dir(self.tmp_dir)
+            self.tmp_dir = None
+            self.tmp_repo_dir = None
+
     @observe(name="Keyword Search")
     @ai_track(description="Keyword Search")
     def keyword_search(
@@ -147,19 +162,24 @@ class BaseTools:
         """
         Searches for a keyword in the codebase.
         """
-        repo_client = self.context.get_repo_client(repo_name=repo_name)
 
-        tmp_dir, tmp_repo_dir = repo_client.load_repo_to_tmp_dir()
+        if self.tmp_dir is None or self.tmp_repo_dir is None:
+            repo_client = self.context.get_repo_client(repo_name=repo_name)
+            tmp_dir, tmp_repo_dir = repo_client.load_repo_to_tmp_dir()
+
+            self.tmp_dir = tmp_dir
+            self.tmp_repo_dir = tmp_repo_dir
+            append_langfuse_observation_metadata({"keyword_search_download": True})
+        else:
+            append_langfuse_observation_metadata({"keyword_search_download": False})
 
         searcher = CodeSearcher(
-            directory=tmp_repo_dir,
+            directory=self.tmp_repo_dir,
             supported_extensions=set(supported_extensions),
             start_path=in_proximity_to,
         )
 
         results = searcher.search(keyword)
-
-        cleanup_dir(tmp_dir)
 
         self.context.event_manager.add_log(
             f"Searched codebase for `{keyword}`, found {len(results)} result(s)."

--- a/src/seer/langfuse.py
+++ b/src/seer/langfuse.py
@@ -46,6 +46,7 @@ def append_langfuse_observation_metadata(new_metadata: dict, langfuse: Langfuse 
     """
     try:
         observation_id = langfuse_context.get_current_observation_id()
+        langfuse_context.flush()
         if observation_id:
             observation = langfuse.get_observation(observation_id)
 

--- a/tests/automation/autofix/test_autofix_tools.py
+++ b/tests/automation/autofix/test_autofix_tools.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -77,3 +77,39 @@ class TestFileSearchWildcard:
 
         autofix_tools.file_search_wildcard("*.py", repo_name="test_repo")
         autofix_tools.context.get_repo_client.assert_called_once_with(repo_name="test_repo")
+
+
+class TestFileSystem:
+    @patch("seer.automation.autofix.tools.cleanup_dir")
+    def test_context_manager_cleanup(self, mock_cleanup_dir):
+        context = MagicMock()
+
+        with BaseTools(context) as tools:
+            tools.tmp_dir = "/tmp/test_dir"
+            tools.tmp_repo_dir = "/tmp/test_dir/repo"
+
+        mock_cleanup_dir.assert_called_once_with("/tmp/test_dir")
+        assert tools.tmp_dir is None
+        assert tools.tmp_repo_dir is None
+
+    def test_cleanup_method(self):
+        context = MagicMock()
+        tools = BaseTools(context)
+        tools.tmp_dir = "/tmp/test_dir"
+        tools.tmp_repo_dir = "/tmp/test_dir/repo"
+
+        with patch("seer.automation.autofix.tools.cleanup_dir") as mock_cleanup_dir:
+            tools.cleanup()
+
+        mock_cleanup_dir.assert_called_once_with("/tmp/test_dir")
+        assert tools.tmp_dir is None
+        assert tools.tmp_repo_dir is None
+
+    def test_cleanup_not_called_when_tmp_dir_is_none(self):
+        context = MagicMock()
+        tools = BaseTools(context)
+
+        with patch("seer.automation.autofix.tools.cleanup_dir") as mock_cleanup_dir:
+            tools.cleanup()
+
+        mock_cleanup_dir.assert_not_called()


### PR DESCRIPTION
The keyword search tool will only download the repo into a temp directory once. You will now need to use basetools with the context manager:
```
with BaseTools(self.context) as tools:
```
the tmp dir and downloaded repo will be deleted at the closing of the context manager.