### PR TITLE
(autofix): Bump 4o version to latest

### DIFF
--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -29,6 +29,7 @@ class LlmClient(ABC):
         system_prompt: Optional[str] = None,
         tools: Optional[list[FunctionTool]] = [],
         response_format: Optional[dict] = None,
+        temperature: float = 0.0,
     ) -> tuple[Message, Usage]:
         raise NotImplementedError
 
@@ -79,6 +80,7 @@ class GptClient(LlmClient):
         system_prompt: Optional[str] = None,
         tools: Optional[list[FunctionTool]] = None,
         response_format: Optional[dict] = None,
+        temperature: float = 0.0,
     ):
         message_dicts = [message.to_message() for message in messages]
         if system_prompt:
@@ -93,7 +95,7 @@ class GptClient(LlmClient):
         completion = self.openai_client.chat.completions.create(
             model=model,
             messages=message_dicts,
-            temperature=0.0,
+            temperature=temperature,
             tools=tool_dicts,
             response_format=response_format if response_format else openai.NotGiven(),
         )
@@ -172,6 +174,7 @@ class ClaudeClient(LlmClient):
         system_prompt: Optional[str] = None,
         tools: Optional[list[FunctionTool]] = None,
         response_format: Optional[dict] = None,
+        temperature: float = 0.0,
     ) -> tuple[Message, Usage]:
         if response_format:
             # Claude claims to be reliable at providing structured outputs (like JSON) when prompted,
@@ -185,7 +188,7 @@ class ClaudeClient(LlmClient):
         # ask Claude for a response
         params: dict[str, Any] = {
             "model": model,
-            "temperature": 0.0,
+            "temperature": temperature,
             "max_tokens": 8192,
             "messages": claude_messages,
         }

--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -317,6 +317,7 @@ class DummyGptClient(GptClient):
         system_prompt: Optional[str] = None,
         tools: Optional[list[FunctionTool]] = [],
         response_format: Optional[dict] = None,
+        temperature: float = 0.0,
     ):
         for handler in self.handlers:
             result = handler(

--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -64,7 +64,7 @@ class LlmClient(ABC):
         )
 
 
-DEFAULT_GPT_MODEL = "gpt-4o-2024-05-13"
+DEFAULT_GPT_MODEL = "gpt-4o-2024-08-06"
 DEFAULT_CLAUDE_MODEL = "claude-3-5-sonnet@20240620"
 
 

--- a/src/seer/automation/autofix/evaluations.py
+++ b/src/seer/automation/autofix/evaluations.py
@@ -256,7 +256,7 @@ def score_fix_single_it(dataset_item: DatasetItemClient, predicted_diff: str, mo
         predicted_diff=predicted_diff,
     )
     response, usage = GptClient().completion(
-        messages=[Message(role="user", content=prompt)], model=model
+        messages=[Message(role="user", content=prompt)], model=model, temperature=1.0
     )
     if not response.content:
         return 0

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -374,7 +374,7 @@ def run_autofix_evaluation_on_item(
     )
 
     scoring_n_panel = 5
-    scoring_model = "gpt-4o-2024-05-13"
+    scoring_model = "gpt-4o-2024-08-06"
 
     diff: str | None = None
 

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -374,7 +374,7 @@ def run_autofix_evaluation_on_item(
     )
 
     scoring_n_panel = 5
-    scoring_model = "gpt-4o-2024-08-06"
+    scoring_model = "o1-mini-2024-09-12"
 
     diff: str | None = None
 


### PR DESCRIPTION
Bumps gpt-4o in the root cause agent to the latest version (08-06). Bumps scoring model to o1-mini.

Evals (ignore second row) show that new model is at least as good as the old one, if not slightly better:
<img width="999" alt="Screenshot 2024-10-02 at 5 56 34 PM" src="https://github.com/user-attachments/assets/c1272d92-6729-41d4-a9ee-d577eb91995c">

Anecdotally, the eval also ran ~5-6 minutes faster, and I didn't even bump the scoring model at this point (for consistency's sake). 

After bumping the scoring model too, the new baseline is:
<img width="848" alt="Screenshot 2024-10-03 at 10 58 05 AM" src="https://github.com/user-attachments/assets/6f6842fc-2a2d-41e2-b44a-0d1173034858">
