### PR TITLE
ref(init): change seer bootup script

### DIFF
--- a/gunicorn.sh
+++ b/gunicorn.sh
@@ -6,4 +6,4 @@ if [ "$DEV" = "true" ] || [ "$DEV" = "1" ]; then
     GUNICORN_ARGS="--reload"
 fi
 
-exec gunicorn --bind :$PORT --worker-class sync --threads 1 --timeout 0 --logger-class src.seer.logging.GunicornHealthCheckFilterLogger --access-logfile - 'src.seer.app:start_app()' $GUNICORN_ARGS
+exec gunicorn --bind :$PORT --worker-class sync --threads 1 --timeout 0 --logger-class seer.logging.GunicornHealthCheckFilterLogger --access-logfile - 'seer.app:start_app()' $GUNICORN_ARGS


### PR DESCRIPTION
from talking with @corps, this script causes bootup logs to be prefixed with `src.`, which causes them to not be logged because our logging filter excludes them. https://github.com/getsentry/seer/blob/7d9af0b8dd3e95a740b07407c11687e05e3836f6/src/seer/bootup.py#L40