### PR TITLE
Add more logging prefixes

### DIFF
--- a/src/seer/logging.py
+++ b/src/seer/logging.py
@@ -15,7 +15,7 @@ LoggingPrefixes = Annotated[list[str], Labeled("logging_prefixes")]
 logging_module = Module()
 
 logging_module.constant(LogLevel, logging.INFO)
-logging_module.constant(LoggingPrefixes, ["seer.", "celery_app."])
+logging_module.constant(LoggingPrefixes, ["seer.", "celery_app.", "src.seer.", "src.celery_app."])
 
 
 @logging_module.provider


### PR DESCRIPTION
Due to some recent changes, our startup invocations are increasingly using `src.seer.*` which chains the relative import paths and logger names which get set during module initialization.  This causes logging to get lost silently.

It's hard to test this since it's an interaction of external bootup scripts and logging names.  The safest option is to be flexible here and take a wider range of logger names.