### PR TITLE
ref(autofix): New llm client and agent interface

### DIFF
--- a/requirements-constraints.txt
+++ b/requirements-constraints.txt
@@ -100,7 +100,7 @@ chromadb==0.4.14
 google-cloud-storage==2.*
 google-cloud-aiplatform==1.*
 google-cloud-secret-manager==2.*
-anthropic[vertex]==0.31.2
+anthropic[vertex]==0.34.2
 langfuse @ git+https://github.com/jennmueng/langfuse-python.git@9d9350de1e4e84fa548fe84f82c1b826be17956e
 watchdog
 stumpy==1.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --output-file=requirements.txt --strip-extras requirements-constraints.txt
 #
-aiohappyeyeballs==2.4.0
+aiohappyeyeballs==2.4.3
     # via aiohttp
-aiohttp==3.10.6
+aiohttp==3.10.8
     # via
     #   -r requirements-constraints.txt
     #   datasets
@@ -21,7 +21,7 @@ amqp==5.2.0
     # via kombu
 annotated-types==0.7.0
     # via pydantic
-anthropic==0.31.2
+anthropic==0.34.2
     # via -r requirements-constraints.txt
 anyio==4.6.0
     # via
@@ -120,7 +120,7 @@ cycler==0.11.0
     #   matplotlib
 cython==3.0.2
     # via -r requirements-constraints.txt
-datasets==3.0.0
+datasets==3.0.1
     # via optimum
 deprecated==1.2.14
     # via pygithub
@@ -195,9 +195,9 @@ google-auth==2.35.0
     #   google-cloud-resource-manager
     #   google-cloud-secret-manager
     #   google-cloud-storage
-google-cloud-aiplatform==1.67.1
+google-cloud-aiplatform==1.69.0
     # via -r requirements-constraints.txt
-google-cloud-bigquery==3.25.0
+google-cloud-bigquery==3.26.0
     # via google-cloud-aiplatform
 google-cloud-core==2.4.1
     # via
@@ -230,7 +230,7 @@ grpc-google-iam-v1==0.13.1
     #   google-cloud-secret-manager
 grpc-stubs==1.53.0.5
     # via sentry-protos
-grpcio==1.66.1
+grpcio==1.66.2
     # via
     #   chromadb
     #   google-api-core
@@ -241,11 +241,11 @@ grpcio==1.66.1
     #   grpcio-reflection
     #   grpcio-status
     #   sentry-protos
-grpcio-health-checking==1.66.1
+grpcio-health-checking==1.66.2
     # via -r requirements-constraints.txt
-grpcio-reflection==1.66.1
+grpcio-reflection==1.66.2
     # via -r requirements-constraints.txt
-grpcio-status==1.66.1
+grpcio-status==1.66.2
     # via google-api-core
 gunicorn==22.0.0
     # via -r requirements-constraints.txt
@@ -255,7 +255,7 @@ h11==0.14.0
     #   uvicorn
 holidays==0.31
     # via -r requirements-constraints.txt
-httpcore==1.0.5
+httpcore==1.0.6
     # via httpx
 httptools==0.6.1
     # via uvicorn
@@ -411,7 +411,7 @@ onnx==1.16.0
     # via -r requirements-constraints.txt
 onnxruntime==1.19.2
     # via chromadb
-openai==1.47.1
+openai==1.51.0
     # via -r requirements-constraints.txt
 openapi-core==0.18.2
     # via -r requirements-constraints.txt
@@ -472,9 +472,9 @@ pip-tools==7.4.1
     # via -r requirements-constraints.txt
 pluggy==1.5.0
     # via pytest
-posthog==3.6.6
+posthog==3.7.0
     # via chromadb
-prompt-toolkit==3.0.47
+prompt-toolkit==3.0.48
     # via click-repl
 proto-plus==1.24.0
     # via
@@ -549,7 +549,7 @@ pyparsing==3.0.9
     #   matplotlib
 pypika==0.48.9
     # via chromadb
-pyproject-hooks==1.1.0
+pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
@@ -621,7 +621,7 @@ requests==2.32.2
     #   transformers
 rfc3339-validator==0.1.4
     # via openapi-schema-validator
-rich==13.8.1
+rich==13.9.1
     # via typer
 rpds-py==0.20.0
     # via
@@ -650,7 +650,7 @@ sentencepiece==0.2.0
     # via
     #   sentence-transformers
     #   transformers
-sentry-protos==0.1.22
+sentry-protos==0.1.23
     # via -r requirements-constraints.txt
 sentry-sdk==2.11.0
     # via -r requirements-constraints.txt
@@ -791,7 +791,7 @@ urllib3==1.26.19
     #   pygithub
     #   requests
     #   sentry-sdk
-uvicorn==0.30.6
+uvicorn==0.31.0
     # via chromadb
 uvloop==0.20.0
     # via uvicorn
@@ -800,7 +800,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-watchdog==5.0.2
+watchdog==5.0.3
     # via -r requirements-constraints.txt
 watchfiles==0.24.0
     # via uvicorn
@@ -821,7 +821,7 @@ wrapt==1.16.0
     #   langfuse
 xxhash==3.5.0
     # via datasets
-yarl==1.12.1
+yarl==1.13.1
     # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/src/seer/automation/agent/agent.py
+++ b/src/seer/automation/agent/agent.py
@@ -1,52 +1,43 @@
 import logging
-import threading
-from abc import ABC
 from typing import Optional
 
 from pydantic import BaseModel, Field
 
-from seer.automation.agent.client import (
-    DEFAULT_CLAUDE_MODEL,
-    DEFAULT_GPT_MODEL,
-    ClaudeClient,
-    GptClient,
-    LlmClient,
-)
+from seer.automation.agent.client import LlmClient, LlmProvider
 from seer.automation.agent.models import Message, ToolCall, Usage
 from seer.automation.agent.tools import FunctionTool
 from seer.automation.agent.utils import parse_json_with_keys
-from seer.automation.autofix.autofix_context import AutofixContext
-from seer.automation.autofix.components.insight_sharing.component import InsightSharingComponent
-from seer.automation.autofix.components.insight_sharing.models import InsightSharingRequest
-from seer.automation.autofix.models import AutofixStatus, DefaultStep
-from seer.bootup import module
-from seer.configuration import configuration_module
 from seer.dependency_injection import inject, injected
 
 logger = logging.getLogger("autofix")
 
 
 class AgentConfig(BaseModel):
-    max_iterations: int = Field(
-        default=16, description="Maximum number of iterations the agent can perform"
-    )
-    model: str | None = Field(default=None, description="The model to be used by the agent")
-    system_prompt: str | None = None
-    stop_message: Optional[str] = Field(
-        default=None, description="Message that signals the agent to stop"
-    )
     interactive: bool = False  # enables interactive user-facing features
 
     class Config:
         validate_assignment = True
 
 
-class LlmAgent(ABC):
+class RunConfig(BaseModel):
+    system_prompt: str | None = None
+    prompt: str | None = None
+    stop_message: Optional[str] = Field(
+        default=None, description="Message that signals the agent to stop"
+    )
+    max_iterations: int = Field(
+        default=16, description="Maximum number of iterations the agent can perform"
+    )
+    model: LlmProvider
+    name: str | None = None
 
+
+class LlmAgent:
+    @inject
     def __init__(
         self,
         config: AgentConfig,
-        client: LlmClient,
+        client: type[LlmClient] = injected,
         tools: Optional[list[FunctionTool]] = None,
         memory: Optional[list[Message]] = None,
         name: str = "Agent",
@@ -59,123 +50,46 @@ class LlmAgent(ABC):
         self.name = name
         self.iterations = 0
 
-    def get_completion(self):
-        return self.client.completion(
+    def get_completion(self, run_config: RunConfig):
+        return self.client.generate_text(
             messages=self.memory,
-            model=self.config.model,
-            system_prompt=self.config.system_prompt if self.config.system_prompt else None,
+            model=run_config.model,
+            system_prompt=run_config.system_prompt if run_config.system_prompt else None,
             tools=(self.tools if len(self.tools) > 0 else None),
         )
 
-    def use_user_messages(self, context: AutofixContext):
-        # adds any queued user messages to the memory
-        user_msgs = context.state.get().steps[-1].queued_user_messages
-        if user_msgs:
-            # enforce alternating user/assistant messages
-            msg = "\n".join(user_msgs)
-            for item in reversed(self.memory):
-                if item.role == "user":
-                    self.memory.append(Message(content=".", role="assistant"))
-                    break
-                elif item.role == "assistant":
-                    break
-            self.memory.append(Message(content=msg, role="user"))
-
-            with context.state.update() as cur:
-                cur.steps[-1].queued_user_messages = []
-            context.event_manager.add_log("Thanks for the input. I'm thinking through it now...")
-
-    def run_in_thread(self, func, args):
-        def wrapper():
-            # ensures dependency injection works
-            module.enable()
-            configuration_module.enable()
-
-            func(*args)
-
-        threading.Thread(target=wrapper).start()
-
-    def share_insights(self, context: AutofixContext, text: str, generated_at_memory_index: int):
-        # generate insights
-        insight_sharing = InsightSharingComponent(context)
-        past_insights = context.state.get().get_all_insights()
-        insight_card = insight_sharing.invoke(
-            InsightSharingRequest(
-                latest_thought=text,
-                memory=self.memory,
-                task_description=context.state.get().get_step_description(),
-                past_insights=past_insights,
-                generated_at_memory_index=generated_at_memory_index,
-            )
-        )
-        # add the insight card to the current step
-        if insight_card:
-            if len(context.state.get().get_all_insights()) == len(
-                past_insights
-            ):  # in case something else was added in parallel, don't add this insight
-                with context.state.update() as cur:
-                    if cur.steps and isinstance(cur.steps[-1], DefaultStep):
-                        step = cur.steps[-1]
-                        step.insights.append(insight_card)
-                        cur.steps[-1] = step
-
-    def run_iteration(self, context: Optional[AutofixContext] = None):
+    def run_iteration(self, run_config: RunConfig):
         logger.debug(f"----[{self.name}] Running Iteration {self.iterations}----")
 
-        message, usage = self.get_completion()
+        completion = self.get_completion(run_config)
 
-        # interrupt if user message is queued and awaiting handling
-        if context and context.state.get().steps[-1].queued_user_messages:
-            self.use_user_messages(context)
-            return
-
-        self.memory.append(message)
-
-        # log thoughts to the user
-        if (
-            message.content
-            and context
-            and self.config.interactive
-            and not context.state.get().request.options.disable_interactivity
-        ):
-            text_before_tag = message.content.split("<")[0]
-            text = text_before_tag
-            if text:
-                self.run_in_thread(
-                    func=self.share_insights, args=(context, text, len(self.memory) - 1)
-                )
+        self.memory.append(completion.message)
 
         # call any tools the model wants to use
-        if message.tool_calls:
-            for tool_call in message.tool_calls:
+        if completion.message.tool_calls:
+            for tool_call in completion.message.tool_calls:
                 tool_response = self.call_tool(tool_call)
                 self.memory.append(tool_response)
 
         self.iterations += 1
-        self.usage += usage
+        self.usage += completion.metadata.usage
 
         return self.memory
 
-    def should_continue(self, context: Optional[AutofixContext] = None) -> bool:
-        if (
-            context
-            and context.state.get().steps[-1].status == AutofixStatus.WAITING_FOR_USER_RESPONSE
-        ):
-            return False
-
+    def should_continue(self, run_config: RunConfig) -> bool:
         # If this is the first iteration or there are no messages, continue
         if self.iterations == 0 or not self.memory:
             return True
 
         # Stop if we've reached the maximum number of iterations
-        if self.iterations >= self.config.max_iterations:
+        if self.iterations >= run_config.max_iterations:
             return False
 
         last_message = self.memory[-1]
         if last_message and last_message.role in ["assistant", "model"]:
             if last_message.content:
                 # Stop if the stop message is found in the content
-                if self.config.stop_message and self.config.stop_message in last_message.content:
+                if run_config.stop_message and run_config.stop_message in last_message.content:
                     return False
                 # Stop if there are no tool calls
                 if not last_message.tool_calls:
@@ -184,23 +98,18 @@ class LlmAgent(ABC):
         # Continue in all other cases
         return True
 
-    def run(
-        self, prompt: str | None, context: Optional[AutofixContext] = None, name: str | None = None
-    ):
-        if prompt:
-            self.add_user_message(prompt)
+    def run(self, run_config: RunConfig):
+        if run_config.prompt:
+            self.add_user_message(run_config.prompt)
+
         logger.debug(f"----[{self.name}] Running Agent----")
 
         self.reset_iterations()
 
-        while self.should_continue(context):
-            if context and self.config.interactive:
-                self.use_user_messages(context)
-            self.run_iteration(context=context)
-            if context and name:
-                context.store_memory(name, self.memory)
+        while self.should_continue(run_config):
+            self.run_iteration(run_config=run_config)
 
-        if self.iterations == self.config.max_iterations:
+        if self.iterations == run_config.max_iterations:
             raise MaxIterationsReachedException(
                 f"Agent {self.name} reached maximum iterations without finishing."
             )
@@ -252,39 +161,3 @@ class LlmAgent(ABC):
 
 class MaxIterationsReachedException(Exception):
     pass
-
-
-class GptAgent(LlmAgent):
-    @inject
-    def __init__(
-        self,
-        config: AgentConfig = AgentConfig(),
-        client: GptClient = injected,
-        tools: Optional[list[FunctionTool]] = None,
-        memory: Optional[list[Message]] = None,
-        name: str = "GptAgent",
-    ):
-        super().__init__(config, client, tools, memory, name)
-        if not self.config.model:
-            self.config.model = DEFAULT_GPT_MODEL
-
-
-class ClaudeAgent(LlmAgent):
-    @inject
-    def __init__(
-        self,
-        config: AgentConfig = AgentConfig(),
-        client: ClaudeClient = injected,
-        tools: Optional[list[FunctionTool]] = None,
-        memory: Optional[list[Message]] = None,
-        name: str = "ClaudeAgent",
-    ):
-        super().__init__(
-            config,
-            client,
-            tools,
-            memory,
-            name,
-        )
-        if not self.config.model:
-            self.config.model = DEFAULT_CLAUDE_MODEL

--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -78,7 +78,7 @@ class OpenAiProvider:
 
     def _get_config(self, model_name: str):
         for config in self.default_configs:
-            if re.match(config["match"], model_name):
+            if re.match(config["match"], model_name):  # type: ignore
                 return config
         return None
 
@@ -99,13 +99,9 @@ class OpenAiProvider:
 
         completion = openai_client.chat.completions.create(
             model=self.provider.model_name,
-            messages=cast(Iterable[ChatCompletionMessageParam], message_dicts),
+            messages=message_dicts,
             temperature=temperature,
-            tools=(
-                cast(Iterable[ChatCompletionToolParam], tool_dicts)
-                if tool_dicts
-                else openai.NotGiven()
-            ),
+            tools=(tool_dicts if tool_dicts else openai.NotGiven()),
             max_tokens=max_tokens or openai.NotGiven(),
         )
 
@@ -170,7 +166,7 @@ class OpenAiProvider:
                 if tool_dicts
                 else openai.NotGiven()
             ),
-            response_format=response_format,  # type: ignore
+            response_format=response_format,
             max_tokens=max_tokens or openai.NotGiven(),
         )
 
@@ -253,7 +249,7 @@ class AnthropicProvider:
 
     def _get_config(self, model_name: str):
         for config in self.default_configs:
-            if re.match(config["match"], model_name):
+            if re.match(config["match"], model_name):  # type: ignore
                 return config
         return None
 

--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -2,11 +2,17 @@ import json
 import logging
 import re
 from dataclasses import dataclass
-from typing import ClassVar, Iterable, Optional, Type, Union, cast
+from typing import Any, ClassVar, Iterable, Type, Union, cast
 
 import anthropic
 from anthropic import NOT_GIVEN
-from anthropic.types import MessageParam, ToolParam
+from anthropic.types import (
+    MessageParam,
+    TextBlockParam,
+    ToolParam,
+    ToolResultBlockParam,
+    ToolUseBlockParam,
+)
 from langfuse.decorators import langfuse_context, observe
 from langfuse.openai import openai
 from openai.types.chat import ChatCompletionMessageParam, ChatCompletionToolParam
@@ -16,7 +22,6 @@ from seer.automation.agent.models import (
     LlmGenerateTextResponse,
     LlmModelDefaultConfig,
     LlmProviderDefaults,
-    LlmProviderDefinition,
     LlmProviderType,
     LlmRefusalError,
     LlmResponseMetadata,
@@ -35,7 +40,9 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class OpenAiProvider:
-    provider: LlmProviderDefinition
+    model_name: str
+    provider_name = LlmProviderType.OPENAI
+    defaults: LlmProviderDefaults | None = None
 
     default_configs: ClassVar[list[LlmModelDefaultConfig]] = [
         LlmModelDefaultConfig(
@@ -60,11 +67,8 @@ class OpenAiProvider:
     def model(cls, model_name: str) -> "OpenAiProvider":
         model_config = cls._get_config(model_name)
         return cls(
-            provider=LlmProviderDefinition(
-                model_name=model_name,
-                provider_name=LlmProviderType.OPENAI,
-                defaults=model_config.defaults if model_config else None,
-            )
+            model_name=model_name,
+            defaults=model_config.defaults if model_config else None,
         )
 
     @classmethod
@@ -79,8 +83,8 @@ class OpenAiProvider:
         *,
         prompt: str | None = None,
         messages: list[Message] | None = None,
-        system_prompt: Optional[str] = None,
-        tools: Optional[list[FunctionTool]] = [],
+        system_prompt: str | None = None,
+        tools: list[FunctionTool] | None = None,
         temperature: float | None = None,
         max_tokens: int | None = None,
     ):
@@ -94,7 +98,7 @@ class OpenAiProvider:
         openai_client = self.get_client()
 
         completion = openai_client.chat.completions.create(
-            model=self.provider.model_name,
+            model=self.model_name,
             messages=cast(Iterable[ChatCompletionMessageParam], message_dicts),
             temperature=temperature,
             tools=(
@@ -131,8 +135,8 @@ class OpenAiProvider:
         return LlmGenerateTextResponse(
             message=message,
             metadata=LlmResponseMetadata(
-                model=self.provider.model_name,
-                provider_name=self.provider.provider_name,
+                model=self.model_name,
+                provider_name=self.provider_name,
                 usage=usage,
             ),
         )
@@ -142,8 +146,8 @@ class OpenAiProvider:
         *,
         prompt: str | None = None,
         messages: list[Message] | None = None,
-        system_prompt: Optional[str] = None,
-        tools: Optional[list[FunctionTool]] = [],
+        system_prompt: str | None = None,
+        tools: list[FunctionTool] | None = None,
         temperature: float | None = None,
         response_format: Type[StructuredOutputType],
         max_tokens: int | None = None,
@@ -158,7 +162,7 @@ class OpenAiProvider:
         openai_client = self.get_client()
 
         completion = openai_client.beta.chat.completions.parse(
-            model=self.provider.model_name,
+            model=self.model_name,
             messages=cast(Iterable[ChatCompletionMessageParam], message_dicts),
             temperature=temperature,
             tools=(
@@ -185,36 +189,79 @@ class OpenAiProvider:
         return LlmGenerateStructuredResponse(
             parsed=parsed,
             metadata=LlmResponseMetadata(
-                model=self.provider.model_name,
-                provider_name=self.provider.provider_name,
+                model=self.model_name,
+                provider_name=self.provider_name,
                 usage=usage,
             ),
         )
 
     @staticmethod
+    def to_message_dict(message: Message) -> ChatCompletionMessageParam:
+        message_dict: dict[str, Any] = {
+            "content": message.content if message.content else "",
+            "role": message.role,
+        }
+
+        if message.tool_calls:
+            tool_calls = [tool_call.model_dump(mode="json") for tool_call in message.tool_calls]
+            parsed_tool_calls = []
+            for item in tool_calls:
+                new_item = item.copy()
+                new_item["function"] = {"name": item["function"], "arguments": item["args"]}
+                new_item["type"] = "function"
+                parsed_tool_calls.append(new_item)
+            message_dict["tool_calls"] = parsed_tool_calls
+
+        if message.tool_call_id:
+            message_dict["tool_call_id"] = message.tool_call_id
+
+        return cast(ChatCompletionMessageParam, message_dict)
+
+    @staticmethod
+    def to_tool_dict(tool: FunctionTool) -> ChatCompletionToolParam:
+        return ChatCompletionToolParam(
+            type="function",
+            function={
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        param["name"]: {
+                            key: value
+                            for key, value in {
+                                "type": param["type"],
+                                "description": param.get("description", ""),
+                                "items": param.get("items"),
+                            }.items()
+                            if value is not None
+                        }
+                        for param in tool.parameters
+                    },
+                    "required": tool.required,
+                },
+            },
+        )
+
+    @classmethod
     def _prep_message_and_tools(
+        cls,
         *,
         messages: list[Message] | None = None,
         prompt: str | None = None,
-        system_prompt: Optional[str] = None,
-        tools: Optional[list[FunctionTool]] = [],
+        system_prompt: str | None = None,
+        tools: list[FunctionTool] | None = None,
     ):
-        message_dicts = (
-            [message.to_message(LlmProviderType.OPENAI) for message in messages] if messages else []
-        )
+        message_dicts = [cls.to_message_dict(message) for message in messages] if messages else []
         if system_prompt:
             message_dicts.insert(
-                0, Message(role="system", content=system_prompt).to_message(LlmProviderType.OPENAI)
+                0, cls.to_message_dict(Message(role="system", content=system_prompt))
             )
         if prompt:
-            message_dicts.insert(
-                0, Message(role="user", content=prompt).to_message(LlmProviderType.OPENAI)
-            )
+            message_dicts.insert(0, cls.to_message_dict(Message(role="user", content=prompt)))
 
         tool_dicts = (
-            [tool.to_dict(LlmProviderType.OPENAI) for tool in tools]
-            if tools and len(tools) > 0
-            else None
+            [cls.to_tool_dict(tool) for tool in tools] if tools and len(tools) > 0 else None
         )
 
         return message_dicts, tool_dicts
@@ -222,7 +269,9 @@ class OpenAiProvider:
 
 @dataclass
 class AnthropicProvider:
-    provider: LlmProviderDefinition
+    model_name: str
+    provider_name = LlmProviderType.ANTHROPIC
+    defaults: LlmProviderDefaults | None = None
 
     default_configs: ClassVar[list[LlmModelDefaultConfig]] = [
         LlmModelDefaultConfig(
@@ -243,11 +292,8 @@ class AnthropicProvider:
     def model(cls, model_name: str) -> "AnthropicProvider":
         model_config = cls._get_config(model_name)
         return cls(
-            provider=LlmProviderDefinition(
-                model_name=model_name,
-                provider_name=LlmProviderType.ANTHROPIC,
-                defaults=model_config.defaults if model_config else None,
-            )
+            model_name=model_name,
+            defaults=model_config.defaults if model_config else None,
         )
 
     @classmethod
@@ -280,7 +326,7 @@ class AnthropicProvider:
 
         completion = anthropic_client.messages.create(
             system=system_prompt or NOT_GIVEN,
-            model=self.provider.model_name,
+            model=self.model_name,
             tools=cast(Iterable[ToolParam], tool_dicts) if tool_dicts else NOT_GIVEN,
             messages=cast(Iterable[MessageParam], message_dicts),
             max_tokens=max_tokens or 8192,
@@ -295,13 +341,13 @@ class AnthropicProvider:
             total_tokens=completion.usage.input_tokens + completion.usage.output_tokens,
         )
 
-        langfuse_context.update_current_observation(model=self.provider.model_name, usage=usage)
+        langfuse_context.update_current_observation(model=self.model_name, usage=usage)
 
         return LlmGenerateTextResponse(
             message=message,
             metadata=LlmResponseMetadata(
-                model=self.provider.model_name,
-                provider_name=self.provider.provider_name,
+                model=self.model_name,
+                provider_name=self.provider_name,
                 usage=usage,
             ),
         )
@@ -327,27 +373,77 @@ class AnthropicProvider:
         return message
 
     @staticmethod
+    def to_message_param(message: Message) -> MessageParam:
+        if message.role == "tool":
+            return MessageParam(
+                role="user",
+                content=[
+                    ToolResultBlockParam(
+                        type="tool_result",
+                        content=message.content or "",
+                        tool_use_id=message.tool_call_id or "",
+                    )
+                ],
+            )
+        elif message.role == "tool_use":
+            if not message.tool_calls:
+                return MessageParam(role="assistant", content=[])
+            tool_call = message.tool_calls[0]  # Assuming only one tool call per message
+            return MessageParam(
+                role="assistant",
+                content=[
+                    ToolUseBlockParam(
+                        type="tool_use",
+                        id=tool_call.id or "",
+                        name=tool_call.function,
+                        input=json.loads(tool_call.args),
+                    )
+                ],
+            )
+        else:
+            return MessageParam(
+                role=message.role,  # type: ignore
+                content=[TextBlockParam(type="text", text=message.content or "")],
+            )
+
+    @staticmethod
+    def to_tool_dict(tool: FunctionTool) -> ToolParam:
+        return ToolParam(
+            name=tool.name,
+            description=tool.description,
+            input_schema={
+                "type": "object",
+                "properties": {
+                    param["name"]: {
+                        key: value
+                        for key, value in {
+                            "type": param["type"],
+                            "description": param.get("description", ""),
+                            "items": param.get("items"),
+                        }.items()
+                        if value is not None
+                    }
+                    for param in tool.parameters
+                },
+                "required": tool.required,
+            },
+        )
+
+    @classmethod
     def _prep_message_and_tools(
+        cls,
         *,
         messages: list[Message] | None = None,
         prompt: str | None = None,
-        system_prompt: Optional[str] = None,
-        tools: Optional[list[FunctionTool]] = [],
-    ):
-        message_dicts = (
-            [message.to_message(LlmProviderType.ANTHROPIC) for message in messages]
-            if messages
-            else []
-        )
+        system_prompt: str | None = None,
+        tools: list[FunctionTool] | None = None,
+    ) -> tuple[list[MessageParam], list[ToolParam] | None, str | None]:
+        message_dicts = [cls.to_message_param(message) for message in messages] if messages else []
         if prompt:
-            message_dicts.insert(
-                0, Message(role="user", content=prompt).to_message(LlmProviderType.ANTHROPIC)
-            )
+            message_dicts.insert(0, cls.to_message_param(Message(role="user", content=prompt)))
 
         tool_dicts = (
-            [tool.to_dict(LlmProviderType.ANTHROPIC) for tool in tools]
-            if tools and len(tools) > 0
-            else None
+            [cls.to_tool_dict(tool) for tool in tools] if tools and len(tools) > 0 else None
         )
 
         return message_dicts, tool_dicts, system_prompt
@@ -364,8 +460,8 @@ class LlmClient:
         prompt: str | None = None,
         messages: list[Message] | None = None,
         model: LlmProvider,
-        system_prompt: Optional[str] = None,
-        tools: Optional[list[FunctionTool]] = [],
+        system_prompt: str | None = None,
+        tools: list[FunctionTool] | None = None,
         temperature: float | None = None,
         max_tokens: int | None = None,
         run_name: str | None = None,
@@ -374,11 +470,11 @@ class LlmClient:
             langfuse_context.update_current_observation(name=run_name + " - Generate Text")
             langfuse_context.flush()
 
-        defaults = model.provider.defaults
+        defaults = model.defaults
         default_temperature = defaults.temperature if defaults else None
         # More defaults to come
 
-        if model.provider.provider_name == LlmProviderType.OPENAI:
+        if model.provider_name == LlmProviderType.OPENAI:
             model = cast(OpenAiProvider, model)
 
             return model.generate_text(
@@ -389,7 +485,7 @@ class LlmClient:
                 temperature=temperature or default_temperature,
                 tools=tools,
             )
-        elif model.provider.provider_name == LlmProviderType.ANTHROPIC:
+        elif model.provider_name == LlmProviderType.ANTHROPIC:
             model = cast(AnthropicProvider, model)
 
             return model.generate_text(
@@ -401,7 +497,7 @@ class LlmClient:
                 tools=tools,
             )
         else:
-            raise ValueError(f"Invalid provider: {model.provider.provider_name}")
+            raise ValueError(f"Invalid provider: {model.provider_name}")
 
     @observe(name="Generate Structured")
     def generate_structured(
@@ -410,9 +506,9 @@ class LlmClient:
         prompt: str,
         messages: list[Message] | None = None,
         model: LlmProvider,
-        system_prompt: Optional[str] = None,
+        system_prompt: str | None = None,
         response_format: Type[StructuredOutputType],
-        tools: Optional[list[FunctionTool]] = [],
+        tools: list[FunctionTool] | None = None,
         temperature: float | None = None,
         max_tokens: int | None = None,
         run_name: str | None = None,
@@ -420,7 +516,7 @@ class LlmClient:
         if run_name:
             langfuse_context.update_current_observation(name=run_name + " - Generate Structured")
 
-        if model.provider.provider_name == LlmProviderType.OPENAI:
+        if model.provider_name == LlmProviderType.OPENAI:
             model = cast(OpenAiProvider, model)
             return model.generate_structured(
                 max_tokens=max_tokens,
@@ -431,10 +527,10 @@ class LlmClient:
                 temperature=temperature,
                 tools=tools,
             )
-        elif model.provider.provider_name == LlmProviderType.ANTHROPIC:
+        elif model.provider_name == LlmProviderType.ANTHROPIC:
             raise NotImplementedError("Anthropic structured outputs are not yet supported")
         else:
-            raise ValueError(f"Invalid provider: {model.provider.provider_name}")
+            raise ValueError(f"Invalid provider: {model.provider_name}")
 
     @staticmethod
     def clean_tool_call_assistant_messages(messages: list[Message]) -> list[Message]:

--- a/src/seer/automation/agent/models.py
+++ b/src/seer/automation/agent/models.py
@@ -1,6 +1,6 @@
 import json
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Generic, Optional, TypeVar
 
 from pydantic import BaseModel
 
@@ -103,3 +103,43 @@ class Message(BaseModel):
                 }
         else:
             raise ValueError(f"Unsupported provider: {provider_name}")
+
+
+class LlmResponseMetadata(BaseModel):
+    model: str
+    provider_name: LlmProviderType
+    usage: Usage
+
+
+class LlmGenerateTextResponse(BaseModel):
+    message: Message
+    metadata: LlmResponseMetadata
+
+
+StructuredOutputType = TypeVar("StructuredOutputType")
+
+
+class LlmGenerateStructuredResponse(BaseModel, Generic[StructuredOutputType]):
+    parsed: StructuredOutputType
+    metadata: LlmResponseMetadata
+
+
+class LlmProviderDefaults(BaseModel):
+    temperature: float | None = None
+
+
+class LlmProviderDefinition(BaseModel):
+    model_name: str
+    provider_name: LlmProviderType
+    defaults: LlmProviderDefaults | None = None
+
+
+class LlmModelDefaultConfig(BaseModel):
+    match: str
+    defaults: LlmProviderDefaults
+
+
+class LlmRefusalError(Exception):
+    """Raised when the LLM refuses to complete the request."""
+
+    pass

--- a/src/seer/automation/agent/tools.py
+++ b/src/seer/automation/agent/tools.py
@@ -70,7 +70,7 @@ class FunctionTool(BaseModel):
                 function={
                     "name": self.name,
                     "description": self.description,
-                    "parameters": base_schema,
+                    "parameters": base_schema,  # type: ignore
                 },
             )
         elif provider == LlmProviderType.ANTHROPIC:

--- a/src/seer/automation/autofix/autofix_agent.py
+++ b/src/seer/automation/autofix/autofix_agent.py
@@ -1,0 +1,150 @@
+import logging
+import threading
+from typing import Optional
+
+from seer.automation.agent.agent import (
+    AgentConfig,
+    LlmAgent,
+    MaxIterationsReachedException,
+    RunConfig,
+)
+from seer.automation.agent.models import Message
+from seer.automation.agent.tools import FunctionTool
+from seer.automation.autofix.autofix_context import AutofixContext
+from seer.automation.autofix.components.insight_sharing.component import InsightSharingComponent
+from seer.automation.autofix.components.insight_sharing.models import InsightSharingRequest
+from seer.automation.autofix.models import AutofixStatus, DefaultStep
+from seer.bootup import module
+from seer.configuration import configuration_module
+
+logger = logging.getLogger(__name__)
+
+
+class AutofixAgent(LlmAgent):
+    def __init__(
+        self,
+        config: AgentConfig,
+        context: AutofixContext,
+        tools: Optional[list[FunctionTool]] = None,
+        memory: Optional[list[Message]] = None,
+        name: str = "Agent",
+    ):
+        super().__init__(config=config, tools=tools, memory=memory, name=name)
+        self.context = context
+
+    def should_continue(self, run_config: RunConfig) -> bool:
+        if self.context.state.get().steps[-1].status == AutofixStatus.WAITING_FOR_USER_RESPONSE:
+            return False
+
+        return super().should_continue(run_config)
+
+    def run(self, run_config: RunConfig):
+        if run_config.prompt:
+            self.add_user_message(run_config.prompt)
+        logger.debug(f"----[{self.name}] Running Agent----")
+
+        self.reset_iterations()
+
+        while self.should_continue(run_config):
+            if self.config.interactive:
+                self.use_user_messages()
+            self.run_iteration(run_config=run_config)
+            if run_config.name:
+                self.context.store_memory(run_config.name, self.memory)
+
+        if self.iterations == run_config.max_iterations:
+            raise MaxIterationsReachedException(
+                f"Agent {self.name} reached maximum iterations without finishing."
+            )
+
+        return self.get_last_message_content()
+
+    def run_iteration(self, run_config: RunConfig):
+        logger.debug(f"----[{self.name}] Running Iteration {self.iterations}----")
+
+        completion = self.get_completion(run_config)
+
+        # interrupt if user message is queued and awaiting handling
+        if self.context.state.get().steps[-1].queued_user_messages:
+            self.use_user_messages()
+            return
+
+        self.memory.append(completion.message)
+
+        # log thoughts to the user
+        if (
+            completion.message.content
+            and self.config.interactive
+            and not self.context.state.get().request.options.disable_interactivity
+        ):
+            text_before_tag = completion.message.content.split("<")[0]
+            text = text_before_tag
+            if text:
+                self.run_in_thread(
+                    func=self.share_insights, args=(self.context, text, len(self.memory) - 1)
+                )
+
+        # call any tools the model wants to use
+        if completion.message.tool_calls:
+            for tool_call in completion.message.tool_calls:
+                tool_response = self.call_tool(tool_call)
+                self.memory.append(tool_response)
+
+        self.iterations += 1
+        self.usage += completion.metadata.usage
+
+        return self.memory
+
+    def use_user_messages(self):
+        # adds any queued user messages to the memory
+        user_msgs = self.context.state.get().steps[-1].queued_user_messages
+        if user_msgs:
+            # enforce alternating user/assistant messages
+            msg = "\n".join(user_msgs)
+            for item in reversed(self.memory):
+                if item.role == "user":
+                    self.memory.append(Message(content=".", role="assistant"))
+                    break
+                elif item.role == "assistant":
+                    break
+            self.memory.append(Message(content=msg, role="user"))
+
+            with self.context.state.update() as cur:
+                cur.steps[-1].queued_user_messages = []
+            self.context.event_manager.add_log(
+                "Thanks for the input. I'm thinking through it now..."
+            )
+
+    def run_in_thread(self, func, args):
+        def wrapper():
+            # ensures dependency injection works
+            module.enable()
+            configuration_module.enable()
+
+            func(*args)
+
+        threading.Thread(target=wrapper).start()
+
+    def share_insights(self, context: AutofixContext, text: str, generated_at_memory_index: int):
+        # generate insights
+        insight_sharing = InsightSharingComponent(context)
+        past_insights = context.state.get().get_all_insights()
+        insight_card = insight_sharing.invoke(
+            InsightSharingRequest(
+                latest_thought=text,
+                memory=self.memory,
+                task_description=context.state.get().get_step_description(),
+                past_insights=past_insights,
+                generated_at_memory_index=generated_at_memory_index,
+            )
+        )
+        # add the insight card to the current step
+        if insight_card:
+            if len(context.state.get().get_all_insights()) == len(
+                past_insights
+            ):  # in case something else was added in parallel, don't add this insight
+                with context.state.update() as cur:
+                    if cur.steps and isinstance(cur.steps[-1], DefaultStep):
+                        step = cur.steps[-1]
+                        step.insights.append(insight_card)
+                        cur.steps[-1] = step

--- a/src/seer/automation/autofix/components/coding/component.py
+++ b/src/seer/automation/autofix/components/coding/component.py
@@ -5,7 +5,6 @@ from sentry_sdk.ai.monitoring import ai_track
 
 from seer.automation.agent.agent import AgentConfig, RunConfig
 from seer.automation.agent.client import AnthropicProvider, LlmClient
-from seer.automation.agent.models import Message
 from seer.automation.autofix.autofix_agent import AutofixAgent
 from seer.automation.autofix.autofix_context import AutofixContext
 from seer.automation.autofix.components.coding.models import (
@@ -50,16 +49,11 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
         for file_path, file_missing_obj in missing_changes_by_file.items():
             new_response = llm_client.generate_text(
                 model=AnthropicProvider.model("claude-3-5-sonnet@20240620"),
-                messages=[
-                    Message(
-                        role="user",
-                        content=CodingPrompts.format_incorrect_diff_fixer(
-                            file_path,
-                            file_missing_obj.diff_chunks,
-                            file_missing_obj.file_content,
-                        ),
-                    )
-                ],
+                prompt=CodingPrompts.format_incorrect_diff_fixer(
+                    file_path,
+                    file_missing_obj.diff_chunks,
+                    file_missing_obj.file_content,
+                ),
                 temperature=0.0,
                 run_name="Incorrect Diff Fixer",
             )

--- a/src/seer/automation/autofix/components/coding/component.py
+++ b/src/seer/automation/autofix/components/coding/component.py
@@ -60,6 +60,8 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
                         ),
                     )
                 ],
+                temperature=0.0,
+                run_name="Incorrect Diff Fixer",
             )
 
             with self.context.state.update() as cur:
@@ -98,6 +100,7 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
                 config=AgentConfig(interactive=True),
                 memory=request.initial_memory,
                 context=self.context,
+                name="Plan+Code",
             )
 
             task_str = (
@@ -126,7 +129,8 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
                     ),
                     system_prompt=CodingPrompts.format_system_msg(),
                     model=AnthropicProvider.model("claude-3-5-sonnet@20240620"),
-                    name="plan_and_code",
+                    memory_storage_key="plan_and_code",
+                    run_name="Plan",
                 ),
             )
 
@@ -142,7 +146,8 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
                 RunConfig(
                     prompt=CodingPrompts.format_fix_msg(),
                     model=AnthropicProvider.model("claude-3-5-sonnet@20240620"),
-                    name="plan_and_code",
+                    memory_storage_key="plan_and_code",
+                    run_name="Code",
                 ),
             )
 
@@ -180,7 +185,8 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
                             missing_files_errors, file_exist_errors
                         ),
                         model=AnthropicProvider.model("claude-3-5-sonnet@20240620"),
-                        name="plan_and_code",
+                        memory_storage_key="plan_and_code",
+                        run_name="Missing File Fix",
                     ),
                 )
 

--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -3,9 +3,9 @@ import logging
 from langfuse.decorators import observe
 from sentry_sdk.ai.monitoring import ai_track
 
-from seer.automation.agent.agent import AgentConfig, GptAgent
-from seer.automation.agent.client import GptClient
-from seer.automation.agent.models import Message
+from seer.automation.agent.agent import AgentConfig, RunConfig
+from seer.automation.agent.client import LlmClient, OpenAiProvider
+from seer.automation.autofix.autofix_agent import AutofixAgent
 from seer.automation.autofix.autofix_context import AutofixContext
 from seer.automation.autofix.components.root_cause.models import (
     MultipleRootCauseAnalysisOutputPrompt,
@@ -15,8 +15,6 @@ from seer.automation.autofix.components.root_cause.models import (
 from seer.automation.autofix.components.root_cause.prompts import RootCauseAnalysisPrompts
 from seer.automation.autofix.tools import BaseTools
 from seer.automation.component import BaseComponent
-from seer.automation.utils import extract_parsed_model
-from seer.dependency_injection import inject, injected
 
 logger = logging.getLogger(__name__)
 
@@ -26,18 +24,14 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
 
     @observe(name="Root Cause Analysis")
     @ai_track(description="Root Cause Analysis")
-    @inject
-    def invoke(
-        self, request: RootCauseAnalysisRequest, gpt_client: GptClient = injected
-    ) -> RootCauseAnalysisOutput | None:
+    def invoke(self, request: RootCauseAnalysisRequest) -> RootCauseAnalysisOutput | None:
         with BaseTools(self.context) as tools:
-            agent = GptAgent(
+            agent = AutofixAgent(
                 tools=tools.get_tools(),
                 config=AgentConfig(
-                    system_prompt=RootCauseAnalysisPrompts.format_system_msg(),
-                    max_iterations=24,
                     interactive=True,
                 ),
+                context=self.context,
                 memory=request.initial_memory,
             )
 
@@ -45,18 +39,22 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
 
             try:
                 response = agent.run(
-                    (
-                        RootCauseAnalysisPrompts.format_default_msg(
-                            event=request.event_details.format_event(),
-                            summary=request.summary,
-                            instruction=request.instruction,
-                            repo_names=[repo.full_name for repo in state.request.repos],
-                        )
-                        if not request.initial_memory
-                        else None
+                    run_config=RunConfig(
+                        model=OpenAiProvider.model("gpt-4o-2024-08-06"),
+                        prompt=(
+                            RootCauseAnalysisPrompts.format_default_msg(
+                                event=request.event_details.format_event(),
+                                summary=request.summary,
+                                instruction=request.instruction,
+                                repo_names=[repo.full_name for repo in state.request.repos],
+                            )
+                            if not request.initial_memory
+                            else None
+                        ),
+                        system_prompt=RootCauseAnalysisPrompts.format_system_msg(),
+                        max_iterations=24,
+                        name="root_cause_analysis",
                     ),
-                    context=self.context,
-                    name="root_cause_analysis",
                 )
 
                 if not response:
@@ -69,31 +67,23 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
                 # Ask for reproduction
                 self.context.event_manager.add_log("Thinking about how to reproduce the issue...")
                 agent.run(
-                    RootCauseAnalysisPrompts.reproduction_prompt_msg(),
+                    run_config=RunConfig(
+                        model=OpenAiProvider.model("gpt-4o-2024-08-06"),
+                        prompt=RootCauseAnalysisPrompts.reproduction_prompt_msg(),
+                    )
                 )
 
-                self.context.store_memory("root_cause_analysis", agent.memory)
-
                 self.context.event_manager.add_log("Cleaning up my findings...")
-                response = gpt_client.openai_client.beta.chat.completions.parse(
-                    messages=[
-                        message.to_message()
-                        for message in gpt_client.clean_tool_call_assistant_messages(agent.memory)
-                    ]
-                    + [
-                        Message(
-                            role="user",
-                            content=RootCauseAnalysisPrompts.root_cause_formatter_msg(),
-                        ).to_message(),
-                    ],
-                    model="gpt-4o-2024-08-06",
+
+                formatted_response = LlmClient.generate_structured(
+                    messages=LlmClient.clean_tool_call_assistant_messages(agent.memory),
+                    prompt=RootCauseAnalysisPrompts.root_cause_formatter_msg(),
+                    model=OpenAiProvider.model("gpt-4o-2024-08-06"),
                     response_format=MultipleRootCauseAnalysisOutputPrompt,
                 )
 
-                parsed = extract_parsed_model(response)
-
                 # Assign the ids to be the numerical indices of the causes and relevant code context
-                cause_model = parsed.cause.to_model()
+                cause_model = formatted_response.parsed.cause.to_model()
                 cause_model.id = 0
                 if cause_model.code_context:
                     for j, snippet in enumerate(cause_model.code_context):

--- a/src/seer/automation/autofix/evaluations.py
+++ b/src/seer/automation/autofix/evaluations.py
@@ -252,10 +252,9 @@ def score_fix_single_it(dataset_item: DatasetItemClient, predicted_diff: str, mo
         expected_diff=dataset_item.expected_output.get("diff"),
         predicted_diff=predicted_diff,
     )
-    response = LlmClient.generate_text(
+    response = LlmClient().generate_text(
         model=OpenAiProvider.model(model),
         prompt=prompt,
-        temperature=0.0,
     )
     if not response.message.content:
         return 0
@@ -321,17 +320,16 @@ def score_root_cause_single_it(
         expected_output=expected_output.to_prompt_str(),
         predicted_solutions=solutions_str,
     )
-    response = LlmClient.generate_text(
+    response = LlmClient().generate_text(
         model=OpenAiProvider.model(model),
         prompt=prompt,
-        temperature=0.0,
     )
     if not response.message.content:
         raise ValueError("No response content")
 
     scores: list[float] = []
     for i in range(len(causes_xml)):
-        score_str = extract_text_inside_tags(response.content, f"score_{i + 1}")
+        score_str = extract_text_inside_tags(response.message.content, f"score_{i + 1}")
         score = float(score_str) if score_str else 0
         scores.append(score)
 

--- a/src/seer/automation/autofix/evaluations.py
+++ b/src/seer/automation/autofix/evaluations.py
@@ -6,8 +6,7 @@ from langfuse.client import DatasetItemClient
 from langfuse.decorators import observe
 from pydantic_xml import attr, element
 
-from seer.automation.agent.client import GptClient
-from seer.automation.agent.models import Message
+from seer.automation.agent.client import LlmClient, OpenAiProvider
 from seer.automation.autofix.components.coding.models import RootCausePlanTaskPromptXml
 from seer.automation.autofix.components.root_cause.models import (
     RootCauseAnalysisItem,
@@ -105,8 +104,6 @@ def sync_run_execution(item: DatasetItemClient):
             RootCauseAnalysisItem(
                 title=expected_output.root_cause,
                 description="",
-                likelihood=1.0,
-                actionability=1.0,
                 reproduction="",
                 code_context=[
                     RootCauseRelevantContext(
@@ -255,13 +252,15 @@ def score_fix_single_it(dataset_item: DatasetItemClient, predicted_diff: str, mo
         expected_diff=dataset_item.expected_output.get("diff"),
         predicted_diff=predicted_diff,
     )
-    response, usage = GptClient().completion(
-        messages=[Message(role="user", content=prompt)], model=model, temperature=1.0
+    response = LlmClient.generate_text(
+        model=OpenAiProvider.model(model),
+        prompt=prompt,
+        temperature=0.0,
     )
-    if not response.content:
+    if not response.message.content:
         return 0
 
-    tree = ET.fromstring(f"<root>{escape_multi_xml(response.content, ['score'])}</root>")
+    tree = ET.fromstring(f"<root>{escape_multi_xml(response.message.content, ['score'])}</root>")
     score_str = extract_xml_element_text(tree, "score")
     score = float(score_str) if score_str else 0
 
@@ -322,10 +321,12 @@ def score_root_cause_single_it(
         expected_output=expected_output.to_prompt_str(),
         predicted_solutions=solutions_str,
     )
-    response, usage = GptClient().completion(
-        model=model, messages=[Message(role="user", content=prompt)]
+    response = LlmClient.generate_text(
+        model=OpenAiProvider.model(model),
+        prompt=prompt,
+        temperature=0.0,
     )
-    if not response.content:
+    if not response.message.content:
         raise ValueError("No response content")
 
     scores: list[float] = []

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -396,7 +396,11 @@ class RepoClient:
         return branch_ref
 
     def create_pr_from_branch(
-        self, branch: GitRef, title: str, description: str, provided_base: str | None = None
+        self,
+        branch: GitRef,
+        title: str,
+        description: str,
+        provided_base: str | None = None,
     ):
         return self.repo.create_pull(
             title=title,

--- a/src/seer/automation/codegen/unit_test_coding_component.py
+++ b/src/seer/automation/codegen/unit_test_coding_component.py
@@ -1,10 +1,11 @@
 import logging
 
-from langfuse.decorators import langfuse_context, observe
+from langfuse.decorators import observe
 from sentry_sdk.ai.monitoring import ai_track
 
 from integrations.codecov.codecov_client import CodecovClient
-from seer.automation.agent.agent import AgentConfig, ClaudeAgent, LlmAgent
+from seer.automation.agent.agent import AgentConfig, LlmAgent, RunConfig
+from seer.automation.agent.client import AnthropicProvider, LlmClient
 from seer.automation.autofix.components.coding.models import PlanStepsPromptXml
 from seer.automation.autofix.components.coding.utils import (
     task_to_file_change,
@@ -18,6 +19,7 @@ from seer.automation.codegen.prompts import CodingUnitTestPrompts
 from seer.automation.component import BaseComponent
 from seer.automation.models import FileChange
 from seer.automation.utils import escape_multi_xml, extract_text_inside_tags
+from seer.dependency_injection import inject, injected
 
 logger = logging.getLogger(__name__)
 
@@ -25,30 +27,16 @@ logger = logging.getLogger(__name__)
 class UnitTestCodingComponent(BaseComponent[CodeUnitTestRequest, CodeUnitTestOutput]):
     context: CodegenContext
 
-    @observe(name="Analyze existing test design")
-    @ai_track(description="AnalyzeTestDesign")
-    def _get_test_design_summary(self, agent: LlmAgent, prompt: str):
-        return agent.run(prompt)
-
-    @observe(name="Create plan")
-    @ai_track(description="GetTestPlan")
-    def _get_plan(self, agent: LlmAgent, prompt: str) -> str:
-        return agent.run(prompt)
-
-    @observe(name="Generate test tasks")
-    @ai_track(description="GenerateTests")
-    def _generate_tests(self, agent: LlmAgent, prompt: str) -> str:
-        return agent.run(prompt=prompt)
-
-    def invoke(self, request: CodeUnitTestRequest) -> CodeUnitTestOutput | None:
-        langfuse_context.update_current_trace(user_id="ram")
+    @observe(name="Generate unit tests")
+    @ai_track(description="Generate unit tests")
+    @inject
+    def invoke(
+        self, request: CodeUnitTestRequest, llm_client: LlmClient = injected
+    ) -> CodeUnitTestOutput | None:
         with BaseTools(self.context) as tools:
-
-            agent = ClaudeAgent(
+            agent = LlmAgent(
                 tools=tools.get_tools(),
-                config=AgentConfig(
-                    system_prompt=CodingUnitTestPrompts.format_system_msg(), max_iterations=24
-                ),
+                config=AgentConfig(interactive=False),
             )
 
             codecov_client_params = request.codecov_client_params
@@ -65,15 +53,15 @@ class UnitTestCodingComponent(BaseComponent[CodeUnitTestRequest, CodeUnitTestOut
                 latest_commit_sha=codecov_client_params["head_sha"],
             )
 
-            existing_test_design_response = self._get_test_design_summary(
-                agent=agent,
+            existing_test_design_response = llm_client.generate_text(
+                model=AnthropicProvider.model("claude-3-5-sonnet@20240620"),
                 prompt=CodingUnitTestPrompts.format_find_unit_test_pattern_step_msg(
                     diff_str=request.diff
                 ),
             )
 
-            self._get_plan(
-                agent=agent,
+            llm_client.generate_text(
+                model=AnthropicProvider.model("claude-3-5-sonnet@20240620"),
                 prompt=CodingUnitTestPrompts.format_plan_step_msg(
                     diff_str=request.diff,
                     has_coverage_info=code_coverage_data,
@@ -81,10 +69,14 @@ class UnitTestCodingComponent(BaseComponent[CodeUnitTestRequest, CodeUnitTestOut
                 ),
             )
 
-            final_response = self._generate_tests(
-                agent=agent,
-                prompt=CodingUnitTestPrompts.format_unit_test_msg(
-                    diff_str=request.diff, test_design_hint=existing_test_design_response
+            final_response = agent.run(
+                run_config=RunConfig(
+                    prompt=CodingUnitTestPrompts.format_unit_test_msg(
+                        diff_str=request.diff, test_design_hint=existing_test_design_response
+                    ),
+                    system_prompt=CodingUnitTestPrompts.format_system_msg(),
+                    model=AnthropicProvider.model("claude-3-5-sonnet@20240620"),
+                    run_name="Generate Unit Tests",
                 ),
             )
 
@@ -110,7 +102,6 @@ class UnitTestCodingComponent(BaseComponent[CodeUnitTestRequest, CodeUnitTestOut
                     logger.warning(f"Failed to get content for {task.file_path}")
                     continue
 
-                # TODO: Handle missing changes
                 changes, _ = task_to_file_change(task, file_content)
                 file_changes += changes
             elif task.type == "file_delete":

--- a/tests/automation/agent/test_agent.py
+++ b/tests/automation/agent/test_agent.py
@@ -8,12 +8,15 @@ from seer.automation.agent.agent import (
     MaxIterationsReachedException,
     RunConfig,
 )
-from seer.automation.agent.client import (
+from seer.automation.agent.client import OpenAiProvider
+from seer.automation.agent.models import (
     LlmGenerateTextResponse,
+    LlmProviderType,
     LlmResponseMetadata,
-    OpenAiProvider,
+    Message,
+    ToolCall,
+    Usage,
 )
-from seer.automation.agent.models import LlmProviderType, Message, ToolCall, Usage
 from seer.automation.agent.tools import FunctionTool
 
 

--- a/tests/automation/agent/test_agent.py
+++ b/tests/automation/agent/test_agent.py
@@ -1,316 +1,209 @@
-import threading
-from typing import Any, Callable
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
 from seer.automation.agent.agent import (
     AgentConfig,
-    ClaudeAgent,
-    GptAgent,
     LlmAgent,
     MaxIterationsReachedException,
+    RunConfig,
 )
-from seer.automation.agent.client import ClaudeClient, GptClient, LlmClient, T
-from seer.automation.agent.models import Message, ToolCall, Usage
+from seer.automation.agent.client import (
+    LlmGenerateTextResponse,
+    LlmResponseMetadata,
+    OpenAiProvider,
+)
+from seer.automation.agent.models import LlmProviderType, Message, ToolCall, Usage
 from seer.automation.agent.tools import FunctionTool
-from seer.automation.autofix.autofix_context import AutofixContext
-from seer.automation.autofix.components.insight_sharing.models import InsightSharingRequest
-from seer.automation.autofix.models import DefaultStep
-from seer.dependency_injection import resolve
 
 
-class TestLlmAgent:
-    @pytest.fixture
-    def config(self):
-        return AgentConfig()
-
-    @pytest.fixture
-    def client(self):
-        class TestClient(LlmClient):
-            def completion(
-                self,
-                messages: list[Message],
-                model: str,
-                system_prompt: str | None = None,
-                tools: list[FunctionTool] | None = ...,
-                response_format: dict | None = None,
-            ) -> tuple[Message, Usage]:
-                pass
-
-            def completion_with_parser(
-                self,
-                messages: list[Message],
-                parser: Callable[[str | None], T],
-                model: str,
-                system_prompt: str | None = None,
-                tools: list[FunctionTool] | None = None,
-                response_format: dict | None = None,
-            ) -> tuple[T, Message, Usage]:
-                pass
-
-            def json_completion(
-                self, messages: list[Message], model: str, system_prompt: str | None = None
-            ) -> tuple[dict[str, Any] | None, Message, Usage]:
-                pass
-
-        return TestClient()
-
-    @pytest.fixture
-    def agent(self, config, client):
-        class TestAgent(LlmAgent):
-            def run_iteration(self):
-                pass
-
-        return TestAgent(config=config, client=client)
-
-    def test_should_continue(self, agent: LlmAgent):
-        assert agent.should_continue()  # Initial state
-
-        agent.iterations = agent.config.max_iterations
-        agent.memory = [Message(role="assistant", content="STOP")]
-        assert not agent.should_continue()  # Max iterations reached
-
-        agent.iterations = 1
-        agent.config.stop_message = "STOP"
-        assert not agent.should_continue()  # Stop message found
-
-    def test_add_user_message(self, agent: LlmAgent):
-        agent.add_user_message("Test message")
-        assert len(agent.memory) == 1
-        assert agent.memory[0].role == "user"
-        assert agent.memory[0].content == "Test message"
-
-    def test_get_last_message_content(self, agent: LlmAgent):
-        assert agent.get_last_message_content() is None  # Empty memory
-        agent.memory = [Message(role="user", content="Test")]
-        assert agent.get_last_message_content() == "Test"
-
-    def test_call_tool(self, agent: LlmAgent):
-        mock_tool_fn = MagicMock(return_value="Tool result")
-        mock_tool = FunctionTool(
-            name="test_tool",
-            description="Test tool",
-            fn=mock_tool_fn,
-            parameters=[],
-        )
-        mock_tool.name = "test_tool"
-
-        agent.tools = [mock_tool]
-
-        tool_call = ToolCall(id="123", function="test_tool", args='{"arg": "value"}')
-        result = agent.call_tool(tool_call)
-
-        assert isinstance(result, Message)
-        assert result.role == "tool"
-        assert result.content == "Tool result"
-        assert result.tool_call_id == "123"
-
-    def test_get_tool_by_name(self, agent: LlmAgent):
-        tool = FunctionTool(
-            name="test_tool", description="Test tool", fn=lambda: None, parameters=[]
-        )
-        agent.tools = [tool]
-        assert agent.get_tool_by_name("test_tool") == tool
-
-        with pytest.raises(StopIteration):
-            agent.get_tool_by_name("non_existent_tool")
-
-    def test_parse_tool_arguments(self, agent: LlmAgent):
-        tool = FunctionTool(
-            name="test_tool",
-            description="Test tool",
-            fn=lambda: None,
-            parameters=[{"name": "arg1"}, {"name": "arg2"}],
-        )
-        args = '{"arg1": "value1", "arg2": "value2", "arg3": "value3"}'
-        parsed_args = agent.parse_tool_arguments(tool, args)
-        assert parsed_args == {"arg1": "value1", "arg2": "value2"}
+@pytest.fixture
+def mock_llm_client():
+    return Mock()
 
 
-class TestGptAgent:
-    @pytest.fixture(params=[(GptAgent, GptClient), (ClaudeAgent, ClaudeClient)])
-    def agent_and_client_classes(self, request):
-        return request.param
+@pytest.fixture
+def agent(mock_llm_client):
+    config = AgentConfig()
+    return LlmAgent(config=config, client=mock_llm_client, name="TestAgent")
 
-    @pytest.fixture
-    def config(self):
-        return AgentConfig(interactive=True)
 
-    @pytest.fixture
-    def agent(self, agent_and_client_classes, config):
-        agent_class, _ = agent_and_client_classes
-        return agent_class(config)
+@pytest.fixture
+def run_config():
+    return RunConfig(
+        system_prompt="You are a helpful assistant.",
+        prompt="Hello, how are you?",
+        model=MagicMock(spec=OpenAiProvider),
+        temperature=0.0,
+        run_name="Test Run",
+    )
 
-    @pytest.fixture
-    def mock_client(self, agent_and_client_classes):
-        _, client_class = agent_and_client_classes
-        return resolve(client_class)
 
-    @pytest.fixture
-    def mock_context(self):
-        context = MagicMock(spec=AutofixContext)
-        state = MagicMock()
-        state.steps = [DefaultStep(title="Test step title")]
-        state.get_all_insights.return_value = []
-        state.get_step_description.return_value = "Test step"
-        state.request.options.disable_interactivity = False
-        context.state = MagicMock()
-        context.state.get.return_value = state
-        return context
+def test_agent_initialization(agent):
+    assert not agent.config.interactive
+    assert agent.name == "TestAgent"
+    assert agent.iterations == 0
+    assert agent.memory == []
 
-    @patch("seer.automation.agent.agent.InsightSharingComponent")
-    @patch("seer.automation.agent.agent.LlmAgent.run_in_thread")
-    def test_run_iteration(self, mock_thread, mock_insight_sharing, agent, mock_context):
-        # Mock the message and usage
-        mock_message = Message(role="assistant", content="Test response")
-        mock_usage = Usage(completion_tokens=10, prompt_tokens=20, total_tokens=30)
-        agent.get_completion = MagicMock(return_value=(mock_message, mock_usage))
 
-        # Mock the insight sharing component
-        mock_insight_card = MagicMock()
-        mock_insight_sharing_instance = MagicMock()
-        mock_insight_sharing_instance.invoke.return_value = mock_insight_card
-        mock_insight_sharing.return_value = mock_insight_sharing_instance
+def test_add_user_message(agent):
+    agent.add_user_message("Test message")
+    assert len(agent.memory) == 1
+    assert agent.memory[0].role == "user"
+    assert agent.memory[0].content == "Test message"
 
-        # Run the method
-        agent.run_iteration(context=mock_context)
 
-        # Assertions
-        assert agent.iterations == 1
-        assert len(agent.memory) == 1
-        assert agent.memory[0] == mock_message
-        assert agent.usage == mock_usage
+def test_get_last_message_content(agent):
+    assert agent.get_last_message_content() is None
+    agent.add_user_message("Test message")
+    assert agent.get_last_message_content() == "Test message"
 
-        # Check if a new thread was created for insight sharing
-        mock_thread.assert_called_once()
-        assert mock_thread.call_args[1]["func"] == agent.share_insights
-        assert isinstance(mock_thread.call_args[1]["args"][0], AutofixContext)
-        assert isinstance(mock_thread.call_args[1]["args"][1], str)
 
-        # To test the share insights method, we need to call it directly
-        agent.share_insights(mock_context, "Test response", -1)
+def test_reset_iterations(agent):
+    agent.iterations = 5
+    agent.reset_iterations()
+    assert agent.iterations == 0
 
-        # Check if insight sharing was called
-        mock_insight_sharing.assert_called_once_with(mock_context)
-        mock_insight_sharing_instance.invoke.assert_called_once()
-        assert isinstance(
-            mock_insight_sharing_instance.invoke.call_args[0][0], InsightSharingRequest
-        )
-        mock_context.state.update.assert_called_once()
 
-    def test_run_iteration_with_queued_user_messages(self, agent, mock_client, mock_context):
-        # Create a mock step with queued_user_messages as a list of strings
-        mock_step = MagicMock(spec=DefaultStep)
-        mock_step.queued_user_messages = ["User message 1", "User message 2"]
+def test_update_usage(agent):
+    usage = Usage(prompt_tokens=10, completion_tokens=20, total_tokens=30)
+    agent.update_usage(usage)
+    assert agent.usage == usage
 
-        # Set the mock step as the last step in the context
-        mock_context.state.get().steps = [mock_step]
 
-        agent.use_user_messages = MagicMock()
+def test_process_message(agent):
+    message = Message(role="assistant", content="Hello!", tool_calls=[])
+    agent.process_message(message)
+    assert len(agent.memory) == 1
+    assert agent.iterations == 1
 
-        mock_message = Message(role="assistant", content="Test response")
-        mock_usage = Usage(completion_tokens=10, prompt_tokens=20, total_tokens=30)
-        mock_client.completion = MagicMock(return_value=(mock_message, mock_usage))
 
-        # Run the method
-        agent.run_iteration(context=mock_context)
+def test_process_message_with_tool_calls(agent):
+    tool_call = ToolCall(id="1", function="test_tool", args='{"arg": "value"}')
+    message = Message(role="assistant", content="Using a tool", tool_calls=[tool_call])
 
-        # Assertions
-        agent.use_user_messages.assert_called_once_with(mock_context)
-        assert agent.iterations == 0  # Should not increment
-        assert len(agent.memory) == 0  # Should not add to memory
-
-        # Additional assertion to verify the queued_user_messages
-        assert mock_context.state.get().steps[-1].queued_user_messages == [
-            "User message 1",
-            "User message 2",
-        ]
-
-    def test_get_completion(self, agent, mock_client):
-        mock_message = Message(role="assistant", content="Test response")
-        mock_usage = Usage(completion_tokens=10, prompt_tokens=20, total_tokens=30)
-        mock_client.completion = MagicMock(return_value=(mock_message, mock_usage))
-
-        message, usage = agent.get_completion()
-
-        assert message == mock_message
-        assert usage == mock_usage
-
-    def test_process_message(self, agent):
-        message = Message(role="assistant", content="Test message")
+    with patch.object(agent, "process_tool_calls") as mock_process_tool_calls:
         agent.process_message(message)
-        assert len(agent.memory) == 1
-        assert agent.memory[0] == message
-        assert agent.iterations == 1
+        mock_process_tool_calls.assert_called_once_with([tool_call])
 
-    def test_process_tool_calls(self, agent):
-        tool_calls = [ToolCall(id="1", function="test_tool", args='{"arg": "value"}')]
-        with patch.object(agent, "call_tool") as mock_call_tool:
-            mock_call_tool.return_value = Message(
-                role="tool", content="Tool result", tool_call_id="1"
-            )
-            agent.process_tool_calls(tool_calls)
-        assert len(agent.memory) == 1
-        assert agent.memory[0].role == "tool"
-        assert agent.memory[0].content == "Tool result"
 
-    def test_update_usage(self, agent):
-        initial_usage = Usage(completion_tokens=10, prompt_tokens=20, total_tokens=30)
-        agent.usage = initial_usage
-        new_usage = Usage(completion_tokens=5, prompt_tokens=10, total_tokens=15)
-        agent.update_usage(new_usage)
-        expected_usage = Usage(completion_tokens=15, prompt_tokens=30, total_tokens=45)
-        assert agent.usage == expected_usage
+def test_should_continue(agent, run_config):
+    # First iteration
+    assert agent.should_continue(run_config)
 
-    def test_run(self, agent, mock_client):
-        mock_message = Message(role="assistant", content="Final response")
-        mock_usage = Usage(completion_tokens=10, prompt_tokens=20, total_tokens=30)
-        mock_client.completion = MagicMock(return_value=(mock_message, mock_usage))
+    # Max iterations reached
+    agent.iterations = run_config.max_iterations
+    agent.memory = [Message(role="assistant", content="Thinking...")]
+    assert not agent.should_continue(run_config)
 
-        result = agent.run("Test prompt")
+    # Stop message encountered
+    agent.iterations = 1
+    run_config.stop_message = "STOP"
+    agent.memory.append(Message(role="assistant", content="Let's STOP here"))
+    assert not agent.should_continue(run_config)
 
-        assert result == "Final response"
-        assert len(agent.memory) > 0
-        assert agent.memory[0].role == "user"
-        assert agent.memory[0].content == "Test prompt"
-
-    def test_run_max_iterations_exception(self, agent, mock_client):
-        agent.config.max_iterations = 1
-        tool = FunctionTool(
-            name="test_tool", description="Test tool", fn=lambda: None, parameters=[]
-        )
-        agent.tools = [tool]
-
-        mock_message = Message(
+    # Continue with tool calls
+    agent.memory.append(
+        Message(
             role="assistant",
-            content="Response",
-            tool_calls=[ToolCall(id="1", function="test_tool", args="{'arg': 'value'}")],
+            content="Using a tool",
+            tool_calls=[ToolCall(id="1", function="test", args="{}")],
         )
-        mock_usage = Usage(completion_tokens=10, prompt_tokens=20, total_tokens=30)
-        mock_client.completion = MagicMock(return_value=(mock_message, mock_usage))
+    )
+    assert agent.should_continue(run_config)
 
-        with pytest.raises(MaxIterationsReachedException):
-            agent.run("Test prompt")
 
-    @patch("seer.automation.agent.agent.module.enable")
-    @patch("seer.automation.agent.agent.configuration_module.enable")
-    def test_run_in_thread(self, mock_config_enable, mock_module_enable, agent):
-        mock_func = MagicMock()
-        mock_args = (1, "test")
+def test_run_iteration(agent, run_config, mock_llm_client):
+    mock_response = LlmGenerateTextResponse(
+        message=Message(role="assistant", content="Hello!"),
+        metadata=LlmResponseMetadata(
+            model="test-model",
+            provider_name=LlmProviderType.OPENAI,
+            usage=Usage(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+        ),
+    )
+    mock_llm_client.generate_text.return_value = mock_response
 
-        event = threading.Event()
+    agent.run_iteration(run_config)
 
-        def mock_func_side_effect(*args):
-            event.set()
+    assert len(agent.memory) == 1
+    assert agent.memory[0].content == "Hello!"
+    assert agent.iterations == 1
+    assert agent.usage.total_tokens == 30
 
-        mock_func.side_effect = mock_func_side_effect
 
-        agent.run_in_thread(mock_func, mock_args)
+def test_run_with_tool_calls(agent, run_config, mock_llm_client):
+    tool = FunctionTool(
+        name="test_tool", description="A test tool", parameters=[], fn=lambda: "Tool result"
+    )
+    agent.tools = [tool]
 
-        assert event.wait(1), "Thread did not finish execution in time"
+    mock_response1 = LlmGenerateTextResponse(
+        message=Message(
+            role="assistant",
+            content="Using a tool",
+            tool_calls=[ToolCall(id="1", function="test_tool", args="{}")],
+        ),
+        metadata=LlmResponseMetadata(
+            model="test-model",
+            provider_name=LlmProviderType.OPENAI,
+            usage=Usage(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+        ),
+    )
+    mock_response2 = LlmGenerateTextResponse(
+        message=Message(role="assistant", content="Done"),
+        metadata=LlmResponseMetadata(
+            model="test-model",
+            provider_name=LlmProviderType.OPENAI,
+            usage=Usage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+        ),
+    )
+    mock_llm_client.generate_text.side_effect = [mock_response1, mock_response2]
 
-        mock_module_enable.assert_called_once()
-        mock_config_enable.assert_called_once()
+    result = agent.run(run_config)
 
-        mock_func.assert_called_once_with(*mock_args)
+    assert result == "Done"
+    assert (
+        len(agent.memory) == 4
+    )  # User message, initial assistant message, tool response, final message
+    assert agent.iterations == 2
+    assert agent.usage.total_tokens == 50
+
+
+def test_run_max_iterations_exception(agent, run_config, mock_llm_client):
+    mock_response = LlmGenerateTextResponse(
+        message=Message(role="assistant", content="Thinking..."),
+        metadata=LlmResponseMetadata(
+            model="test-model",
+            provider_name=LlmProviderType.OPENAI,
+            usage=Usage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+        ),
+    )
+    mock_llm_client.generate_text.return_value = mock_response
+
+    run_config.max_iterations = 1
+
+    with pytest.raises(MaxIterationsReachedException):
+        agent.run(run_config)
+
+    assert agent.iterations == 1
+
+
+def test_run_with_initial_prompt(agent, run_config, mock_llm_client):
+    mock_response = LlmGenerateTextResponse(
+        message=Message(role="assistant", content="Hello!"),
+        metadata=LlmResponseMetadata(
+            model="test-model",
+            provider_name=LlmProviderType.OPENAI,
+            usage=Usage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+        ),
+    )
+    mock_llm_client.generate_text.return_value = mock_response
+
+    run_config.prompt = "Initial prompt"
+    result = agent.run(run_config)
+
+    assert result == "Hello!"
+    assert len(agent.memory) == 2  # Initial user message and assistant response
+    assert agent.memory[0].content == "Initial prompt"
+    assert agent.memory[0].role == "user"

--- a/tests/automation/autofix/components/coding/test_coding_component.py
+++ b/tests/automation/autofix/components/coding/test_coding_component.py
@@ -2,8 +2,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from seer.automation.agent.client import LlmClient, LlmGenerateTextResponse, LlmResponseMetadata
-from seer.automation.agent.models import LlmProviderType, Message, Usage
+from seer.automation.agent.client import LlmClient
+from seer.automation.agent.models import (
+    LlmGenerateTextResponse,
+    LlmProviderType,
+    LlmResponseMetadata,
+    Message,
+    Usage,
+)
 from seer.automation.autofix.autofix_context import AutofixContext
 from seer.automation.autofix.components.coding.component import CodingComponent
 from seer.automation.autofix.components.coding.models import (

--- a/tests/automation/autofix/components/test_insight_sharing.py
+++ b/tests/automation/autofix/components/test_insight_sharing.py
@@ -139,3 +139,18 @@ class TestInsightSharingComponent:
 
         # make sure no error is raised
         component.invoke(request, mock_llm_client)
+
+    def test_exception_is_caught(self, component, mock_llm_client):
+        request = InsightSharingRequest(
+            task_description="Test task",
+            latest_thought="Latest thought",
+            past_insights=["Past insight 1"],
+            memory=[Message(role="user", content="Test memory")],
+            generated_at_memory_index=0,
+        )
+
+        mock_llm_client.generate_text.side_effect = Exception("Test exception")
+
+        # make sure no error is raised
+        result = component.invoke(request, mock_llm_client)
+        assert result is None

--- a/tests/automation/autofix/components/test_insight_sharing.py
+++ b/tests/automation/autofix/components/test_insight_sharing.py
@@ -2,10 +2,18 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from seer.automation.agent.models import Message
+from seer.automation.agent.models import (
+    LlmGenerateStructuredResponse,
+    LlmGenerateTextResponse,
+    LlmProviderType,
+    LlmResponseMetadata,
+    Message,
+    Usage,
+)
 from seer.automation.autofix.autofix_context import AutofixContext
 from seer.automation.autofix.components.insight_sharing.component import InsightSharingComponent
 from seer.automation.autofix.components.insight_sharing.models import (
+    InsightContextOutput,
     InsightSharingOutput,
     InsightSharingRequest,
 )
@@ -20,13 +28,13 @@ class TestInsightSharingComponent:
         return InsightSharingComponent(mock_context)
 
     @pytest.fixture
-    def mock_gpt_client(self):
+    def mock_llm_client(self):
         with patch(
-            "seer.automation.autofix.components.insight_sharing.component.GptClient"
+            "seer.automation.autofix.components.insight_sharing.component.LlmClient"
         ) as mock:
             yield mock
 
-    def test_invoke_with_insight(self, component, mock_gpt_client):
+    def test_invoke_with_insight(self, component, mock_llm_client):
         request = InsightSharingRequest(
             task_description="Test task",
             latest_thought="Latest thought",
@@ -35,24 +43,34 @@ class TestInsightSharingComponent:
             generated_at_memory_index=0,
         )
 
-        mock_completion_1 = MagicMock()
-        mock_completion_1.choices[0].message.content = "New insight"
-        mock_completion_1.usage = MagicMock(completion_tokens=10, prompt_tokens=20, total_tokens=30)
-
-        mock_completion_2 = MagicMock()
-        mock_completion_2.choices[0].message.parsed = MagicMock(
-            explanation="Test explanation",
-            error_message_context=["Test error context"],
-            codebase_context=[],
-            stacktrace_context=[],
-            event_log_context=[],
+        mock_generate_text_response = LlmGenerateTextResponse(
+            message=Message(role="assistant", content="New insight"),
+            metadata=LlmResponseMetadata(
+                model="test_model",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            ),
         )
-        mock_completion_2.choices[0].message.refusal = None
 
-        mock_gpt_client.openai_client.chat.completions.create.return_value = mock_completion_1
-        mock_gpt_client.openai_client.beta.chat.completions.parse.return_value = mock_completion_2
+        mock_generate_structured_response = LlmGenerateStructuredResponse(
+            parsed=InsightContextOutput(
+                explanation="Test explanation",
+                error_message_context=["Test error context"],
+                codebase_context=[],
+                stacktrace_context=[],
+                event_log_context=[],
+            ),
+            metadata=LlmResponseMetadata(
+                model="test_model",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            ),
+        )
 
-        result = component.invoke(request, mock_gpt_client)
+        mock_llm_client.generate_text.return_value = mock_generate_text_response
+        mock_llm_client.generate_structured.return_value = mock_generate_structured_response
+
+        result = component.invoke(request, mock_llm_client)
         assert isinstance(result, InsightSharingOutput)
         assert result.insight == "New insight"
         assert result.justification == "Test explanation"
@@ -61,7 +79,7 @@ class TestInsightSharingComponent:
         assert result.stacktrace_context == []
         assert result.breadcrumb_context == []
 
-    def test_invoke_with_no_insight(self, component, mock_gpt_client):
+    def test_invoke_with_no_insight(self, component, mock_llm_client):
         request = InsightSharingRequest(
             task_description="Test task",
             latest_thought="Latest thought",
@@ -70,16 +88,20 @@ class TestInsightSharingComponent:
             generated_at_memory_index=0,
         )
 
-        mock_completion = MagicMock()
-        mock_completion.choices[0].message.content = "<NO_INSIGHT/>"
+        mock_llm_client.generate_text.return_value = LlmGenerateTextResponse(
+            message=Message(role="assistant", content="<NO_INSIGHT/>"),
+            metadata=LlmResponseMetadata(
+                model="test_model",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            ),
+        )
 
-        mock_gpt_client.openai_client.chat.completions.create.return_value = mock_completion
-
-        result = component.invoke(request, mock_gpt_client)
+        result = component.invoke(request, mock_llm_client)
 
         assert result is None
 
-    def test_invoke_with_error(self, component, mock_gpt_client):
+    def test_invoke_with_error(self, component, mock_llm_client):
         request = InsightSharingRequest(
             task_description="Test task",
             latest_thought="Latest thought",
@@ -88,15 +110,32 @@ class TestInsightSharingComponent:
             generated_at_memory_index=0,
         )
 
-        mock_completion_1 = MagicMock()
-        mock_completion_1.choices[0].message.content = "New insight"
-        mock_completion_1.usage = MagicMock(completion_tokens=10, prompt_tokens=20, total_tokens=30)
+        mock_completion_1 = LlmGenerateTextResponse(
+            message=Message(role="assistant", content="New insight"),
+            metadata=LlmResponseMetadata(
+                model="test_model",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            ),
+        )
 
-        mock_completion_2 = MagicMock()
-        mock_completion_2.choices[0].message.refusal = "Test refusal"
+        mock_completion_2 = LlmGenerateStructuredResponse(
+            parsed=InsightContextOutput(
+                explanation="Test explanation",
+                error_message_context=["Test error context"],
+                codebase_context=[],
+                stacktrace_context=[],
+                event_log_context=[],
+            ),
+            metadata=LlmResponseMetadata(
+                model="test_model",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            ),
+        )
 
-        mock_gpt_client.openai_client.chat.completions.create.return_value = mock_completion_1
-        mock_gpt_client.openai_client.beta.chat.completions.parse.return_value = mock_completion_2
+        mock_llm_client.generate_text.return_value = mock_completion_1
+        mock_llm_client.generate_structured.return_value = mock_completion_2
 
         # make sure no error is raised
-        component.invoke(request, mock_gpt_client)
+        component.invoke(request, mock_llm_client)

--- a/tests/automation/autofix/components/test_root_cause.py
+++ b/tests/automation/autofix/components/test_root_cause.py
@@ -2,12 +2,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from seer.automation.agent.client import (
-    LlmClient,
+from seer.automation.agent.client import LlmClient
+from seer.automation.agent.models import (
     LlmGenerateStructuredResponse,
+    LlmProviderType,
     LlmResponseMetadata,
+    Usage,
 )
-from seer.automation.agent.models import LlmProviderType, Usage
 from seer.automation.autofix.autofix_context import AutofixContext
 from seer.automation.autofix.components.root_cause.component import RootCauseAnalysisComponent
 from seer.automation.autofix.components.root_cause.models import (

--- a/tests/automation/autofix/components/test_root_cause.py
+++ b/tests/automation/autofix/components/test_root_cause.py
@@ -1,9 +1,13 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from openai.types.chat import ParsedChatCompletion, ParsedChatCompletionMessage, ParsedChoice
 
-from seer.automation.agent.client import GptClient
+from seer.automation.agent.client import (
+    LlmClient,
+    LlmGenerateStructuredResponse,
+    LlmResponseMetadata,
+)
+from seer.automation.agent.models import LlmProviderType, Usage
 from seer.automation.autofix.autofix_context import AutofixContext
 from seer.automation.autofix.components.root_cause.component import RootCauseAnalysisComponent
 from seer.automation.autofix.components.root_cause.models import (
@@ -22,66 +26,51 @@ class TestRootCauseComponent:
         return RootCauseAnalysisComponent(mock_context)
 
     @pytest.fixture
-    def mock_gpt_agent(self):
-        with patch("seer.automation.autofix.components.root_cause.component.GptAgent") as mock:
+    def mock_agent(self):
+        with patch("seer.automation.autofix.components.root_cause.component.AutofixAgent") as mock:
             yield mock
 
-    def test_root_cause_simple_response_parsing(self, component, mock_gpt_agent):
-        mock_gpt_agent.return_value.run.side_effect = [
+    def test_root_cause_simple_response_parsing(self, component, mock_agent):
+        mock_agent.return_value.run.side_effect = [
             "Anything really",
             "Reproduction steps",
         ]
 
-        mock_gpt_client = MagicMock()
-        mock_gpt_client.openai_client.beta.chat.completions.parse.return_value = (
-            ParsedChatCompletion(
-                id="1",
-                choices=[
-                    ParsedChoice(
-                        index=0,
-                        message=ParsedChatCompletionMessage(
-                            role="assistant",
-                            content=None,
-                            function_call=None,
-                            tool_calls=None,
-                            parsed=MultipleRootCauseAnalysisOutputPrompt(
-                                cause=RootCauseAnalysisItemPrompt(
-                                    title="Missing Null Check",
-                                    description="The root cause of the issue is ...",
-                                    reproduction_instructions="Steps to reproduce",
-                                    relevant_code=None,
-                                )
-                            ),
-                            refusal=None,
-                        ),
-                        finish_reason="stop",
-                    )
-                ],
-                created=1234567890,
-                model="gpt-4o-2024-08-06",
-                object="chat.completion",
-                system_fingerprint="test",
-                usage=None,
-            )
+        mock_llm_client = MagicMock()
+        mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
+            parsed=MultipleRootCauseAnalysisOutputPrompt(
+                cause=RootCauseAnalysisItemPrompt(
+                    title="Missing Null Check",
+                    description="The root cause of the issue is ...",
+                    reproduction_instructions="Steps to reproduce",
+                    relevant_code=None,
+                )
+            ),
+            metadata=LlmResponseMetadata(
+                model="test-model",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+            ),
         )
 
         module = Module()
-        module.constant(GptClient, mock_gpt_client)
+        module.constant(LlmClient, mock_llm_client)
+
         with module:
             output = component.invoke(MagicMock())
 
-            assert output is not None
-            assert len(output.causes) == 1
-            assert output.causes[0].title == "Missing Null Check"
-            assert output.causes[0].description == "The root cause of the issue is ..."
-            assert output.causes[0].reproduction == "Steps to reproduce"
-            assert output.causes[0].code_context is None
+        assert output is not None
+        assert len(output.causes) == 1
+        assert output.causes[0].title == "Missing Null Check"
+        assert output.causes[0].description == "The root cause of the issue is ..."
+        assert output.causes[0].reproduction == "Steps to reproduce"
+        assert output.causes[0].code_context is None
 
-    def test_no_root_causes_response(self, component, mock_gpt_agent):
-        mock_gpt_agent.return_value.run.return_value = "<NO_ROOT_CAUSES>"
+    def test_no_root_causes_response(self, component, mock_agent):
+        mock_agent.return_value.run.return_value = "<NO_ROOT_CAUSES>"
 
         output = component.invoke(MagicMock())
 
         assert output is None
         # Ensure that the second run (reproduction) and the formatter are not called when <NO_ROOT_CAUSES> is returned
-        assert mock_gpt_agent.return_value.run.call_count == 1
+        assert mock_agent.return_value.run.call_count == 1

--- a/tests/automation/autofix/test_autofix_agent.py
+++ b/tests/automation/autofix/test_autofix_agent.py
@@ -1,0 +1,196 @@
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from johen import generate
+
+from seer.automation.agent.agent import AgentConfig, RunConfig
+from seer.automation.agent.client import OpenAiProvider
+from seer.automation.agent.models import Message
+from seer.automation.autofix.autofix_agent import AutofixAgent
+from seer.automation.autofix.components.insight_sharing.models import InsightSharingOutput
+from seer.automation.autofix.models import (
+    AutofixContinuation,
+    AutofixRequest,
+    AutofixStatus,
+    DefaultStep,
+)
+from seer.automation.state import LocalMemoryState
+
+
+@pytest.fixture
+def mock_context():
+    request = next(generate(AutofixRequest))
+    continuation = AutofixContinuation(request=request)
+    state = LocalMemoryState(val=continuation)
+    return MagicMock(state=state)
+
+
+@pytest.fixture
+def mock_llm_client():
+    return Mock()
+
+
+@pytest.fixture
+def autofix_agent(mock_context, mock_llm_client):
+    config = AgentConfig()
+    return AutofixAgent(config=config, context=mock_context, name="TestAutofixAgent")
+
+
+@pytest.fixture
+def interactive_autofix_agent(mock_context, mock_llm_client):
+    config = AgentConfig(interactive=True)
+    return AutofixAgent(config=config, context=mock_context, name="TestAutofixAgent")
+
+
+@pytest.fixture
+def run_config():
+    return RunConfig(
+        system_prompt="You are a helpful assistant for fixing code.",
+        prompt="Fix this bug.",
+        model=OpenAiProvider.model("gpt-4o-mini-2024-07-18"),
+        temperature=0.0,
+        run_name="Test Autofix Run",
+    )
+
+
+def test_autofix_agent_initialization(autofix_agent, mock_context):
+    assert autofix_agent.name == "TestAutofixAgent"
+    assert autofix_agent.context == mock_context
+    assert autofix_agent.iterations == 0
+    assert autofix_agent.memory == []
+
+
+def test_should_continue_waiting_for_user_response(autofix_agent, run_config):
+    with autofix_agent.context.state.update() as state:
+        state.steps = [
+            DefaultStep(status=AutofixStatus.WAITING_FOR_USER_RESPONSE, key="test", title="Test")
+        ]
+    assert not autofix_agent.should_continue(run_config)
+
+
+def test_should_continue_normal_case(autofix_agent, run_config):
+    with autofix_agent.context.state.update() as state:
+        state.steps = [DefaultStep(status=AutofixStatus.PROCESSING, key="test", title="Test")]
+    assert autofix_agent.should_continue(run_config)
+
+
+@patch("seer.automation.autofix.autofix_agent.AutofixAgent.get_completion")
+def test_run_iteration_with_queued_user_messages(
+    mock_get_completion,
+    interactive_autofix_agent,
+    run_config,
+):
+    mock_completion = MagicMock(
+        message=Message(role="assistant", content="Thinking about the solution...")
+    )
+    mock_get_completion.return_value = mock_completion
+
+    with interactive_autofix_agent.context.state.update() as state:
+        state.steps.append(
+            DefaultStep(
+                status=AutofixStatus.PROCESSING,
+                key="test",
+                title="Test",
+                queued_user_messages=["User input"],
+            )
+        )
+
+    interactive_autofix_agent.run_iteration(run_config)
+
+    assert len(interactive_autofix_agent.memory) == 2
+    assert interactive_autofix_agent.memory[0] == Message(role="user", content="User input")
+    assert interactive_autofix_agent.memory[1] == mock_completion.message
+
+
+@patch("seer.automation.autofix.autofix_agent.AutofixAgent.get_completion")
+@patch("seer.automation.autofix.autofix_agent.AutofixAgent.run_in_thread")
+def test_run_iteration_with_insight_sharing(
+    mock_run_in_thread, mock_get_completion, autofix_agent, run_config
+):
+    mock_completion = MagicMock()
+    mock_completion.message.content = "Thinking about the solution..."
+    mock_get_completion.return_value = mock_completion
+    autofix_agent.config.interactive = True
+    with autofix_agent.context.state.update() as state:
+        state.request.options.disable_interactivity = False
+
+    autofix_agent.run_iteration(run_config)
+
+    mock_run_in_thread.assert_called_once()
+    assert mock_run_in_thread.call_args[1]["func"] == autofix_agent.share_insights
+
+
+@patch("seer.automation.autofix.autofix_agent.AutofixAgent.get_completion")
+@patch("seer.automation.autofix.autofix_agent.AutofixAgent.call_tool")
+def test_run_iteration_with_tool_calls(
+    mock_call_tool, mock_get_completion, autofix_agent, run_config
+):
+    mock_completion = MagicMock()
+    mock_completion.message.tool_calls = [MagicMock(), MagicMock()]
+    mock_get_completion.return_value = mock_completion
+    mock_call_tool.return_value = MagicMock()
+
+    autofix_agent.run_iteration(run_config)
+
+    assert mock_call_tool.call_count == 2
+    assert len(autofix_agent.memory) == 3  # Completion message + 2 tool responses
+
+
+def test_use_user_messages(autofix_agent):
+    with autofix_agent.context.state.update() as state:
+        state.steps = [
+            DefaultStep(
+                status=AutofixStatus.PROCESSING,
+                key="test",
+                title="Test",
+                queued_user_messages=["User input 1"],
+            )
+        ]
+    autofix_agent.memory = [Message(role="assistant", content="Previous response")]
+
+    autofix_agent.use_user_messages()
+
+    assert len(autofix_agent.memory) == 2
+    assert autofix_agent.memory[-2].role == "assistant"
+    assert autofix_agent.memory[-2].content == "Previous response"
+    assert autofix_agent.memory[-1].role == "user"
+    assert autofix_agent.memory[-1].content == "User input 1"
+
+
+@patch("seer.automation.autofix.autofix_agent.InsightSharingComponent")
+def test_share_insights(mock_insight_sharing_component, autofix_agent):
+    mock_component = MagicMock()
+    mock_insight_sharing_component.return_value = mock_component
+    mock_component.invoke.return_value = MagicMock()
+
+    autofix_agent.memory = [Message(role="user", content="Fix this bug")]
+
+    with autofix_agent.context.state.update() as state:
+        state.steps = [
+            DefaultStep(
+                status=AutofixStatus.PROCESSING, key="test", title="Fixing a bug", insights=[]
+            )
+        ]
+
+    autofix_agent.share_insights(autofix_agent.context, "Thinking about the solution", 0)
+
+    mock_component.invoke.assert_called_once()
+    assert len(autofix_agent.context.state.get().steps[-1].insights) == 1
+
+
+def test_share_insights_no_new_insights(autofix_agent):
+    with autofix_agent.context.state.update() as state:
+        state.steps = [
+            DefaultStep(
+                status=AutofixStatus.PROCESSING,
+                key="test",
+                title="Fixing a bug",
+                insights=[next(generate(InsightSharingOutput))],
+            )
+        ]
+
+    initial_insights_count = len(autofix_agent.context.state.get().steps[-1].insights)
+    autofix_agent.share_insights(autofix_agent.context, "Thinking about the solution", 0)
+    final_insights_count = len(autofix_agent.context.state.get().steps[-1].insights)
+
+    assert initial_insights_count == final_insights_count

--- a/tests/automation/summarize/test_replays.py
+++ b/tests/automation/summarize/test_replays.py
@@ -89,7 +89,6 @@ class TestSummarizeReplays:
         mock_llm_client.generate_structured.assert_called_once()
 
     def test_run_cross_session_completion(self, mock_llm_client):
-
         mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
             parsed=CommonReplaySummary(
                 common_user_steps_taken=[],

--- a/tests/automation/summarize/test_replays.py
+++ b/tests/automation/summarize/test_replays.py
@@ -2,7 +2,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from seer.automation.agent.models import (
+    LlmGenerateStructuredResponse,
+    LlmProviderType,
+    LlmResponseMetadata,
+    Usage,
+)
 from seer.automation.summarize.replays import (
+    CommonReplaySummary,
     Replay,
     ReplayEvent,
     ReplaySummary,
@@ -13,12 +20,11 @@ from seer.automation.summarize.replays import (
     run_single_replay_summary,
     summarize_replays,
 )
-from seer.automation.utils import extract_parsed_model
 
 
 class TestSummarizeReplays:
     @pytest.fixture
-    def mock_gpt_client(self):
+    def mock_llm_client(self):
         return MagicMock()
 
     @pytest.fixture
@@ -64,60 +70,42 @@ class TestSummarizeReplays:
         mock_single_summary.assert_called_once()
         mock_cross_session.assert_called_once()
 
-    def test_run_single_replay_summary(self, mock_gpt_client, sample_replay):
-        mock_completion = MagicMock()
-        mock_completion.choices[0].message.parsed = ReplaySummary(
-            user_steps_taken=[], pages_visited=[], user_journey_summary="Test summary"
+    def test_run_single_replay_summary(self, mock_llm_client, sample_replay):
+        mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
+            parsed=ReplaySummary(
+                user_steps_taken=[], pages_visited=[], user_journey_summary="Test summary"
+            ),
+            metadata=LlmResponseMetadata(
+                model="test",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            ),
         )
-        mock_completion.choices[0].message.refusal = None
-        mock_gpt_client.openai_client.beta.chat.completions.parse.return_value = mock_completion
 
-        result = run_single_replay_summary(sample_replay, gpt_client=mock_gpt_client)
+        result = run_single_replay_summary(sample_replay, llm_client=mock_llm_client)
 
         assert isinstance(result, ReplaySummary)
         assert result.user_journey_summary == "Test summary"
-        mock_gpt_client.openai_client.beta.chat.completions.parse.assert_called_once()
+        mock_llm_client.generate_structured.assert_called_once()
 
-    def test_run_cross_session_completion(self, mock_gpt_client):
-        mock_completion = MagicMock()
-        mock_completion.choices[0].message.parsed = MagicMock(
-            common_user_steps_taken=[],
-            reproduction_steps="Test steps",
-            issue_impact_summary="Test impact",
+    def test_run_cross_session_completion(self, mock_llm_client):
+
+        mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
+            parsed=CommonReplaySummary(
+                common_user_steps_taken=[],
+                reproduction_steps="Test steps",
+                issue_impact_summary="Test impact",
+            ),
+            metadata=LlmResponseMetadata(
+                model="test",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            ),
         )
-        mock_completion.choices[0].message.refusal = None
-        mock_gpt_client.openai_client.beta.chat.completions.parse.return_value = mock_completion
 
-        result = run_cross_session_completion(["Step 1", "Step 2"], gpt_client=mock_gpt_client)
+        result = run_cross_session_completion(["Step 1", "Step 2"], llm_client=mock_llm_client)
 
+        assert isinstance(result, CommonReplaySummary)
         assert result.reproduction_steps == "Test steps"
         assert result.issue_impact_summary == "Test impact"
-        mock_gpt_client.openai_client.beta.chat.completions.parse.assert_called_once()
-
-    def test_extract_parsed_model(self):
-        mock_completion = MagicMock()
-        mock_completion.choices[0].message.parsed = ReplaySummary(
-            user_steps_taken=[], pages_visited=[], user_journey_summary="Test summary"
-        )
-        mock_completion.choices[0].message.refusal = None
-
-        result = extract_parsed_model(mock_completion)
-
-        assert isinstance(result, ReplaySummary)
-        assert result.user_journey_summary == "Test summary"
-
-    def test_extract_parsed_model_refusal(self):
-        mock_completion = MagicMock()
-        mock_completion.choices[0].message.parsed = None
-        mock_completion.choices[0].message.refusal = "Test refusal"
-
-        with pytest.raises(RuntimeError, match="Test refusal"):
-            extract_parsed_model(mock_completion)
-
-    def test_extract_parsed_model_parsing_failure(self):
-        mock_completion = MagicMock()
-        mock_completion.choices[0].message.parsed = None
-        mock_completion.choices[0].message.refusal = None
-
-        with pytest.raises(RuntimeError, match="Failed to parse message"):
-            extract_parsed_model(mock_completion)
+        mock_llm_client.generate_structured.assert_called_once()

--- a/tests/generators.py
+++ b/tests/generators.py
@@ -8,7 +8,6 @@ from johen import generate
 from johen.examples import Examples
 from johen.generators import specialized
 
-from seer.automation.agent.client import DummyGptClient, LlmCompletionHandler
 from seer.automation.models import SentryExceptionEntry, SentryFrame, StacktraceFrame
 from seer.rpc import DummyRpcClient, RpcClientHandler
 
@@ -80,20 +79,3 @@ class RpcClientMock:
                 self.client.handlers = old_handlers
 
     enabled = contextlib.contextmanager(_enabled)
-
-
-@dataclasses.dataclass
-class GptClientMock:
-    client: DummyGptClient
-    mocked_path: str = "seer.automation.agent.agent.GptClient"
-
-    @contextlib.contextmanager
-    def enabled(self, *handlers: LlmCompletionHandler) -> Iterator[DummyGptClient]:
-        old_handlers = self.client.handlers
-        with mock.patch(self.mocked_path) as target:
-            target.return_value = self.client
-            self.client.handlers = [*old_handlers, *handlers]
-            try:
-                yield self.client
-            finally:
-                self.client.handlers = old_handlers


### PR DESCRIPTION
We were calling LLMs in multiple different ways, and the llm clients and the agents were getting somewhat unwieldy, so this refactoring work aims to simplify, unify, and optimize how we interact with LLMs.

# The LLM Clients:
The LLM clients now follow a similar interface to the [vercel ai sdk](https://sdk.vercel.ai/docs/ai-sdk-core/overview), the two main methods you will interact with is `generate_text` and `generate_structured`, where the former is for normal completion and the latter is for structured output completion. The structured output completion currently only works with the OpenAI provider for now.

### LLM Providers
The LLM providers, `OpenAiProvider` and `AnthropicProvider` contains all the specific logic for each provider, you select the model via the provider and pass it to the generate calls, for example `model=OpenAiProvider.model('gpt-4o-mini')`. This allows us to bake in defaults such as temperature into the model selection.

### The calling methods
You can call the LLM clients via the two generate calls:
```py
# generate_text
response = llm_client.generate_text(
  model=AnthropicProvider.model("claude-3-5-sonnet@20240620"),
  prompt=CodingPrompts.format_incorrect_diff_fixer(
    file_path,
    file_missing_obj.diff_chunks,
    file_missing_obj.file_content,
  ),
  temperature=0.0,
  run_name="Incorrect Diff Fixer",
)
```
```py
# generate_structured
response = llm_client.generate_structured(
  model=OpenAiProvider.model("gpt-4o-mini"),
  system_prompt="...",
  messages=[...]
)
```
You can pass messages, or a `prompt` which will be appended as the user message.

# The LLM Agents
You initialize an llm agent as such:
```py
agent = AutofixAgent(
  tools=tools.get_tools(),
  config=AgentConfig(interactive=True),
  memory=request.initial_memory,
  context=self.context,
  name="Plan+Code",
)
```
and each call has its own `RunConfig`, you can run it as many times as you want to share the tools and memory across multiple agent runs.
```py
response = agent.run(
  run_config=RunConfig(
    prompt=(
      CodingPrompts.format_fix_discovery_msg(
        event=request.event_details.format_event(),
        task_str=task_str,
        summary=request.summary,
        repo_names=[repo.full_name for repo in state.request.repos],
        instruction=request.instruction,
      )
      if not request.initial_memory
      else None
    ),
    system_prompt=CodingPrompts.format_system_msg(),
    model=AnthropicProvider.model("claude-3-5-sonnet@20240620"),
    memory_storage_key="plan_and_code",
    run_name="Plan",
  ),
)
```

### Naming
As you can see with the above, you can just pass run names to the above calls and they will be grouped + named in langfuse neatly:
![CleanShot 2024-10-08 at 10 52 29](https://github.com/user-attachments/assets/7517c886-77d0-4a01-ad6d-941b96ee2a4b)
