### PR TITLE
[fix] Update branch ref for unit test generation 

### DIFF
--- a/src/seer/automation/codegen/unit_test_github_pr_creator.py
+++ b/src/seer/automation/codegen/unit_test_github_pr_creator.py
@@ -42,5 +42,5 @@ class GeneratedTestsPullRequestCreator:
             branch=branch_ref,
             title=pr_title,
             description=description,
-            provided_base=self.pr.base.ref,
+            provided_base=self.pr.head.ref,
         )

--- a/tests/automation/codegen/test_unit_test_step.py
+++ b/tests/automation/codegen/test_unit_test_step.py
@@ -56,7 +56,7 @@ class TestUnittestStep(unittest.TestCase):
     def test_create_github_pull_request_success(self, _):
         file_changes_payload = [MagicMock(spec=FileChange), MagicMock(spec=FileChange)]
         pr = MagicMock()
-        pr.head.sha = "head_sha"
+        pr.head.ref = "head_sha"
         pr.number = 123
         pr.base.ref = "main"
         repo_client = MagicMock(spec=RepoClient)
@@ -81,7 +81,7 @@ class TestUnittestStep(unittest.TestCase):
             branch="branch_ref",
             title=pr_title,
             description="This PR adds tests for #123\n\n### Commits:\n- commit message 1\n- commit message 2",
-            provided_base="main",
+            provided_base="head_sha",
         )
         self.assertEqual(repo_client.base_commit_sha, pr.head.sha)
 


### PR DESCRIPTION
Create a branch that merges against the original PR branch instead of the repo's default branch. 

Example of testing locally: https://github.com/rohitvinnakota-codecov/hello-world-sunday/pull/13