### PR TITLE
(autofix): Add bad endpoint

### DIFF
--- a/src/seer/app.py
+++ b/src/seer/app.py
@@ -176,7 +176,6 @@ def autofix_start_endpoint(data: AutofixRequest) -> AutofixEndpointResponse:
 @json_api(blueprint, "/v1/automation/autofix/raise-error")  # TODO remove this endpoint
 def autofix_test_copilot_endpoint(data: AutofixRequest) -> AutofixEndpointResponse:
     raise Exception("This is a test error to create a Sentry issue")
-    return AutofixEndpointResponse(started=True)
 
 
 @json_api(blueprint, "/v1/automation/autofix/update")

--- a/src/seer/app.py
+++ b/src/seer/app.py
@@ -173,6 +173,12 @@ def autofix_start_endpoint(data: AutofixRequest) -> AutofixEndpointResponse:
     return AutofixEndpointResponse(started=True, run_id=run_id)
 
 
+@json_api(blueprint, "/v1/automation/autofix/raise-error")  # TODO remove this endpoint
+def autofix_test_copilot_endpoint(data: AutofixRequest) -> AutofixEndpointResponse:
+    raise Exception("This is a test error to create a Sentry issue")
+    return AutofixEndpointResponse(started=True)
+
+
 @json_api(blueprint, "/v1/automation/autofix/update")
 def autofix_update_endpoint(
     data: AutofixUpdateRequest,


### PR DESCRIPTION
Add an endpoint that raises an Exception intentionally. This is so we can test creating a suspect commit comment in prod and test the GitHub Copilot extension.

This should definitely be removed after testing/demoing is done.