### PR TITLE
(autofix): Add celery job that throws an error every minute

### DIFF
--- a/src/celery_app/tasks.py
+++ b/src/celery_app/tasks.py
@@ -25,6 +25,13 @@ def setup_periodic_tasks(sender, config: AppConfig = injected, **kwargs):
             delete_data_for_ttl.signature(kwargs={}, queue=CeleryQueues.DEFAULT),
             name="Delete old Automation runs for 90 day time-to-live",
         )
+        # TODO remove this task, it's just for testing in prod; throws an error every minute
+        sender.add_periodic_task(
+            crontab(minute="*", hour="*"),
+            throw_an_error.signature(kwargs={}, queue=CeleryQueues.DEFAULT),
+            name="Intentionally raise an error",
+        )
+
     if config.GRPC_SERVER_ENABLE:
         from seer.grpc import try_grpc_client
 
@@ -33,10 +40,3 @@ def setup_periodic_tasks(sender, config: AppConfig = injected, **kwargs):
             try_grpc_client.signature(kwargs={}, queue=CeleryQueues.DEFAULT),
             name="Try executing grpc request every minute.",
         )
-
-    # TODO remove this task, it's just for testing in prod; throws an error every minute
-    sender.add_periodic_task(
-        crontab(minute="*", hour="*"),
-        throw_an_error.signature(kwargs={}, queue=CeleryQueues.DEFAULT),
-        name="Intentionally raise an error",
-    )

--- a/src/celery_app/tasks.py
+++ b/src/celery_app/tasks.py
@@ -6,7 +6,7 @@ import seer.app  # noqa: F401
 from celery_app.app import celery_app as celery  # noqa: F401
 from celery_app.config import CeleryQueues
 from seer.automation.autofix.tasks import check_and_mark_recent_autofix_runs
-from seer.automation.tasks import delete_data_for_ttl
+from seer.automation.tasks import delete_data_for_ttl, throw_an_error
 from seer.configuration import AppConfig
 from seer.dependency_injection import inject, injected
 
@@ -33,3 +33,10 @@ def setup_periodic_tasks(sender, config: AppConfig = injected, **kwargs):
             try_grpc_client.signature(kwargs={}, queue=CeleryQueues.DEFAULT),
             name="Try executing grpc request every minute.",
         )
+
+    # TODO remove this task, it's just for testing in prod; throws an error every minute
+    sender.add_periodic_task(
+        crontab(minute="*", hour="*"),
+        throw_an_error.signature(kwargs={}, queue=CeleryQueues.DEFAULT),
+        name="Intentionally raise an error",
+    )

--- a/src/seer/app.py
+++ b/src/seer/app.py
@@ -173,11 +173,6 @@ def autofix_start_endpoint(data: AutofixRequest) -> AutofixEndpointResponse:
     return AutofixEndpointResponse(started=True, run_id=run_id)
 
 
-@json_api(blueprint, "/v1/automation/autofix/raise-error")  # TODO remove this endpoint
-def autofix_test_copilot_endpoint(data: AutofixRequest) -> AutofixEndpointResponse:
-    raise Exception("This is a test error to create a Sentry issue")
-
-
 @json_api(blueprint, "/v1/automation/autofix/update")
 def autofix_update_endpoint(
     data: AutofixUpdateRequest,

--- a/src/seer/app.py
+++ b/src/seer/app.py
@@ -176,7 +176,6 @@ def autofix_start_endpoint(data: AutofixRequest) -> AutofixEndpointResponse:
 @json_api(blueprint, "/v1/automation/autofix/raise-error")  # TODO remove this endpoint
 def autofix_test_copilot_endpoint(data: AutofixRequest) -> AutofixEndpointResponse:
     raise Exception("This is a test error to create a Sentry issue")
-    return AutofixEndpointResponse(started=True)
 
 
 @json_api(blueprint, "/v1/automation/autofix/update")

--- a/src/seer/app.py
+++ b/src/seer/app.py
@@ -173,6 +173,12 @@ def autofix_start_endpoint(data: AutofixRequest) -> AutofixEndpointResponse:
     return AutofixEndpointResponse(started=True, run_id=run_id)
 
 
+@json_api(blueprint, "/v1/automation/autofix/raise-error")  # TODO remove this endpoint
+def autofix_test_copilot_endpoint(data: AutofixRequest) -> AutofixEndpointResponse:
+    raise Exception("This is a test error to create a Sentry issue")
+    return AutofixEndpointResponse(started=True)
+
+
 @json_api(blueprint, "/v1/automation/autofix/update")
 def autofix_update_endpoint(
     data: AutofixUpdateRequest,

--- a/src/seer/automation/tasks.py
+++ b/src/seer/automation/tasks.py
@@ -10,6 +10,12 @@ from seer.db import DbIssueSummary, DbRunState, Session
 logger = logging.getLogger(__name__)
 
 
+# TODO remove this task, it's just for testing in prod; throws an error every minute
+@celery_app.task(time_limit=30)
+def throw_an_error():
+    raise Exception("This is a test error to create a Sentry issue")
+
+
 @celery_app.task(time_limit=30)
 def delete_data_for_ttl():
     logger.info("Deleting old automation runs and issue summaries for 90 day time-to-live")

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -30,6 +30,7 @@ def test_detected_celery_jobs():
             [
                 "Check and mark recent autofix runs every hour",
                 "Delete old Automation runs for 90 day time-to-live",
+                "Intentionally raise an error",  # TODO remove this once testing in prod is done
             ]
         )
 
@@ -59,6 +60,7 @@ def test_autofix_beat_jobs():
             [
                 "Check and mark recent autofix runs every hour",
                 "Delete old Automation runs for 90 day time-to-live",
+                "Intentionally raise an error",  # TODO remove this once testing in prod is done
             ]
         )
 

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -22,6 +22,7 @@ def test_detected_celery_jobs():
                 "seer.automation.codegen.unittest_step.unittest_task",
                 "seer.automation.tasks.delete_data_for_ttl",
                 "seer.smoke_test.smoke_test",
+                "seer.automation.tasks.throw_an_error",  # TODO remove this once testing in prod is done
             ]
         )
 


### PR DESCRIPTION
Removes the error-raising endpoint and adds a celery job to do the same thing.

This is all for testing GH Copilot in prod, should be removed later.