### PR TITLE
feat(unit-test): Use codecov unit test gh app and fallback to autofix app if not present

### DIFF
--- a/src/seer/automation/codegen/codegen_context.py
+++ b/src/seer/automation/codegen/codegen_context.py
@@ -1,6 +1,6 @@
 import logging
 
-from seer.automation.codebase.repo_client import RepoClient
+from seer.automation.codebase.repo_client import RepoClient, RepoClientType
 from seer.automation.codegen.codegen_event_manager import CodegenEventManager
 from seer.automation.codegen.models import CodegenContinuation
 from seer.automation.codegen.state import CodegenContinuationState
@@ -53,12 +53,14 @@ class CodegenContext(PipelineContext):
         with self.state.update() as state:
             state.signals = value
 
-    def get_repo_client(self, repo_name: str | None = None):
+    def get_repo_client(
+        self, repo_name: str | None = None, type: RepoClientType = RepoClientType.READ
+    ):
         """
         Gets a repo client for the current single repo or for a given repo name.
         If there are more than 1 repos, a repo name must be provided.
         """
-        return RepoClient.from_repo_definition(self.repo, "read")
+        return RepoClient.from_repo_definition(self.repo, type)
 
     def get_file_contents(
         self, path: str, repo_name: str | None = None, ignore_local_changes: bool = False

--- a/src/seer/automation/codegen/unit_test_coding_component.py
+++ b/src/seer/automation/codegen/unit_test_coding_component.py
@@ -13,6 +13,7 @@ from seer.automation.autofix.components.coding.utils import (
     task_to_file_delete,
 )
 from seer.automation.autofix.tools import BaseTools
+from seer.automation.codebase.repo_client import RepoClientType
 from seer.automation.codegen.codegen_context import CodegenContext
 from seer.automation.codegen.models import CodeUnitTestOutput, CodeUnitTestRequest
 from seer.automation.codegen.prompts import CodingUnitTestPrompts
@@ -33,7 +34,7 @@ class UnitTestCodingComponent(BaseComponent[CodeUnitTestRequest, CodeUnitTestOut
     def invoke(
         self, request: CodeUnitTestRequest, llm_client: LlmClient = injected
     ) -> CodeUnitTestOutput | None:
-        with BaseTools(self.context) as tools:
+        with BaseTools(self.context, repo_client_type=RepoClientType.CODECOV_UNIT_TEST) as tools:
             agent = LlmAgent(
                 tools=tools.get_tools(),
                 config=AgentConfig(interactive=False),

--- a/src/seer/automation/codegen/unittest_step.py
+++ b/src/seer/automation/codegen/unittest_step.py
@@ -8,6 +8,7 @@ from seer.automation.autofix.config import (
     AUTOFIX_EXECUTION_HARD_TIME_LIMIT_SECS,
     AUTOFIX_EXECUTION_SOFT_TIME_LIMIT_SECS,
 )
+from seer.automation.codebase.repo_client import RepoClientType
 from seer.automation.codegen.models import CodeUnitTestRequest
 from seer.automation.codegen.step import CodegenStep
 from seer.automation.codegen.unit_test_coding_component import UnitTestCodingComponent
@@ -52,7 +53,7 @@ class UnittestStep(CodegenStep):
         self.logger.info("Executing Codegen - Unittest Step")
         self.context.event_manager.mark_running()
 
-        repo_client = self.context.get_repo_client()
+        repo_client = self.context.get_repo_client(type=RepoClientType.CODECOV_UNIT_TEST)
         pr = repo_client.repo.get_pull(self.request.pr_id)
         diff_content = repo_client.get_pr_diff_content(pr.url)
 

--- a/src/seer/configuration.py
+++ b/src/seer/configuration.py
@@ -52,6 +52,8 @@ class AppConfig(BaseModel):
     GITHUB_PRIVATE_KEY: str = ""
     GITHUB_SENTRY_APP_ID: str | None = None
     GITHUB_SENTRY_PRIVATE_KEY: str | None = None
+    GITHUB_CODECOV_UNIT_TEST_APP_ID: str | None = None
+    GITHUB_CODECOV_UNIT_TEST_PRIVATE_KEY: str | None = None
 
     LANGFUSE_PUBLIC_KEY: str = ""
     LANGFUSE_SECRET_KEY: str = ""


### PR DESCRIPTION
For unit test gen, use the codecov github app for repo client if available, if not fallback to autofix app

Tested with both unit test gen and autofix to make sure this doesn't break anything.