### PR TITLE
[feat] Post comment to PR post unit test generation

### DIFF
--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -523,7 +523,7 @@ class RepoClient:
         original_pr_id = int(original_pr_url.split("/")[-1])
         repo_name = original_pr_url.split("github.com/")[1].split("/pull")[0]
         url = f"https://api.github.com/repos/{repo_name}/issues/{original_pr_id}/comments"
-        comment = f"Unit tests have been generated and are available [here]({unit_test_pr_url}) for your review."
+        comment = f"Sentry has generated a new [PR]({unit_test_pr_url}) with unit tests for this PR. View the new PR({unit_test_pr_url}) to review the changes."
         params = {"body": comment}
         headers = self._get_auth_headers()
         response = requests.post(url, headers=headers, json=params)

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -518,3 +518,14 @@ class RepoClient:
         data = requests.get(pr_url, headers=self._get_auth_headers(accept_type="json"))
         data.raise_for_status()  # Raise an exception for HTTP errors
         return data.json()["head"]["sha"]
+
+    def post_unit_test_reference_to_original_pr(self, original_pr_url: str, unit_test_pr_url: str):
+        original_pr_id = int(original_pr_url.split("/")[-1])
+        repo_name = original_pr_url.split("github.com/")[1].split("/pull")[0]
+        url = f"https://api.github.com/repos/{repo_name}/issues/{original_pr_id}/comments"
+        comment = f"Unit tests have been generated and are available [here]({unit_test_pr_url}) for your review."
+        params = {"body": comment}
+        headers = self._get_auth_headers()
+        response = requests.post(url, headers=headers, json=params)
+        response.raise_for_status()
+        return response.json()["html_url"]

--- a/src/seer/automation/codegen/unit_test_github_pr_creator.py
+++ b/src/seer/automation/codegen/unit_test_github_pr_creator.py
@@ -38,9 +38,13 @@ class GeneratedTestsPullRequestCreator:
             commit_messages
         )
 
-        self.repo_client.create_pr_from_branch(
+        new_pr = self.repo_client.create_pr_from_branch(
             branch=branch_ref,
             title=pr_title,
             description=description,
             provided_base=self.pr.head.ref,
         )
+
+        original_pr_url = self.pr.html_url
+        new_pr_url = new_pr.html_url
+        self.repo_client.post_unit_test_reference_to_original_pr(original_pr_url, new_pr_url)

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -395,7 +395,7 @@ class TestRepoClientIndexFileSet:
         }
         mock_post.return_value = mock_response
 
-        result = self.repo_client.post_unit_test_reference_to_original_pr(
+        result = RepoClient.post_unit_test_reference_to_original_pr(
             original_pr_url, unit_test_pr_url
         )
 

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from github import UnknownObjectException
@@ -382,7 +382,7 @@ class TestRepoClientIndexFileSet:
         assert result == {"file1.py"}
 
     @patch("seer.automation.codebase.repo_client.requests.post")
-    def test_post_unit_test_reference_to_original_pr(self, mock_post):
+    def test_post_unit_test_reference_to_original_pr(self, repo_client, mock_post):
         original_pr_url = "https://github.com/sentry/sentry/pull/12345"
         unit_test_pr_url = "https://github.com/sentry/sentry/pull/67890"
         expected_url = "https://api.github.com/repos/sentry/sentry/issues/12345/comments"
@@ -395,11 +395,10 @@ class TestRepoClientIndexFileSet:
         }
         mock_post.return_value = mock_response
 
-        result = RepoClient.post_unit_test_reference_to_original_pr(
+        result = repo_client.post_unit_test_reference_to_original_pr(
             original_pr_url, unit_test_pr_url
         )
 
-        mock_post.assert_called_once_with(
-            expected_url, headers=self.repo_client._get_auth_headers(), json=expected_params
-        )
-        self.assertEqual(result, "https://github.com/sentry/sentry/pull/12345#issuecomment-1")
+        mock_post.assert_called_once_with(expected_url, headers=ANY, json=expected_params)
+
+        assert result == "https://github.com/sentry/sentry/pull/12345#issuecomment-1"

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -382,11 +382,14 @@ class TestRepoClientIndexFileSet:
         assert result == {"file1.py"}
 
     @patch("seer.automation.codebase.repo_client.requests.post")
-    def test_post_unit_test_reference_to_original_pr(self, repo_client, mock_post):
+    def test_post_unit_test_reference_to_original_pr(self, mock_post, repo_client):
         original_pr_url = "https://github.com/sentry/sentry/pull/12345"
         unit_test_pr_url = "https://github.com/sentry/sentry/pull/67890"
         expected_url = "https://api.github.com/repos/sentry/sentry/issues/12345/comments"
-        expected_comment = f"Sentry has generated a new [PR]({unit_test_pr_url}) with unit tests for this PR. View the new PR({unit_test_pr_url}) to review the changes."
+        expected_comment = (
+            f"Sentry has generated a new [PR]({unit_test_pr_url}) with unit tests for this PR. "
+            f"View the new PR({unit_test_pr_url}) to review the changes."
+        )
         expected_params = {"body": expected_comment}
 
         mock_response = MagicMock()

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -380,3 +380,26 @@ class TestRepoClientIndexFileSet:
         )
         result = client.get_index_file_set("main")
         assert result == {"file1.py"}
+
+    @patch("seer.automation.codebase.repo_client.requests.post")
+    def test_post_unit_test_reference_to_original_pr(self, mock_post):
+        original_pr_url = "https://github.com/sentry/sentry/pull/12345"
+        unit_test_pr_url = "https://github.com/sentry/sentry/pull/67890"
+        expected_url = "https://api.github.com/repos/sentry/sentry/issues/12345/comments"
+        expected_comment = f"Sentry has generated a new [PR]({unit_test_pr_url}) with unit tests for this PR. View the new PR({unit_test_pr_url}) to review the changes."
+        expected_params = {"body": expected_comment}
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "html_url": "https://github.com/sentry/sentry/pull/12345#issuecomment-1"
+        }
+        mock_post.return_value = mock_response
+
+        result = self.repo_client.post_unit_test_reference_to_original_pr(
+            original_pr_url, unit_test_pr_url
+        )
+
+        mock_post.assert_called_once_with(
+            expected_url, headers=self.repo_client._get_auth_headers(), json=expected_params
+        )
+        self.assertEqual(result, "https://github.com/sentry/sentry/pull/12345#issuecomment-1")


### PR DESCRIPTION
Posts a comment to the original PR once unit test generation is complete. 

<img width="946" alt="Screenshot 2024-10-17 at 9 04 11 AM" src="https://github.com/user-attachments/assets/e3af3a27-6786-4ff0-8fc4-08aaf35b88df">


- [x] Finalize copy