### PR TITLE
fix(autofix + issue summary): Make handled field optional

### DIFF
--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -275,7 +275,7 @@ class SentryEventData(TypedDict):
 
 class ExceptionMechanism(TypedDict):
     type: str
-    handled: bool
+    handled: bool | None = None
 
 
 class ExceptionDetails(BaseModel):

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -275,7 +275,7 @@ class SentryEventData(TypedDict):
 
 class ExceptionMechanism(TypedDict):
     type: str
-    handled: bool | None = None
+    handled: NotRequired[bool]
 
 
 class ExceptionDetails(BaseModel):


### PR DESCRIPTION
Fixes a ValidationError when an event payload doesn't have this field. [Sentry Issue](https://sentry.sentry.io/issues/6013887390/?node=txn-e68fd8207bc24ef7ba9a8a0eb963d44e&project=6178942&query=is:unresolved%20issue.priority:%5Bhigh,%20medium%5D&statsPeriod=7d&stream_index=2)