### PR TITLE
feat(autofix): Add explanation when no root cause found

### DIFF
--- a/src/seer/automation/autofix/components/root_cause/models.py
+++ b/src/seer/automation/autofix/components/root_cause/models.py
@@ -165,3 +165,4 @@ class RootCauseAnalysisRequest(BaseComponentRequest):
 
 class RootCauseAnalysisOutput(BaseComponentOutput):
     causes: list[RootCauseAnalysisItem]
+    termination_reason: str | None = None

--- a/src/seer/automation/autofix/components/root_cause/prompts.py
+++ b/src/seer/automation/autofix/components/root_cause/prompts.py
@@ -18,7 +18,7 @@ class RootCauseAnalysisPrompts:
             - Don't always assume data being passed is correct, it could be incorrect! Sometimes the API request is malformed, or there is a bug on the client/server side that is causing the issue.
             - You are not able to search in or make changes to external libraries. If the error is caused by an external library or the stacktrace only contains frames from external libraries, do not attempt to search in external libraries.
             - At any point, please feel free to ask your teammates (who are much more familiar with the codebase) any specific questions that would help you in your analysis.
-            - If you are not able to find any potential root causes, return only <NO_ROOT_CAUSES>.
+            - If you are not able to find any potential root causes, return only <NO_ROOT_CAUSES> followed by a specific 10-20 word reason for why.
             - If multiple searches turn up no viable results, you should conclude the session.
             - At EVERY step of your investigation, you MUST think out loud! Share what you're learning and thinking along the way, EVERY TIME YOU SPEAK.
 

--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -90,12 +90,12 @@ class AutofixEventManager:
 
             cur.status = AutofixStatus.PROCESSING
 
-    def send_root_cause_analysis_result(self, root_cause_output: RootCauseAnalysisOutput | None):
+    def send_root_cause_analysis_result(self, root_cause_output: RootCauseAnalysisOutput):
         with self.state.update() as cur:
             root_cause_processing_step = cur.find_or_add(self.root_cause_analysis_processing_step)
             root_cause_processing_step.status = AutofixStatus.COMPLETED
             root_cause_step = cur.find_or_add(self.root_cause_analysis_step)
-            if root_cause_output and root_cause_output.causes:
+            if root_cause_output.causes:
                 root_cause_step.status = AutofixStatus.COMPLETED
                 root_cause_step.causes = root_cause_output.causes
 
@@ -103,6 +103,7 @@ class AutofixEventManager:
             else:
                 root_cause_step.status = AutofixStatus.ERROR
                 cur.status = AutofixStatus.ERROR
+                root_cause_step.termination_reason = root_cause_output.termination_reason
 
     def set_selected_root_cause(self, payload: AutofixRootCauseUpdatePayload):
         root_cause_selection: CustomRootCauseSelection | CodeContextRootCauseSelection | None = None

--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -176,6 +176,7 @@ class RootCauseStep(BaseStep):
 
     causes: list[RootCauseAnalysisItem] = []
     selection: RootCauseSelection | None = None
+    termination_reason: str | None = None
 
 
 class ChangesStep(BaseStep):

--- a/src/seer/automation/autofix/steps/root_cause_step.py
+++ b/src/seer/automation/autofix/steps/root_cause_step.py
@@ -84,14 +84,14 @@ class RootCauseStep(AutofixPipelineStep):
         self.context.event_manager.send_root_cause_analysis_result(root_cause_output)
         self.context.event_manager.add_log(
             "Here is Autofix's proposed root cause."
-            if root_cause_output
-            else "Sorry, Autofix couldn't find the root cause."
+            if root_cause_output.termination_reason is None and root_cause_output.causes
+            else "Autofix couldn't find the root cause. Maybe help Autofix rethink by editing a card above?"
         )
 
         # GitHub Copilot can comment on a provided PR with the root cause analysis
         pr_to_comment_on = state.request.options.comment_on_pr_with_url
         if pr_to_comment_on:
-            causes = root_cause_output.causes if root_cause_output else []
+            causes = root_cause_output.causes
             cause_string = "Autofix couldn't find a root cause for this issue."
             if causes:
                 cause_string = causes[0].to_markdown_string()

--- a/tests/automation/autofix/components/test_root_cause.py
+++ b/tests/automation/autofix/components/test_root_cause.py
@@ -76,3 +76,48 @@ class TestRootCauseComponent:
         assert output.termination_reason == "this is too hard, I give up"
         # Ensure that the second run (reproduction) and the formatter are not called when <NO_ROOT_CAUSES> is returned
         assert mock_agent.return_value.run.call_count == 1
+
+    def test_agent_run_returns_none(self, component, mock_agent):
+        mock_agent.return_value.run.return_value = None
+
+        output = component.invoke(MagicMock())
+
+        assert output.causes == []
+        assert output.termination_reason == "Something went wrong when Autofix was running."
+        # Ensure that the second run (reproduction) and the formatter are not called
+        assert mock_agent.return_value.run.call_count == 1
+
+    def test_agent_run_returns_none_on_second_call(self, component, mock_agent):
+        # Mock the agent.run method to return a valid response first, then None
+        mock_agent.return_value.run.side_effect = ["Valid root cause analysis", None]
+
+        mock_llm_client = MagicMock()
+        mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
+            parsed=MultipleRootCauseAnalysisOutputPrompt(
+                cause=RootCauseAnalysisItemPrompt(
+                    title="Test Root Cause",
+                    description="This is a test root cause",
+                    reproduction_instructions="",
+                    relevant_code=None,
+                )
+            ),
+            metadata=LlmResponseMetadata(
+                model="test-model",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+            ),
+        )
+
+        module = Module()
+        module.constant(LlmClient, mock_llm_client)
+
+        with module:
+            output = component.invoke(MagicMock())
+
+        assert output.causes == []
+        assert (
+            output.termination_reason
+            == "Something went wrong when Autofix was trying to figure out how to reproduce the issue."
+        )
+        # Ensure that the run method is called twice
+        assert mock_agent.return_value.run.call_count == 2

--- a/tests/automation/autofix/components/test_root_cause.py
+++ b/tests/automation/autofix/components/test_root_cause.py
@@ -68,10 +68,11 @@ class TestRootCauseComponent:
         assert output.causes[0].code_context is None
 
     def test_no_root_causes_response(self, component, mock_agent):
-        mock_agent.return_value.run.return_value = "<NO_ROOT_CAUSES>"
+        mock_agent.return_value.run.return_value = "<NO_ROOT_CAUSES> this is too hard, I give up"
 
         output = component.invoke(MagicMock())
 
-        assert output is None
+        assert output.causes == []
+        assert output.termination_reason == "this is too hard, I give up"
         # Ensure that the second run (reproduction) and the formatter are not called when <NO_ROOT_CAUSES> is returned
         assert mock_agent.return_value.run.call_count == 1

--- a/tests/automation/autofix/steps/test_root_cause_step.py
+++ b/tests/automation/autofix/steps/test_root_cause_step.py
@@ -3,10 +3,17 @@ from unittest.mock import MagicMock, patch
 
 from johen import generate
 
-from seer.automation.autofix.components.root_cause.models import RootCauseAnalysisOutput
-from seer.automation.autofix.models import AutofixContinuation, AutofixRequest
+from seer.automation.autofix.components.root_cause.models import (
+    RootCauseAnalysisItem,
+    RootCauseAnalysisOutput,
+)
+from seer.automation.autofix.models import (
+    AutofixContinuation,
+    AutofixRequest,
+    AutofixRequestOptions,
+)
 from seer.automation.autofix.steps.root_cause_step import RootCauseStep
-from seer.automation.models import IssueDetails, SentryEventData
+from seer.automation.models import IssueDetails, RepoDefinition, SentryEventData
 from seer.automation.summarize.issue import IssueSummary
 
 
@@ -42,6 +49,54 @@ class TestRootCauseStep(unittest.TestCase):
 
         step.invoke()
 
+        step.context.event_manager.send_root_cause_analysis_start.assert_called()
+        step.context.process_event_paths.assert_called()
+        step.context.event_manager.send_root_cause_analysis_result.assert_called()
+
+    @patch("seer.automation.autofix.steps.root_cause_step.RootCauseAnalysisComponent")
+    def test_github_copilot_pr_comment(self, mock_root_cause_component):
+        mock_context = MagicMock()
+        RootCauseStep._instantiate_context = MagicMock(return_value=mock_context)
+
+        error_event = next(generate(SentryEventData))
+        pr_url = "https://github.com/example/repo/pull/123"
+        repo = RepoDefinition(name="repo", owner="example", provider="github", external_id="123")
+
+        mock_context.event_manager = MagicMock()
+        mock_context.has_missing_codebase_indexes.return_value = False
+        mock_context.state.get.return_value = AutofixContinuation(
+            request=AutofixRequest(
+                organization_id=1,
+                project_id=1,
+                repos=[repo],
+                issue=IssueDetails(id=0, title="", events=[error_event]),
+                issue_summary=IssueSummary(
+                    reason_step_by_step=[],
+                    summary_of_the_issue_based_on_your_step_by_step_reasoning="summary",
+                    summary_of_the_functionality_affected="impact",
+                    five_to_ten_word_headline="headline",
+                ),
+                options=AutofixRequestOptions(comment_on_pr_with_url=pr_url),
+            )
+        )
+
+        mock_root_cause_output = RootCauseAnalysisOutput(
+            causes=[RootCauseAnalysisItem(description="Test root cause", id=0, title="Test title")]
+        )
+        mock_root_cause_component.return_value.invoke.return_value = mock_root_cause_output
+
+        step = RootCauseStep({"run_id": 1, "step_id": 1})
+
+        step.invoke()
+
+        # Assert that the PR comment method was called with the correct arguments
+        mock_context.comment_root_cause_on_pr.assert_called_once_with(
+            pr_url=pr_url,
+            repo_definition=repo,
+            root_cause="# Test title\n\n## Description\nTest root cause\n\n## Reproduction Steps\nNone",
+        )
+
+        # Assert that other expected methods were called
         step.context.event_manager.send_root_cause_analysis_start.assert_called()
         step.context.process_event_paths.assert_called()
         step.context.event_manager.send_root_cause_analysis_result.assert_called()


### PR DESCRIPTION
Generates a short explanation for why Autofix failed to find a root cause. Also sends it the frontend so we can show it like this:
<img width="693" alt="Screenshot 2024-10-23 at 10 22 18 AM" src="https://github.com/user-attachments/assets/43892dfa-b9e0-4d06-82d0-9764b68af47c">
