### PR TITLE
feat(issue summary): Make issue summary bulleted, remove impact

### DIFF
--- a/src/seer/automation/autofix/prompts.py
+++ b/src/seer/automation/autofix/prompts.py
@@ -37,7 +37,7 @@ def format_summary(summary: IssueSummary | None) -> str:
         {analysis}
         """
     ).format(
-        details=summary.summary_of_the_issue_based_on_your_step_by_step_reasoning,
+        details=summary.bulleted_summary_of_the_issue_based_on_your_step_by_step_reasoning,
         analysis="\n".join(
             [f"- {step.reasoning} {step.justification}" for step in summary.reason_step_by_step]
         ),

--- a/tests/automation/autofix/steps/test_root_cause_step.py
+++ b/tests/automation/autofix/steps/test_root_cause_step.py
@@ -71,8 +71,7 @@ class TestRootCauseStep(unittest.TestCase):
                 issue=IssueDetails(id=0, title="", events=[error_event]),
                 issue_summary=IssueSummary(
                     reason_step_by_step=[],
-                    summary_of_the_issue_based_on_your_step_by_step_reasoning="summary",
-                    summary_of_the_functionality_affected="impact",
+                    bulleted_summary_of_the_issue_based_on_your_step_by_step_reasoning="summary",
                     five_to_ten_word_headline="headline",
                 ),
                 options=AutofixRequestOptions(comment_on_pr_with_url=pr_url),

--- a/tests/automation/autofix/steps/test_root_cause_step.py
+++ b/tests/automation/autofix/steps/test_root_cause_step.py
@@ -35,8 +35,7 @@ class TestRootCauseStep(unittest.TestCase):
                 issue=IssueDetails(id=0, title="", events=[error_event]),
                 issue_summary=IssueSummary(
                     reason_step_by_step=[],
-                    summary_of_the_issue_based_on_your_step_by_step_reasoning="summary",
-                    summary_of_the_functionality_affected="impact",
+                    bulleted_summary_of_the_issue_based_on_your_step_by_step_reasoning="summary",
                     five_to_ten_word_headline="headline",
                 ),
             )

--- a/tests/automation/autofix/test_autofix_context.py
+++ b/tests/automation/autofix/test_autofix_context.py
@@ -130,8 +130,7 @@ class TestAutofixContext(unittest.TestCase):
     def test_get_issue_summary(self):
         with Session() as session:
             valid_summary_data = {
-                "summary_of_the_issue_based_on_your_step_by_step_reasoning": "summary",
-                "summary_of_the_functionality_affected": "impact",
+                "bulleted_summary_of_the_issue_based_on_your_step_by_step_reasoning": "summary",
                 "reason_step_by_step": [],
                 "five_to_ten_word_headline": "headline",
             }
@@ -146,9 +145,8 @@ class TestAutofixContext(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertIsInstance(result, IssueSummary)
         self.assertEqual(
-            result.summary_of_the_issue_based_on_your_step_by_step_reasoning, "summary"
+            result.bulleted_summary_of_the_issue_based_on_your_step_by_step_reasoning, "summary"
         )
-        self.assertEqual(result.summary_of_the_functionality_affected, "impact")
         self.assertEqual(result.five_to_ten_word_headline, "headline")
 
         with Session() as session:

--- a/tests/automation/summarize/test_issue.py
+++ b/tests/automation/summarize/test_issue.py
@@ -26,9 +26,8 @@ class TestSummarizeIssue:
         mock_structured_completion = MagicMock()
         mock_raw_summary = MagicMock(
             reason_step_by_step=[],
-            summary_of_the_issue_based_on_your_step_by_step_reasoning="Test summary",
-            summary_of_the_functionality_affected="Test functionality",
-            five_to_ten_word_headline="Test headline",
+            bulleted_summary_of_the_issue_based_on_your_step_by_step_reasoning="Test summary",
+            five_to_ten_word_headline="Test headline!",
         )
         mock_structured_completion.choices[0].message.parsed = mock_raw_summary
         mock_structured_completion.choices[0].message.refusal = None
@@ -46,8 +45,8 @@ class TestSummarizeIssue:
         assert isinstance(result, SummarizeIssueResponse)
         assert result.group_id == 1
         assert result.summary == "Test summary"
-        assert result.impact == "Test functionality"
-        assert result.headline == "Test headline"
+        assert result.impact == ""
+        assert result.headline == "Test headline."
         assert raw_result == mock_raw_summary
 
     @patch("seer.automation.summarize.issue.EventDetails.from_event")
@@ -59,8 +58,7 @@ class TestSummarizeIssue:
         mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
             parsed=MagicMock(
                 reason_step_by_step=[],
-                summary_of_the_issue_based_on_your_step_by_step_reasoning="Test summary",
-                summary_of_the_functionality_affected="Test functionality",
+                bulleted_summary_of_the_issue_based_on_your_step_by_step_reasoning="Test summary",
                 five_to_ten_word_headline="Test headline",
             ),
             metadata=LlmResponseMetadata(
@@ -88,8 +86,7 @@ class TestRunSummarizeIssue:
             group_id=1, headline="headline", summary="summary", impact="impact"
         ), IssueSummary(
             reason_step_by_step=[],
-            summary_of_the_issue_based_on_your_step_by_step_reasoning="summary",
-            summary_of_the_functionality_affected="impact",
+            bulleted_summary_of_the_issue_based_on_your_step_by_step_reasoning="summary",
             five_to_ten_word_headline="headline",
         )
 
@@ -119,8 +116,7 @@ class TestRunSummarizeIssue:
             group_id=1, headline="headline", summary="summary", impact="impact"
         ), IssueSummary(
             reason_step_by_step=[],
-            summary_of_the_issue_based_on_your_step_by_step_reasoning="summary",
-            summary_of_the_functionality_affected="impact",
+            bulleted_summary_of_the_issue_based_on_your_step_by_step_reasoning="summary",
             five_to_ten_word_headline="headline",
         )
 


### PR DESCRIPTION
Remove impact section from generation since we're not using it to let the model focus (but still preserve the model we're sending to the frontend).

Prompt engineer the summary to be bulleted shorthand.