### PR TITLE
feat(autofix): Add simple issue short circut, remove repro steps

### DIFF
--- a/src/seer/automation/autofix/components/is_obvious.py
+++ b/src/seer/automation/autofix/components/is_obvious.py
@@ -1,0 +1,59 @@
+import textwrap
+
+from langfuse.decorators import observe
+from sentry_sdk.ai.monitoring import ai_track
+
+from seer.automation.agent.client import LlmClient, OpenAiProvider
+from seer.automation.autofix.autofix_context import AutofixContext
+from seer.automation.component import BaseComponent, BaseComponentOutput, BaseComponentRequest
+from seer.automation.models import EventDetails
+from seer.dependency_injection import inject, injected
+
+
+class IsObviousRequest(BaseComponentRequest):
+    event_details: EventDetails
+
+
+class IsObviousOutput(BaseComponentOutput):
+    is_root_cause_clear: bool
+
+
+class IsObviousPrompts:
+    @staticmethod
+    def format_default_msg(
+        event_details: EventDetails,
+    ):
+        return textwrap.dedent(
+            """\
+            You are an exceptional principal engineer that is amazing at finding the root cause of any issue. We have an issue in our codebase described below. Is the root cause of the issue clear from the details below? Or does it require searching for more information around the codebase?
+
+            {event_details}"""
+        ).format(
+            event_details=event_details,
+        )
+
+
+class IsObviousComponent(BaseComponent[IsObviousRequest, IsObviousOutput]):
+    context: AutofixContext
+
+    @observe(name="Check if Obvious")
+    @ai_track(description="Check if Obvious")
+    @inject
+    def invoke(
+        self, request: IsObviousRequest, llm_client: LlmClient = injected
+    ) -> IsObviousOutput | None:
+        output = llm_client.generate_structured(
+            prompt=IsObviousPrompts.format_default_msg(
+                event_details=request.event_details,
+            ),
+            model=OpenAiProvider.model("gpt-4o-mini"),
+            response_format=IsObviousOutput,
+        )
+        data = output.parsed
+
+        with self.context.state.update() as cur:
+            cur.usage += output.metadata.usage
+
+        if data is None:
+            return IsObviousOutput(is_root_cause_clear=False)
+        return data

--- a/src/seer/automation/autofix/components/root_cause/models.py
+++ b/src/seer/automation/autofix/components/root_cause/models.py
@@ -90,7 +90,7 @@ class RootCauseAnalysisItem(BaseModel):
 class RootCauseAnalysisItemPrompt(BaseModel):
     title: str
     description: str
-    reproduction_instructions: str | None = None
+    # reproduction_instructions: str | None = None
     unit_test: UnitTestSnippetPrompt | None = None
     relevant_code: Optional[RootCauseAnalysisRelevantContext]
 
@@ -99,16 +99,16 @@ class RootCauseAnalysisItemPrompt(BaseModel):
         return cls(
             title=model.title,
             description=model.description,
-            reproduction_instructions=model.reproduction,
-            unit_test=(
-                UnitTestSnippetPrompt(
-                    file_path=model.unit_test.file_path,
-                    code_snippet=model.unit_test.snippet,
-                    description=model.unit_test.description,
-                )
-                if model.unit_test
-                else None
-            ),
+            # reproduction_instructions=model.reproduction,
+            # unit_test=(
+            #     UnitTestSnippetPrompt(
+            #         file_path=model.unit_test.file_path,
+            #         code_snippet=model.unit_test.snippet,
+            #         description=model.unit_test.description,
+            #     )
+            #     if model.unit_test
+            #     else None
+            # ),
             relevant_code=(
                 RootCauseAnalysisRelevantContext(
                     snippets=[
@@ -130,16 +130,16 @@ class RootCauseAnalysisItemPrompt(BaseModel):
         return RootCauseAnalysisItem.model_validate(
             {
                 **self.model_dump(),
-                "reproduction": self.reproduction_instructions,
-                "unit_test": (
-                    {
-                        "file_path": self.unit_test.file_path,
-                        "snippet": self.unit_test.code_snippet,
-                        "description": self.unit_test.description,
-                    }
-                    if self.unit_test
-                    else None
-                ),
+                # "reproduction": self.reproduction_instructions,
+                # "unit_test": (
+                #     {
+                #         "file_path": self.unit_test.file_path,
+                #         "snippet": self.unit_test.code_snippet,
+                #         "description": self.unit_test.description,
+                #     }
+                #     if self.unit_test
+                #     else None
+                # ),
                 "code_context": (
                     self.relevant_code.model_dump()["snippets"] if self.relevant_code else None
                 ),

--- a/src/seer/automation/autofix/components/root_cause/prompts.py
+++ b/src/seer/automation/autofix/components/root_cause/prompts.py
@@ -7,19 +7,32 @@ from seer.automation.summarize.issue import IssueSummary
 
 class RootCauseAnalysisPrompts:
     @staticmethod
-    def format_system_msg():
+    def format_system_msg(has_tools: bool = True):
         return textwrap.dedent(
-            """\
+            f"""\
             You are an exceptional principal engineer that is amazing at finding the root cause of any issue.
 
-            You have tools to search a codebase to find the root cause of an issue. Please use the tools as many times as you want to find the root cause of the issue.
+            {
+                "You have tools to search a codebase to find the root cause of an issue. Please use the tools as many times as you want to find the root cause of the issue."
+                if has_tools
+                else "You do not have tools to search a codebase to find the root cause of an issue."
+            }
 
             # Guidelines:
             - Don't always assume data being passed is correct, it could be incorrect! Sometimes the API request is malformed, or there is a bug on the client/server side that is causing the issue.
-            - You are not able to search in or make changes to external libraries. If the error is caused by an external library or the stacktrace only contains frames from external libraries, do not attempt to search in external libraries.
-            - At any point, please feel free to ask your teammates (who are much more familiar with the codebase) any specific questions that would help you in your analysis.
+            {"- You are not able to search in or make changes to external libraries. If the error is caused by an external library or the stacktrace only contains frames from external libraries, do not attempt to search in external libraries."
+                if has_tools
+                else ""
+            }
+            {"- At any point, please feel free to ask your teammates (who are much more familiar with the codebase) any specific questions that would help you in your analysis."
+                if has_tools
+                else ""
+            }
             - If you are not able to find any potential root causes, return only <NO_ROOT_CAUSES> followed by a specific 10-20 word reason for why.
-            - If multiple searches turn up no viable results, you should conclude the session.
+            {"- If multiple searches turn up no viable results, you should conclude the session."
+                if has_tools
+                else ""
+            }
             - At EVERY step of your investigation, you MUST think out loud! Share what you're learning and thinking along the way, EVERY TIME YOU SPEAK.
 
             It is important that we find the potential root causes of the issue."""

--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -268,6 +268,16 @@ class AutofixRequest(BaseModel):
 
     options: AutofixRequestOptions = Field(default_factory=AutofixRequestOptions)
 
+    @field_validator("issue_summary", mode="before")
+    @classmethod
+    def validate_issue_summary(cls, value):
+        if value is None:
+            return None
+        try:
+            return IssueSummary.model_validate(value)
+        except Exception:
+            return None
+
     @field_validator("repos", mode="after")
     @classmethod
     def validate_repo_duplicates(cls, repos):

--- a/tests/automation/autofix/components/test_is_obvious.py
+++ b/tests/automation/autofix/components/test_is_obvious.py
@@ -1,0 +1,103 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from seer.automation.agent.client import LlmClient
+from seer.automation.agent.models import (
+    LlmGenerateStructuredResponse,
+    LlmProviderType,
+    LlmResponseMetadata,
+    Usage,
+)
+from seer.automation.autofix.autofix_context import AutofixContext
+from seer.automation.autofix.components.is_obvious import (
+    IsObviousComponent,
+    IsObviousOutput,
+    IsObviousRequest,
+)
+from seer.automation.models import EventDetails
+from seer.dependency_injection import Module
+
+
+class TestIsObviousComponent:
+    @pytest.fixture
+    def component(self):
+        mock_context = MagicMock(spec=AutofixContext)
+        mock_context.state = MagicMock()
+        return IsObviousComponent(mock_context)
+
+    def test_invoke_returns_true(self, component):
+        mock_llm_client = MagicMock(spec=LlmClient)
+        mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
+            parsed=IsObviousOutput(is_root_cause_clear=True),
+            metadata=LlmResponseMetadata(
+                model="test-model",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+            ),
+        )
+
+        module = Module()
+        module.constant(LlmClient, mock_llm_client)
+
+        with module:
+            result = component.invoke(IsObviousRequest(event_details=MagicMock(spec=EventDetails)))
+
+        assert result is not None
+        assert result.is_root_cause_clear is True
+
+    def test_invoke_returns_false(self, component):
+        mock_llm_client = MagicMock(spec=LlmClient)
+        mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
+            parsed=IsObviousOutput(is_root_cause_clear=False),
+            metadata=LlmResponseMetadata(
+                model="test-model",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+            ),
+        )
+
+        module = Module()
+        module.constant(LlmClient, mock_llm_client)
+
+        with module:
+            result = component.invoke(IsObviousRequest(event_details=MagicMock(spec=EventDetails)))
+
+        assert result is not None
+        assert result.is_root_cause_clear is False
+
+    def test_invoke_handles_none_response(self, component):
+        mock_llm_client = MagicMock(spec=LlmClient)
+        mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
+            parsed=None,
+            metadata=LlmResponseMetadata(
+                model="test-model",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+            ),
+        )
+
+        module = Module()
+        module.constant(LlmClient, mock_llm_client)
+
+        with module:
+            result = component.invoke(IsObviousRequest(event_details=MagicMock(spec=EventDetails)))
+
+        assert result is not None
+        assert result.is_root_cause_clear is False
+
+    def test_invoke_formats_prompt_correctly(self, component):
+        mock_llm_client = MagicMock(spec=LlmClient)
+        mock_event_details = MagicMock(spec=EventDetails)
+        mock_event_details.__str__.return_value = "Test event details"
+
+        module = Module()
+        module.constant(LlmClient, mock_llm_client)
+
+        with module:
+            component.invoke(IsObviousRequest(event_details=mock_event_details))
+
+        # Verify the prompt was formatted with the event details
+        mock_llm_client.generate_structured.assert_called_once()
+        prompt_arg = mock_llm_client.generate_structured.call_args[1]["prompt"]
+        assert "Test event details" in prompt_arg

--- a/tests/automation/autofix/components/test_root_cause.py
+++ b/tests/automation/autofix/components/test_root_cause.py
@@ -7,14 +7,18 @@ from seer.automation.agent.models import (
     LlmGenerateStructuredResponse,
     LlmProviderType,
     LlmResponseMetadata,
+    Message,
     Usage,
 )
 from seer.automation.autofix.autofix_context import AutofixContext
+from seer.automation.autofix.components.is_obvious import IsObviousOutput
 from seer.automation.autofix.components.root_cause.component import RootCauseAnalysisComponent
 from seer.automation.autofix.components.root_cause.models import (
     MultipleRootCauseAnalysisOutputPrompt,
     RootCauseAnalysisItemPrompt,
+    RootCauseAnalysisRequest,
 )
+from seer.automation.models import EventDetails
 from seer.dependency_injection import Module
 
 
@@ -31,10 +35,17 @@ class TestRootCauseComponent:
         with patch("seer.automation.autofix.components.root_cause.component.AutofixAgent") as mock:
             yield mock
 
+    @pytest.fixture
+    def mock_is_obvious_component(self):
+        with patch(
+            "seer.automation.autofix.components.root_cause.component.IsObviousComponent"
+        ) as mock:
+            yield mock
+
     def test_root_cause_simple_response_parsing(self, component, mock_agent):
         mock_agent.return_value.run.side_effect = [
             "Anything really",
-            "Reproduction steps",
+            "Formatter",
         ]
 
         mock_llm_client = MagicMock()
@@ -43,7 +54,6 @@ class TestRootCauseComponent:
                 cause=RootCauseAnalysisItemPrompt(
                     title="Missing Null Check",
                     description="The root cause of the issue is ...",
-                    reproduction_instructions="Steps to reproduce",
                     relevant_code=None,
                 )
             ),
@@ -64,7 +74,6 @@ class TestRootCauseComponent:
         assert len(output.causes) == 1
         assert output.causes[0].title == "Missing Null Check"
         assert output.causes[0].description == "The root cause of the issue is ..."
-        assert output.causes[0].reproduction == "Steps to reproduce"
         assert output.causes[0].code_context is None
 
     def test_no_root_causes_response(self, component, mock_agent):
@@ -74,7 +83,7 @@ class TestRootCauseComponent:
 
         assert output.causes == []
         assert output.termination_reason == "this is too hard, I give up"
-        # Ensure that the second run (reproduction) and the formatter are not called when <NO_ROOT_CAUSES> is returned
+        # Ensure that the formatter is not called when <NO_ROOT_CAUSES> is returned
         assert mock_agent.return_value.run.call_count == 1
 
     def test_agent_run_returns_none(self, component, mock_agent):
@@ -84,20 +93,28 @@ class TestRootCauseComponent:
 
         assert output.causes == []
         assert output.termination_reason == "Something went wrong when Autofix was running."
-        # Ensure that the second run (reproduction) and the formatter are not called
+        # Ensure that the formatter is not called
         assert mock_agent.return_value.run.call_count == 1
 
-    def test_agent_run_returns_none_on_second_call(self, component, mock_agent):
-        # Mock the agent.run method to return a valid response first, then None
-        mock_agent.return_value.run.side_effect = ["Valid root cause analysis", None]
+    def test_root_cause_with_obvious_root_cause(
+        self, component, mock_agent, mock_is_obvious_component
+    ):
+        # Mock IsObviousComponent to return True
+        mock_is_obvious = MagicMock()
+        mock_is_obvious.invoke.return_value = IsObviousOutput(is_root_cause_clear=True)
+        mock_is_obvious_component.return_value = mock_is_obvious
+
+        mock_agent.return_value.run.side_effect = [
+            "Some root cause analysis",
+            "Formatter",
+        ]
 
         mock_llm_client = MagicMock()
         mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
             parsed=MultipleRootCauseAnalysisOutputPrompt(
                 cause=RootCauseAnalysisItemPrompt(
                     title="Test Root Cause",
-                    description="This is a test root cause",
-                    reproduction_instructions="",
+                    description="Description",
                     relevant_code=None,
                 )
             ),
@@ -112,12 +129,95 @@ class TestRootCauseComponent:
         module.constant(LlmClient, mock_llm_client)
 
         with module:
-            output = component.invoke(MagicMock())
+            component.invoke(RootCauseAnalysisRequest(event_details=MagicMock(spec=EventDetails)))
 
-        assert output.causes == []
-        assert (
-            output.termination_reason
-            == "Something went wrong when Autofix was trying to figure out how to reproduce the issue."
+        # Verify agent was created without tools
+        mock_agent.assert_called_once()
+        tools_arg = mock_agent.call_args[1]["tools"]
+        assert tools_arg is None
+
+    def test_root_cause_with_non_obvious_root_cause(
+        self, component, mock_agent, mock_is_obvious_component
+    ):
+        # Mock IsObviousComponent to return False
+        mock_is_obvious = MagicMock()
+        mock_is_obvious.invoke.return_value = IsObviousOutput(is_root_cause_clear=False)
+        mock_is_obvious_component.return_value = mock_is_obvious
+
+        mock_agent.return_value.run.side_effect = [
+            "Some root cause analysis",
+            "Formatter",
+        ]
+
+        mock_llm_client = MagicMock()
+        mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
+            parsed=MultipleRootCauseAnalysisOutputPrompt(
+                cause=RootCauseAnalysisItemPrompt(
+                    title="Test Root Cause",
+                    description="Description",
+                    relevant_code=None,
+                )
+            ),
+            metadata=LlmResponseMetadata(
+                model="test-model",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+            ),
         )
-        # Ensure that the run method is called twice
-        assert mock_agent.return_value.run.call_count == 2
+
+        module = Module()
+        module.constant(LlmClient, mock_llm_client)
+
+        with module:
+            component.invoke(RootCauseAnalysisRequest(event_details=MagicMock(spec=EventDetails)))
+
+        # Verify agent was created with tools
+        mock_agent.assert_called_once()
+        tools_arg = mock_agent.call_args[1]["tools"]
+        assert tools_arg is not None
+
+    def test_root_cause_with_initial_memory_skips_is_obvious(
+        self, component, mock_agent, mock_is_obvious_component
+    ):
+        mock_is_obvious = MagicMock()
+        mock_is_obvious_component.return_value = mock_is_obvious
+
+        mock_agent.return_value.run.side_effect = [
+            "Some root cause analysis",
+            "Formatter",
+        ]
+
+        mock_llm_client = MagicMock()
+        mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
+            parsed=MultipleRootCauseAnalysisOutputPrompt(
+                cause=RootCauseAnalysisItemPrompt(
+                    title="Test Root Cause",
+                    description="Description",
+                    relevant_code=None,
+                )
+            ),
+            metadata=LlmResponseMetadata(
+                model="test-model",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+            ),
+        )
+
+        module = Module()
+        module.constant(LlmClient, mock_llm_client)
+
+        with module:
+            component.invoke(
+                RootCauseAnalysisRequest(
+                    event_details=MagicMock(spec=EventDetails),
+                    initial_memory=[Message(role="user", content="Hello")],
+                )
+            )
+
+        # Verify IsObviousComponent was not called
+        mock_is_obvious.invoke.assert_not_called()
+
+        # Verify agent was created with tools (default behavior when skipping is_obvious)
+        mock_agent.assert_called_once()
+        tools_arg = mock_agent.call_args[1]["tools"]
+        assert tools_arg is not None


### PR DESCRIPTION
This PR:
1. Adds a validator to the Issue Summary model so that eval datasets with old summary models can still be run.
2. Comments out the reproduction/unit test step in the root cause step.
3. Adds a check at the beginning of the root cause step that asks an LLM if tools are needed to identify the root cause (this call takes under 1 second). If it says no, the tools and certain parts of the prompt are removed.

These changes:
- reduce total run cost from ~60 cents to ~30 cents.
- improve eval scores by 3-5 points.
- on simple issues, get to the root cause much faster.