### PR TITLE
feat(autofix): Add short circuit to plan and code step

### DIFF
--- a/src/seer/automation/autofix/components/coding/component.py
+++ b/src/seer/automation/autofix/components/coding/component.py
@@ -5,6 +5,7 @@ from sentry_sdk.ai.monitoring import ai_track
 
 from seer.automation.agent.agent import AgentConfig, RunConfig
 from seer.automation.agent.client import AnthropicProvider, LlmClient
+from seer.automation.agent.models import Message
 from seer.automation.autofix.autofix_agent import AutofixAgent
 from seer.automation.autofix.autofix_context import AutofixContext
 from seer.automation.autofix.components.coding.models import (
@@ -19,6 +20,10 @@ from seer.automation.autofix.components.coding.utils import (
     task_to_file_change,
     task_to_file_create,
     task_to_file_delete,
+)
+from seer.automation.autofix.components.is_fix_obvious import (
+    IsFixObviousComponent,
+    IsFixObviousRequest,
 )
 from seer.automation.autofix.components.root_cause.models import RootCauseAnalysisItem
 from seer.automation.autofix.tools import BaseTools
@@ -105,6 +110,55 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
                 else request.root_cause_and_fix
             )
 
+            has_tools = True
+            if isinstance(request.root_cause_and_fix, RootCauseAnalysisItem):
+                expanded_files_messages = []
+                relevant_files = [
+                    {"file_path": context.snippet.file_path, "repo_name": context.snippet.repo_name}
+                    for context in (
+                        request.root_cause_and_fix.code_context
+                        if request.root_cause_and_fix.code_context
+                        else []
+                    )
+                    if context.snippet
+                ]
+                for file in relevant_files:
+                    file_content = (
+                        self.context.get_file_contents(
+                            path=file["file_path"], repo_name=file["repo_name"]
+                        )
+                        if file["file_path"]
+                        else None
+                    )
+                    if file_content:
+                        agent_message = Message(
+                            role="assistant",
+                            content=f"Expand document: {file['file_path']} in {file['repo_name']}",
+                        )
+                        user_message = Message(
+                            role="user",
+                            content=file_content,
+                        )
+                        agent.memory.append(agent_message)
+                        agent.memory.append(user_message)
+                        expanded_files_messages.append(agent_message)
+                        expanded_files_messages.append(user_message)
+
+                if expanded_files_messages:
+                    is_obvious = IsFixObviousComponent(self.context).invoke(
+                        IsFixObviousRequest(
+                            event_details=request.event_details,
+                            task_str=task_str,
+                            fix_instruction=request.fix_instruction,
+                            memory=expanded_files_messages,
+                        )
+                        if not request.initial_memory
+                        else None
+                    )
+                    if is_obvious and is_obvious.is_fix_clear:
+                        agent.tools = []
+                        has_tools = False
+
             state = self.context.state.get()
 
             response = agent.run(
@@ -117,11 +171,12 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
                             repo_names=[repo.full_name for repo in state.request.repos],
                             instruction=request.instruction,
                             fix_instruction=request.fix_instruction,
+                            has_tools=has_tools,
                         )
                         if not request.initial_memory
                         else None
                     ),
-                    system_prompt=CodingPrompts.format_system_msg(),
+                    system_prompt=CodingPrompts.format_system_msg(has_tools=has_tools),
                     model=AnthropicProvider.model("claude-3-5-sonnet-v2@20241022"),
                     memory_storage_key="plan_and_code",
                     run_name="Plan",
@@ -142,6 +197,7 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
                     model=AnthropicProvider.model("claude-3-5-sonnet-v2@20241022"),
                     memory_storage_key="plan_and_code",
                     run_name="Code",
+                    has_tools=has_tools,
                 ),
             )
 

--- a/src/seer/automation/autofix/components/is_fix_obvious.py
+++ b/src/seer/automation/autofix/components/is_fix_obvious.py
@@ -1,0 +1,75 @@
+import textwrap
+
+from langfuse.decorators import observe
+from sentry_sdk.ai.monitoring import ai_track
+
+from seer.automation.agent.client import LlmClient, OpenAiProvider
+from seer.automation.agent.models import Message
+from seer.automation.autofix.autofix_context import AutofixContext
+from seer.automation.component import BaseComponent, BaseComponentOutput, BaseComponentRequest
+from seer.automation.models import EventDetails
+from seer.dependency_injection import inject, injected
+
+
+class IsFixObviousRequest(BaseComponentRequest):
+    event_details: EventDetails
+    task_str: str
+    fix_instruction: str | None
+    memory: list[Message]
+
+
+class IsFixObviousOutput(BaseComponentOutput):
+    is_fix_clear: bool
+
+
+class IsFixObviousPrompts:
+    @staticmethod
+    def format_default_msg(
+        event_details: EventDetails,
+        task_str: str,
+        fix_instruction: str | None,
+    ):
+        return textwrap.dedent(
+            """\
+            You are an exceptional principal engineer that is amazing at fixing any issue. We have an issue in our codebase and its root cause is described below, and you've already looked at some code files. Are the code changes needed to fix the issue clear from the details below? Or does it require searching for more information around the codebase?
+
+            {event_details}
+
+            The root cause of the issue has been identified and context about the issue has been provided:
+            {task_str}
+
+            {fix_instruction}"""
+        ).format(
+            event_details=event_details,
+            task_str=task_str,
+            fix_instruction=fix_instruction if fix_instruction else "",
+        )
+
+
+class IsFixObviousComponent(BaseComponent[IsFixObviousRequest, IsFixObviousOutput]):
+    context: AutofixContext
+
+    @observe(name="Check if Obvious")
+    @ai_track(description="Check if Obvious")
+    @inject
+    def invoke(
+        self, request: IsFixObviousRequest, llm_client: LlmClient = injected
+    ) -> IsFixObviousOutput | None:
+        output = llm_client.generate_structured(
+            prompt=IsFixObviousPrompts.format_default_msg(
+                event_details=request.event_details,
+                task_str=request.task_str,
+                fix_instruction=request.fix_instruction,
+            ),
+            messages=request.memory,
+            model=OpenAiProvider.model("gpt-4o-mini"),
+            response_format=IsFixObviousOutput,
+        )
+        data = output.parsed
+
+        with self.context.state.update() as cur:
+            cur.usage += output.metadata.usage
+
+        if data is None:
+            return IsFixObviousOutput(is_fix_clear=False)
+        return data

--- a/src/seer/automation/autofix/components/is_root_cause_obvious.py
+++ b/src/seer/automation/autofix/components/is_root_cause_obvious.py
@@ -10,15 +10,15 @@ from seer.automation.models import EventDetails
 from seer.dependency_injection import inject, injected
 
 
-class IsObviousRequest(BaseComponentRequest):
+class IsRootCauseObviousRequest(BaseComponentRequest):
     event_details: EventDetails
 
 
-class IsObviousOutput(BaseComponentOutput):
+class IsRootCauseObviousOutput(BaseComponentOutput):
     is_root_cause_clear: bool
 
 
-class IsObviousPrompts:
+class IsRootCauseObviousPrompts:
     @staticmethod
     def format_default_msg(
         event_details: EventDetails,
@@ -33,21 +33,23 @@ class IsObviousPrompts:
         )
 
 
-class IsObviousComponent(BaseComponent[IsObviousRequest, IsObviousOutput]):
+class IsRootCauseObviousComponent(
+    BaseComponent[IsRootCauseObviousRequest, IsRootCauseObviousOutput]
+):
     context: AutofixContext
 
     @observe(name="Check if Obvious")
     @ai_track(description="Check if Obvious")
     @inject
     def invoke(
-        self, request: IsObviousRequest, llm_client: LlmClient = injected
-    ) -> IsObviousOutput | None:
+        self, request: IsRootCauseObviousRequest, llm_client: LlmClient = injected
+    ) -> IsRootCauseObviousOutput | None:
         output = llm_client.generate_structured(
-            prompt=IsObviousPrompts.format_default_msg(
+            prompt=IsRootCauseObviousPrompts.format_default_msg(
                 event_details=request.event_details,
             ),
             model=OpenAiProvider.model("gpt-4o-mini"),
-            response_format=IsObviousOutput,
+            response_format=IsRootCauseObviousOutput,
         )
         data = output.parsed
 
@@ -55,5 +57,5 @@ class IsObviousComponent(BaseComponent[IsObviousRequest, IsObviousOutput]):
             cur.usage += output.metadata.usage
 
         if data is None:
-            return IsObviousOutput(is_root_cause_clear=False)
+            return IsRootCauseObviousOutput(is_root_cause_clear=False)
         return data

--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -7,7 +7,10 @@ from seer.automation.agent.agent import AgentConfig, RunConfig
 from seer.automation.agent.client import LlmClient, OpenAiProvider
 from seer.automation.autofix.autofix_agent import AutofixAgent
 from seer.automation.autofix.autofix_context import AutofixContext
-from seer.automation.autofix.components.is_obvious import IsObviousComponent, IsObviousRequest
+from seer.automation.autofix.components.is_root_cause_obvious import (
+    IsRootCauseObviousComponent,
+    IsRootCauseObviousRequest,
+)
 from seer.automation.autofix.components.root_cause.models import (
     MultipleRootCauseAnalysisOutputPrompt,
     RootCauseAnalysisOutput,
@@ -31,8 +34,8 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
         self, request: RootCauseAnalysisRequest, llm_client: LlmClient = injected
     ) -> RootCauseAnalysisOutput:
         is_obvious = (
-            IsObviousComponent(self.context).invoke(
-                IsObviousRequest(event_details=request.event_details)
+            IsRootCauseObviousComponent(self.context).invoke(
+                IsRootCauseObviousRequest(event_details=request.event_details)
             )
             if not request.initial_memory
             else None

--- a/tests/automation/autofix/components/test_is_fix_obvious.py
+++ b/tests/automation/autofix/components/test_is_fix_obvious.py
@@ -7,29 +7,30 @@ from seer.automation.agent.models import (
     LlmGenerateStructuredResponse,
     LlmProviderType,
     LlmResponseMetadata,
+    Message,
     Usage,
 )
 from seer.automation.autofix.autofix_context import AutofixContext
-from seer.automation.autofix.components.is_obvious import (
-    IsObviousComponent,
-    IsObviousOutput,
-    IsObviousRequest,
+from seer.automation.autofix.components.is_fix_obvious import (
+    IsFixObviousComponent,
+    IsFixObviousOutput,
+    IsFixObviousRequest,
 )
 from seer.automation.models import EventDetails
 from seer.dependency_injection import Module
 
 
-class TestIsObviousComponent:
+class TestIsFixObviousComponent:
     @pytest.fixture
     def component(self):
         mock_context = MagicMock(spec=AutofixContext)
         mock_context.state = MagicMock()
-        return IsObviousComponent(mock_context)
+        return IsFixObviousComponent(mock_context)
 
     def test_invoke_returns_true(self, component):
         mock_llm_client = MagicMock(spec=LlmClient)
         mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
-            parsed=IsObviousOutput(is_root_cause_clear=True),
+            parsed=IsFixObviousOutput(is_fix_clear=True),
             metadata=LlmResponseMetadata(
                 model="test-model",
                 provider_name=LlmProviderType.OPENAI,
@@ -41,15 +42,31 @@ class TestIsObviousComponent:
         module.constant(LlmClient, mock_llm_client)
 
         with module:
-            result = component.invoke(IsObviousRequest(event_details=MagicMock(spec=EventDetails)))
+            result = component.invoke(
+                IsFixObviousRequest(
+                    event_details=MagicMock(spec=EventDetails),
+                    task_str="Fix the null pointer exception",
+                    fix_instruction="Add null checks",
+                    memory=[
+                        Message(role="assistant", content="File content"),
+                        Message(role="user", content="def example():\n    return None"),
+                    ],
+                )
+            )
 
         assert result is not None
-        assert result.is_root_cause_clear is True
+        assert result.is_fix_clear is True
+
+        # Verify the prompt was formatted with all required information
+        mock_llm_client.generate_structured.assert_called_once()
+        prompt_arg = mock_llm_client.generate_structured.call_args[1]["prompt"]
+        assert "Fix the null pointer exception" in prompt_arg
+        assert "Add null checks" in prompt_arg
 
     def test_invoke_returns_false(self, component):
         mock_llm_client = MagicMock(spec=LlmClient)
         mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
-            parsed=IsObviousOutput(is_root_cause_clear=False),
+            parsed=IsFixObviousOutput(is_fix_clear=False),
             metadata=LlmResponseMetadata(
                 model="test-model",
                 provider_name=LlmProviderType.OPENAI,
@@ -61,10 +78,17 @@ class TestIsObviousComponent:
         module.constant(LlmClient, mock_llm_client)
 
         with module:
-            result = component.invoke(IsObviousRequest(event_details=MagicMock(spec=EventDetails)))
+            result = component.invoke(
+                IsFixObviousRequest(
+                    event_details=MagicMock(spec=EventDetails),
+                    task_str="Complex task requiring investigation",
+                    fix_instruction=None,
+                    memory=[],
+                )
+            )
 
         assert result is not None
-        assert result.is_root_cause_clear is False
+        assert result.is_fix_clear is False
 
     def test_invoke_handles_none_response(self, component):
         mock_llm_client = MagicMock(spec=LlmClient)
@@ -81,23 +105,14 @@ class TestIsObviousComponent:
         module.constant(LlmClient, mock_llm_client)
 
         with module:
-            result = component.invoke(IsObviousRequest(event_details=MagicMock(spec=EventDetails)))
+            result = component.invoke(
+                IsFixObviousRequest(
+                    event_details=MagicMock(spec=EventDetails),
+                    task_str="Some task",
+                    fix_instruction=None,
+                    memory=[],
+                )
+            )
 
         assert result is not None
-        assert result.is_root_cause_clear is False
-
-    def test_invoke_formats_prompt_correctly(self, component):
-        mock_llm_client = MagicMock(spec=LlmClient)
-        mock_event_details = MagicMock(spec=EventDetails)
-        mock_event_details.__str__.return_value = "Test event details"
-
-        module = Module()
-        module.constant(LlmClient, mock_llm_client)
-
-        with module:
-            component.invoke(IsObviousRequest(event_details=mock_event_details))
-
-        # Verify the prompt was formatted with the event details
-        mock_llm_client.generate_structured.assert_called_once()
-        prompt_arg = mock_llm_client.generate_structured.call_args[1]["prompt"]
-        assert "Test event details" in prompt_arg
+        assert result.is_fix_clear is False

--- a/tests/automation/autofix/components/test_is_root_cause_obvious.py
+++ b/tests/automation/autofix/components/test_is_root_cause_obvious.py
@@ -1,0 +1,109 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from seer.automation.agent.client import LlmClient
+from seer.automation.agent.models import (
+    LlmGenerateStructuredResponse,
+    LlmProviderType,
+    LlmResponseMetadata,
+    Usage,
+)
+from seer.automation.autofix.autofix_context import AutofixContext
+from seer.automation.autofix.components.is_root_cause_obvious import (
+    IsRootCauseObviousComponent,
+    IsRootCauseObviousOutput,
+    IsRootCauseObviousRequest,
+)
+from seer.automation.models import EventDetails
+from seer.dependency_injection import Module
+
+
+class TestIsRootCauseObviousComponent:
+    @pytest.fixture
+    def component(self):
+        mock_context = MagicMock(spec=AutofixContext)
+        mock_context.state = MagicMock()
+        return IsRootCauseObviousComponent(mock_context)
+
+    def test_invoke_returns_true(self, component):
+        mock_llm_client = MagicMock(spec=LlmClient)
+        mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
+            parsed=IsRootCauseObviousOutput(is_root_cause_clear=True),
+            metadata=LlmResponseMetadata(
+                model="test-model",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+            ),
+        )
+
+        module = Module()
+        module.constant(LlmClient, mock_llm_client)
+
+        with module:
+            result = component.invoke(
+                IsRootCauseObviousRequest(event_details=MagicMock(spec=EventDetails))
+            )
+
+        assert result is not None
+        assert result.is_root_cause_clear is True
+
+    def test_invoke_returns_false(self, component):
+        mock_llm_client = MagicMock(spec=LlmClient)
+        mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
+            parsed=IsRootCauseObviousOutput(is_root_cause_clear=False),
+            metadata=LlmResponseMetadata(
+                model="test-model",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+            ),
+        )
+
+        module = Module()
+        module.constant(LlmClient, mock_llm_client)
+
+        with module:
+            result = component.invoke(
+                IsRootCauseObviousRequest(event_details=MagicMock(spec=EventDetails))
+            )
+
+        assert result is not None
+        assert result.is_root_cause_clear is False
+
+    def test_invoke_handles_none_response(self, component):
+        mock_llm_client = MagicMock(spec=LlmClient)
+        mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
+            parsed=None,
+            metadata=LlmResponseMetadata(
+                model="test-model",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+            ),
+        )
+
+        module = Module()
+        module.constant(LlmClient, mock_llm_client)
+
+        with module:
+            result = component.invoke(
+                IsRootCauseObviousRequest(event_details=MagicMock(spec=EventDetails))
+            )
+
+        assert result is not None
+        assert result.is_root_cause_clear is False
+
+    def test_invoke_formats_prompt_correctly(self, component):
+        mock_llm_client = MagicMock(spec=LlmClient)
+        mock_event_details = MagicMock(spec=EventDetails)
+        mock_event_details.__str__.return_value = "Test event details"
+
+        module = Module()
+        module.constant(LlmClient, mock_llm_client)
+
+        with module:
+            component.invoke(IsRootCauseObviousRequest(event_details=mock_event_details))
+
+        # Verify the prompt was formatted with the event details
+        mock_llm_client.generate_structured.assert_called_once()
+        prompt_arg = mock_llm_client.generate_structured.call_args[1]["prompt"]
+        assert "Test event details" in prompt_arg

--- a/tests/automation/autofix/components/test_root_cause.py
+++ b/tests/automation/autofix/components/test_root_cause.py
@@ -11,7 +11,7 @@ from seer.automation.agent.models import (
     Usage,
 )
 from seer.automation.autofix.autofix_context import AutofixContext
-from seer.automation.autofix.components.is_obvious import IsObviousOutput
+from seer.automation.autofix.components.is_root_cause_obvious import IsRootCauseObviousOutput
 from seer.automation.autofix.components.root_cause.component import RootCauseAnalysisComponent
 from seer.automation.autofix.components.root_cause.models import (
     MultipleRootCauseAnalysisOutputPrompt,
@@ -38,7 +38,7 @@ class TestRootCauseComponent:
     @pytest.fixture
     def mock_is_obvious_component(self):
         with patch(
-            "seer.automation.autofix.components.root_cause.component.IsObviousComponent"
+            "seer.automation.autofix.components.root_cause.component.IsRootCauseObviousComponent"
         ) as mock:
             yield mock
 
@@ -99,9 +99,8 @@ class TestRootCauseComponent:
     def test_root_cause_with_obvious_root_cause(
         self, component, mock_agent, mock_is_obvious_component
     ):
-        # Mock IsObviousComponent to return True
         mock_is_obvious = MagicMock()
-        mock_is_obvious.invoke.return_value = IsObviousOutput(is_root_cause_clear=True)
+        mock_is_obvious.invoke.return_value = IsRootCauseObviousOutput(is_root_cause_clear=True)
         mock_is_obvious_component.return_value = mock_is_obvious
 
         mock_agent.return_value.run.side_effect = [
@@ -139,9 +138,8 @@ class TestRootCauseComponent:
     def test_root_cause_with_non_obvious_root_cause(
         self, component, mock_agent, mock_is_obvious_component
     ):
-        # Mock IsObviousComponent to return False
         mock_is_obvious = MagicMock()
-        mock_is_obvious.invoke.return_value = IsObviousOutput(is_root_cause_clear=False)
+        mock_is_obvious.invoke.return_value = IsRootCauseObviousOutput(is_root_cause_clear=False)
         mock_is_obvious_component.return_value = mock_is_obvious
 
         mock_agent.return_value.run.side_effect = [
@@ -214,7 +212,6 @@ class TestRootCauseComponent:
                 )
             )
 
-        # Verify IsObviousComponent was not called
         mock_is_obvious.invoke.assert_not_called()
 
         # Verify agent was created with tools (default behavior when skipping is_obvious)


### PR DESCRIPTION
Pre-expands code files from the Root Cause Step's relevant code context. Then asks an LLM if we can make the fix without any further searching to decide if we give the agent tools or not.

- cost down to 30 cents per run
- shaves 30 seconds off run time
- maintains eval scores