### PR TITLE
chore(anomaly detection): fix flaky data cleanup test

### DIFF
--- a/tests/seer/anomaly_detection/test_cleanup_tasks.py
+++ b/tests/seer/anomaly_detection/test_cleanup_tasks.py
@@ -126,8 +126,13 @@ class TestCleanupTasks(unittest.TestCase):
             new_timeseries_points = alert.timeseries
             assert old_timeseries_points != new_timeseries_points
 
+            new_timeseries_points.sort(key=lambda x: x.timestamp)
+
+            sorted_old_timeseries_points = old_timeseries_points[1000:]
+            sorted_old_timeseries_points.sort(key=lambda x: x.timestamp)
+
             for old, new, algo_data in zip(
-                old_timeseries_points[1000:],
+                sorted_old_timeseries_points,
                 new_timeseries_points,
                 anomalies_new.get_anomaly_algo_data(len(points_new)),
             ):

--- a/tests/seer/anomaly_detection/test_cleanup_tasks.py
+++ b/tests/seer/anomaly_detection/test_cleanup_tasks.py
@@ -127,12 +127,10 @@ class TestCleanupTasks(unittest.TestCase):
             assert old_timeseries_points != new_timeseries_points
 
             new_timeseries_points.sort(key=lambda x: x.timestamp)
-
-            sorted_old_timeseries_points = old_timeseries_points[1000:]
-            sorted_old_timeseries_points.sort(key=lambda x: x.timestamp)
+            old_timeseries_points.sort(key=lambda x: x.timestamp)
 
             for old, new, algo_data in zip(
-                sorted_old_timeseries_points,
+                old_timeseries_points[1000:],
                 new_timeseries_points,
                 anomalies_new.get_anomaly_algo_data(len(points_new)),
             ):


### PR DESCRIPTION
- Fix flaky test by sorting the `old_timeseries_points` and `new_timeseries_points` to ensure consistency of order during comparison