### PR TITLE
chore(anomaly_detection): apply direction logic for alerts with both as direction

### DIFF
--- a/src/seer/anomaly_detection/detectors/location_detectors.py
+++ b/src/seer/anomaly_detection/detectors/location_detectors.py
@@ -1,6 +1,7 @@
 import abc
 import logging
 from enum import Enum
+from typing import Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -30,7 +31,7 @@ class LocationDetector(BaseModel, abc.ABC):
         streamed_timestamp: np.float64,
         history_values: npt.NDArray[np.float64],
         history_timestamps: npt.NDArray[np.float64],
-    ) -> PointLocation:
+    ) -> Optional[PointLocation]:
         return NotImplemented
 
 
@@ -53,7 +54,7 @@ class LinearRegressionLocationDetector(LocationDetector):
         streamed_timestamp: np.float64,
         history_values: npt.NDArray[np.float64],
         history_timestamps: npt.NDArray[np.float64],
-    ) -> PointLocation:
+    ) -> Optional[PointLocation]:
         """
         Detect relative location of the streamed value in the context of recent data points using linear regression.
 
@@ -70,7 +71,7 @@ class LinearRegressionLocationDetector(LocationDetector):
         recent_data = np.concatenate([history_values[-self.window_size :], [streamed_value]])
 
         if len(recent_data) < self.window_size + 1:
-            return PointLocation.NONE  # Not enough data to determine trend
+            return None  # Not enough data to determine trend
 
         x = np.arange(len(recent_data))
         y = recent_data
@@ -108,7 +109,7 @@ class ProphetLocationDetector(LocationDetector):
         streamed_timestamp: np.float64,
         history_values: npt.NDArray[np.float64],
         history_timestamps: npt.NDArray[np.float64],
-    ) -> PointLocation:
+    ) -> Optional[PointLocation]:
         """
         Detect relative location of the streamed value in the context of recent data points using Prophet.
 

--- a/tests/seer/anomaly_detection/detectors/test_location_detectors.py
+++ b/tests/seer/anomaly_detection/detectors/test_location_detectors.py
@@ -48,9 +48,7 @@ class TestLinearRegressionLocationDetector(unittest.TestCase):
         timestamps = np.array([1.0, 2.0])
         cur_val = 3.0
         cur_timestamp = 3.0
-        self.assertEqual(
-            self.detector.detect(cur_val, cur_timestamp, values, timestamps), PointLocation.NONE
-        )
+        self.assertEqual(self.detector.detect(cur_val, cur_timestamp, values, timestamps), None)
 
     def test_custom_window_size(self):
         detector = LinearRegressionLocationDetector(window_size=3, threshold=0.5)

--- a/tests/seer/anomaly_detection/test_anomaly_detection.py
+++ b/tests/seer/anomaly_detection/test_anomaly_detection.py
@@ -95,7 +95,7 @@ class TestAnomalyDetection(unittest.TestCase):
             "tests/seer/anomaly_detection/test_data/synthetic_series", as_ts_datatype=False
         )
         ts_values = loaded_synthetic_data.timeseries[0]
-        ts_timestamps = np.arange(1, len(ts_values), 1) + datetime.now().timestamp()
+        ts_timestamps = np.arange(1, len(ts_values) + 1) + datetime.now().timestamp()
         window_size = loaded_synthetic_data.window_sizes[0]
 
         dummy_mp = np.ones((len(ts_values) - window_size + 1, 4))

--- a/tests/seer/anomaly_detection/test_cleanup_tasks.py
+++ b/tests/seer/anomaly_detection/test_cleanup_tasks.py
@@ -6,6 +6,7 @@ import numpy as np
 
 from seer.anomaly_detection.accessors import DbAlertDataAccessor
 from seer.anomaly_detection.detectors.anomaly_detectors import MPBatchAnomalyDetector
+from seer.anomaly_detection.models import MPTimeSeriesAnomalies
 from seer.anomaly_detection.models.external import AnomalyDetectionConfig, TimeSeriesPoint
 from seer.anomaly_detection.models.timeseries import TimeSeries
 from seer.anomaly_detection.tasks import cleanup_timeseries
@@ -38,7 +39,16 @@ class TestCleanupTasks(unittest.TestCase):
             timestamps=np.array([point.timestamp for point in points]),
             values=np.array([point.value for point in points]),
         )
-        anomalies = MPBatchAnomalyDetector().detect(ts, config)
+        if len(ts.values) == 0:
+            anomalies = MPTimeSeriesAnomalies(
+                flags=np.array([]),
+                scores=np.array([]),
+                matrix_profile=np.array([]),
+                window_size=0,
+                thresholds=np.array([]),
+            )
+        else:
+            anomalies = MPBatchAnomalyDetector().detect(ts, config)
 
         alert_data_accessor = DbAlertDataAccessor()
         alert_data_accessor.save_alert(


### PR DESCRIPTION
This change ensures that the direction logic is applied for anomalous points even when the alert is configured for both directions. This change helps reduce noise from anomalies that do not breach any threshold.

Note: Apart the core logic of enabling direction logic, this PR also includes multiple fixes for the time stamps not being handled correctly that surfaced due to this change.