### PR TITLE
fix(autofix): Fix formatting for short circuit prompts

### DIFF
--- a/src/seer/automation/autofix/components/is_fix_obvious.py
+++ b/src/seer/automation/autofix/components/is_fix_obvious.py
@@ -29,8 +29,9 @@ class IsFixObviousPrompts:
         task_str: str,
         fix_instruction: str | None,
     ):
-        return textwrap.dedent(
-            """\
+        return (
+            textwrap.dedent(
+                """\
             You are an exceptional principal engineer that is amazing at fixing any issue. We have an issue in our codebase and its root cause is described below, and you've already looked at some code files. Are the code changes needed to fix the issue clear from the details below? Or does it require searching for more information around the codebase?
 
             {event_details}
@@ -39,10 +40,13 @@ class IsFixObviousPrompts:
             {task_str}
 
             {fix_instruction}"""
-        ).format(
-            event_details=event_details,
-            task_str=task_str,
-            fix_instruction=fix_instruction if fix_instruction else "",
+            )
+            .format(
+                event_details=event_details.format_event(),
+                task_str=task_str,
+                fix_instruction=fix_instruction if fix_instruction else "",
+            )
+            .strip()
         )
 
 

--- a/src/seer/automation/autofix/components/is_root_cause_obvious.py
+++ b/src/seer/automation/autofix/components/is_root_cause_obvious.py
@@ -23,13 +23,17 @@ class IsRootCauseObviousPrompts:
     def format_default_msg(
         event_details: EventDetails,
     ):
-        return textwrap.dedent(
-            """\
+        return (
+            textwrap.dedent(
+                """\
             You are an exceptional principal engineer that is amazing at finding the root cause of any issue. We have an issue in our codebase described below. Is the root cause of the issue clear from the details below? Or does it require searching for more information around the codebase?
 
             {event_details}"""
-        ).format(
-            event_details=event_details,
+            )
+            .format(
+                event_details=event_details.format_event(),
+            )
+            .strip()
         )
 
 

--- a/tests/automation/autofix/components/test_is_root_cause_obvious.py
+++ b/tests/automation/autofix/components/test_is_root_cause_obvious.py
@@ -95,7 +95,7 @@ class TestIsRootCauseObviousComponent:
     def test_invoke_formats_prompt_correctly(self, component):
         mock_llm_client = MagicMock(spec=LlmClient)
         mock_event_details = MagicMock(spec=EventDetails)
-        mock_event_details.__str__.return_value = "Test event details"
+        mock_event_details.format_event.return_value = "Test event details"
 
         module = Module()
         module.constant(LlmClient, mock_llm_client)


### PR DESCRIPTION
We were just dumping the raw `event_details` object in there, when we should've been calling `format_event()`.