### PR TITLE
fix(autofix): Fix rethink bug in plan+code due to pre-expanded files

### DIFF
--- a/src/seer/automation/autofix/components/insight_sharing/component.py
+++ b/src/seer/automation/autofix/components/insight_sharing/component.py
@@ -30,6 +30,7 @@ class InsightSharingPrompts:
 
             Write the next under-20-word conclusion in the chain of thought based on the notes below, or if there is no good conclusion to add, return <NO_INSIGHT/>. The criteria for a good conclusion are that it should be a large, novel jump in insights, not similar to any item in the existing chain of thought, it should be a complete conclusion after some meaty analysis, not a plan of what to analyze next, and it should be valuable for {task_description}. It should also be very concrete, to-the-point, and specific. Every item in the chain of thought should read like a chain that clearly builds off of the previous step. If you can't find a conclusion that meets ALL of these criteria, return <NO_INSIGHT/>.
 
+            NOTES TO ANALYZE:
             {latest_thought}"""
         ).format(
             task_description=task_description,

--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -169,6 +169,7 @@ class BaseStep(BaseModel):
 class DefaultStep(BaseStep):
     type: Literal[StepType.DEFAULT] = StepType.DEFAULT
     insights: list[InsightSharingOutput] = []
+    initial_memory_length: int = 1
 
 
 class RootCauseStep(BaseStep):

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -338,7 +338,7 @@ def truncate_memory_to_match_insights(memory: list[Message], step: DefaultStep):
             truncated_memory = new_memory
             break
     if not step.insights:
-        truncated_memory = memory[:1]
+        truncated_memory = memory[: step.initial_memory_length]
     return truncated_memory if truncated_memory else memory
 
 

--- a/tests/automation/autofix/test_autofix_tasks.py
+++ b/tests/automation/autofix/test_autofix_tasks.py
@@ -410,6 +410,7 @@ class TestHandleUserMessages:
         mock_step = MagicMock(spec=DefaultStep)
         mock_step.key = "root_cause_analysis_processing"
         mock_step.insights = []
+        mock_step.initial_memory_length = 1
         mock_state.get.return_value.steps = [mock_step]
         mock_state.get.return_value.run_id = 123
         mock_state.update.return_value.__enter__.return_value.steps = [mock_step]
@@ -437,6 +438,7 @@ class TestHandleUserMessages:
             MagicMock(spec=InsightSharingOutput, generated_at_memory_index=4),
             MagicMock(spec=InsightSharingOutput, generated_at_memory_index=-1),
         ]
+        mock_step.initial_memory_length = 1
 
         # Create a mock memory list
         memory = [


### PR DESCRIPTION
The memory truncation logic upon a rethink always kept only 1 memory item if you did it from before the first insight card. This broke certain cases in the plan+code step since it can have multiple initial messages. #1371 

This PR fixes that by tracking how many items make up the "initial prompt". 

(also tacking on a small prompt tweak for insight sharing that seems to help with #1372 