### PR TITLE
fix(anomaly detection): Fix Stream Smoothing

### DIFF
--- a/src/seer/anomaly_detection/accessors.py
+++ b/src/seer/anomaly_detection/accessors.py
@@ -83,6 +83,7 @@ class DbAlertDataAccessor(AlertDataAccessor):
         mp = []
         ts = []
         values = []
+        original_flags = []
         for point in db_alert.timeseries:
             ts.append(point.timestamp.timestamp)
             values.append(point.value)
@@ -93,6 +94,7 @@ class DbAlertDataAccessor(AlertDataAccessor):
                     point.anomaly_algo_data
                 )
                 mp.append([dist, idx, l_idx, r_idx])
+                original_flags.append(original_flag)
             if point.timestamp.timestamp() < timestamp_threshold:
                 num_old_points += 1
 
@@ -107,6 +109,7 @@ class DbAlertDataAccessor(AlertDataAccessor):
             ),
             window_size=window_size,
             thresholds=[],  # Note: thresholds are not stored in the database. They are computed on the fly.
+            original_flags=original_flags,
         )
         return DynamicAlert(
             organization_id=db_alert.organization_id,

--- a/src/seer/anomaly_detection/accessors.py
+++ b/src/seer/anomaly_detection/accessors.py
@@ -89,7 +89,7 @@ class DbAlertDataAccessor(AlertDataAccessor):
             flags.append(point.anomaly_type)
             scores.append(point.anomaly_score)
             if point.anomaly_algo_data is not None:
-                dist, idx, l_idx, r_idx = MPTimeSeriesAnomalies.extract_algo_data(
+                dist, idx, l_idx, r_idx, original_flag = MPTimeSeriesAnomalies.extract_algo_data(
                     point.anomaly_algo_data
                 )
                 mp.append([dist, idx, l_idx, r_idx])

--- a/src/seer/anomaly_detection/anomaly_detection.py
+++ b/src/seer/anomaly_detection/anomaly_detection.py
@@ -147,9 +147,7 @@ class AnomalyDetection(BaseModel):
             history_mp=anomalies.matrix_profile,
             window_size=anomalies.window_size,
             history_flags=anomalies.flags,
-            anomaly_algo_data=anomalies.get_anomaly_algo_data(len(historic.timeseries.timestamps))[
-                -5:  # TODO: This slice should be based on the time period
-            ],
+            anomaly_algo_data=anomalies.get_anomaly_algo_data(len(historic.timeseries.timestamps)),
         )
         streamed_anomalies = stream_detector.detect(
             convert_external_ts_to_internal(ts_external), config
@@ -157,7 +155,8 @@ class AnomalyDetection(BaseModel):
 
         # Get current point's anomaly data and track original flag
         curr_algo_data = streamed_anomalies.get_anomaly_algo_data(len(ts_external))[0]
-        curr_algo_data["original_flag"] = streamed_anomalies.original_flags[-1]
+        if streamed_anomalies.original_flags and curr_algo_data is not None:
+            curr_algo_data["original_flag"] = streamed_anomalies.original_flags[-1]
 
         # Save new data point
         alert_data_accessor.save_timepoint(
@@ -240,6 +239,8 @@ class AnomalyDetection(BaseModel):
             history_values=historic.values,
             history_mp=anomalies.matrix_profile,
             window_size=anomalies.window_size,
+            history_flags=anomalies.flags,
+            anomaly_algo_data=anomalies.get_anomaly_algo_data(len(historic.timestamps)),
         )
         streamed_anomalies = stream_detector.detect(
             convert_external_ts_to_internal(ts_external), config

--- a/src/seer/anomaly_detection/anomaly_detection.py
+++ b/src/seer/anomaly_detection/anomaly_detection.py
@@ -140,9 +140,6 @@ class AnomalyDetection(BaseModel):
 
         # TODO: Need to check the time gap between historic data and the new datapoint against the alert configuration
 
-        print("lens")
-        print(len(historic.timeseries.timestamps))
-        print(len(anomalies.original_flags))
         # Get the original flags from the historic data
         original_flags = anomalies.original_flags
         if original_flags is not None and len(original_flags) != len(

--- a/src/seer/anomaly_detection/anomaly_detection.py
+++ b/src/seer/anomaly_detection/anomaly_detection.py
@@ -146,6 +146,7 @@ class AnomalyDetection(BaseModel):
             history_values=historic.timeseries.values,
             history_mp=anomalies.matrix_profile,
             window_size=anomalies.window_size,
+            history_flags=anomalies.flags,
         )
         streamed_anomalies = stream_detector.detect(
             convert_external_ts_to_internal(ts_external), config
@@ -182,7 +183,7 @@ class AnomalyDetection(BaseModel):
         else:
             # Standard case - just track original flag
             curr_algo_data["original_flag"] = streamed_anomalies.flags[-1]
-            # TODO: Should use MajorityVoteFlagSmoother here for standard smoothing
+            # The MajorityVoteFlagSmoother should be applied within stream detector
 
         # Save new data point
         alert_data_accessor.save_timepoint(

--- a/src/seer/anomaly_detection/anomaly_detection.py
+++ b/src/seer/anomaly_detection/anomaly_detection.py
@@ -241,8 +241,6 @@ class AnomalyDetection(BaseModel):
         batch_detector = MPBatchAnomalyDetector()
         anomalies = batch_detector.detect(historic, config)
 
-        print("anomalies original flags")
-        print(anomalies.original_flags)
         # Run stream detection on current data
         stream_detector = MPStreamAnomalyDetector(
             history_timestamps=historic.timestamps,

--- a/src/seer/anomaly_detection/anomaly_detection.py
+++ b/src/seer/anomaly_detection/anomaly_detection.py
@@ -151,6 +151,39 @@ class AnomalyDetection(BaseModel):
             convert_external_ts_to_internal(ts_external), config
         )
 
+        # Check previous point's anomaly algo data for base case tracking
+        prev_algo_data = None
+        if len(historic.timeseries.timestamps) > 0:
+
+            prev_algo_data = historic.anomalies.get_anomaly_algo_data(
+                len(historic.timeseries.timestamps)
+            )[-1]
+
+        # Get current point's anomaly data
+        curr_algo_data = streamed_anomalies.get_anomaly_algo_data(len(ts_external))[0]
+
+        # Base case: Start tracking if current point is anomalous and previous point doesn't have base case
+        if streamed_anomalies.flags[-1] == "anomaly_higher_confidence" and (
+            prev_algo_data is None or "base_case_remaining" not in prev_algo_data
+        ):
+            curr_algo_data["base_case_remaining"] = (
+                3  # TODO: Make this based on the time_period in anomaly config
+            )
+            curr_algo_data["original_flag"] = "anomaly_higher_confidence"
+            streamed_anomalies.flags[-1] = "anomaly_higher_confidence"  # TODO: Confirm if needed
+
+        # Check if previous point was tracking base case
+        elif prev_algo_data is not None and "base_case_remaining" in prev_algo_data:
+            if prev_algo_data["base_case_remaining"] > 0:
+                # Force anomaly and decrement counter
+                streamed_anomalies.flags[-1] = "anomaly_higher_confidence"
+                curr_algo_data["base_case_remaining"] -= 1
+                curr_algo_data["original_flag"] = "anomaly_higher_confidence"
+        else:
+            # Standard case - just track original flag
+            curr_algo_data["original_flag"] = streamed_anomalies.flags[-1]
+            # TODO: Should use MajorityVoteFlagSmoother here for standard smoothing
+
         # Save new data point
         alert_data_accessor.save_timepoint(
             external_alert_id=alert.id,

--- a/src/seer/anomaly_detection/anomaly_detection_di.py
+++ b/src/seer/anomaly_detection/anomaly_detection_di.py
@@ -54,8 +54,3 @@ def mp_utils_provider() -> MPUtils:
 @anomaly_detection_module.provider
 def location_detector_provider() -> LocationDetector:
     return ProphetLocationDetector()
-
-
-# @anomaly_detection_module.provider
-# def flag_smoother_provider() -> FlagSmoother:
-#     return MajorityVoteFlagSmoother()

--- a/src/seer/anomaly_detection/anomaly_detection_di.py
+++ b/src/seer/anomaly_detection/anomaly_detection_di.py
@@ -1,7 +1,5 @@
 from seer.anomaly_detection.accessors import AlertDataAccessor, DbAlertDataAccessor
 from seer.anomaly_detection.detectors import (
-    FlagSmoother,
-    MajorityVoteFlagSmoother,
     MinMaxNormalizer,
     MPCascadingScorer,
     MPConfig,
@@ -58,6 +56,6 @@ def location_detector_provider() -> LocationDetector:
     return ProphetLocationDetector()
 
 
-@anomaly_detection_module.provider
-def flag_smoother_provider() -> FlagSmoother:
-    return MajorityVoteFlagSmoother()
+# @anomaly_detection_module.provider
+# def flag_smoother_provider() -> FlagSmoother:
+#     return MajorityVoteFlagSmoother()

--- a/src/seer/anomaly_detection/detectors/__init__.py
+++ b/src/seer/anomaly_detection/detectors/__init__.py
@@ -24,4 +24,5 @@ MinMaxNormalizer = normalizers.MinMaxNormalizer
 
 MPUtils = mp_utils.MPUtils
 FlagSmoother = smoothers.FlagSmoother
-MajorityVoteFlagSmoother = smoothers.MajorityVoteFlagSmoother
+MajorityVoteBatchFlagSmoother = smoothers.MajorityVoteBatchFlagSmoother
+MajorityVoteStreamFlagSmoother = smoothers.MajorityVoteStreamFlagSmoother

--- a/src/seer/anomaly_detection/detectors/anomaly_detectors.py
+++ b/src/seer/anomaly_detection/detectors/anomaly_detectors.py
@@ -72,7 +72,6 @@ class MPBatchAnomalyDetector(AnomalyDetector):
         mp_config: MPConfig = injected,
         scorer: MPScorer = injected,
         mp_utils: MPUtils = injected,
-        # flag_smoother: FlagSmoother = injected,
     ) -> MPTimeSeriesAnomalies:
         """
         This method calls stumpy.stump to compute the matrix profile and scores the matrix profile distances
@@ -225,18 +224,6 @@ class MPStreamAnomalyDetector(AnomalyDetector):
                 if flags_and_scores is None:
                     raise ServerError("Failed to score the matrix profile distance")
 
-                # Use the history size to determine how many points to use for stream smoothing
-                # anomaly_algo_data_to_use = self.anomaly_algo_data[
-                #     -self.stream_smooth_context_sizes[config.time_period] :
-                # ]
-
-                # The original flags are the flags of the previous points
-                # past_original_flags = [
-                #     algo_data["original_flag"] if algo_data is not None else "none"
-                #     for algo_data in anomaly_algo_data_to_use
-                # ]
-
-                # self.anomaly_algo_data.append({"original_flag": flags_and_scores.flags[-1]})
                 self.original_flags.append(flags_and_scores.flags[-1])
 
                 stream_flag_smoother = MajorityVoteStreamFlagSmoother()

--- a/src/seer/anomaly_detection/detectors/anomaly_detectors.py
+++ b/src/seer/anomaly_detection/detectors/anomaly_detectors.py
@@ -153,7 +153,6 @@ class MPStreamAnomalyDetector(AnomalyDetector):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
     )
-
     stream_history_size: dict[int, int] = Field(
         default={5: 19, 15: 11, 30: 7, 60: 5},
         description="History size for stream smoothing based on the function smooth_size = floor(43 / sqrt(time_period))",

--- a/src/seer/anomaly_detection/detectors/anomaly_detectors.py
+++ b/src/seer/anomaly_detection/detectors/anomaly_detectors.py
@@ -147,9 +147,6 @@ class MPStreamAnomalyDetector(AnomalyDetector):
         ..., description="Matrix profile of the baseline timeseries."
     )
     window_size: int = Field(..., description="Window size to use for stream computation")
-    # history_flags: list[AnomalyFlags | None] = Field(
-    #     ..., description="Flags of the baseline timeseries."
-    # )
     original_flags: list[AnomalyFlags | None] = Field(
         ..., description="Original flags of the baseline timeseries."
     )
@@ -165,7 +162,6 @@ class MPStreamAnomalyDetector(AnomalyDetector):
         config: AnomalyDetectionConfig,
         scorer: MPScorer = injected,
         mp_utils: MPUtils = injected,
-        # flag_smoother: FlagSmoother = injected,
     ) -> MPTimeSeriesAnomalies:
         """
         This method uses stumpy.stumpi to stream compute the matrix profile and scores the matrix profile distances
@@ -203,7 +199,6 @@ class MPStreamAnomalyDetector(AnomalyDetector):
             streamed_mp: list[list[float]] = []
             thresholds: list[float] = []
             for cur_val, cur_timestamp in zip(timeseries.values, timeseries.timestamps):
-
                 # Update the stumpi stream processor with new data
                 stream.update(cur_val)
 
@@ -232,7 +227,7 @@ class MPStreamAnomalyDetector(AnomalyDetector):
                 smoothed_flags = stream_flag_smoother.smooth(
                     original_flags=self.original_flags,
                     ad_config=config,
-                    vote_threshold=0.4,
+                    vote_threshold=0.3,
                     cur_flag=flags_and_scores.flags,
                 )
 

--- a/src/seer/anomaly_detection/detectors/anomaly_detectors.py
+++ b/src/seer/anomaly_detection/detectors/anomaly_detectors.py
@@ -215,13 +215,6 @@ class MPStreamAnomalyDetector(AnomalyDetector):
                 if flags_and_scores is None:
                     raise ServerError("Failed to score the matrix profile distance")
 
-                # Apply smoothing to the flags
-                smoothed_flags = flag_smoother.smooth(
-                    flags=flags_and_scores.flags,
-                    ad_config=config,
-                )
-                flags_and_scores.flags = smoothed_flags
-
                 scores.extend(flags_and_scores.scores)
                 flags.extend(flags_and_scores.flags)
                 thresholds.extend(flags_and_scores.thresholds)

--- a/src/seer/anomaly_detection/detectors/smoothers.py
+++ b/src/seer/anomaly_detection/detectors/smoothers.py
@@ -40,9 +40,9 @@ class MajorityVoteFlagSmoother(FlagSmoother):
         """
         slices = []
 
-        num_gap = (
-            self.period_to_smooth_size[time_period] // 2
-        )  # Number of non-consistent flags allowed between points based on the smoothing size
+        num_gap = self.period_to_smooth_size[
+            time_period
+        ]  # Number of non-consistent flags allowed between points based on the smoothing size
 
         # Sliding window O(n)
         i = 0

--- a/src/seer/anomaly_detection/detectors/smoothers.py
+++ b/src/seer/anomaly_detection/detectors/smoothers.py
@@ -139,10 +139,7 @@ class MajorityVoteFlagSmoother(FlagSmoother):
             smoothed_flag = self._stream_smooth_flags(flags, vote_threshold, cur_flag)
             return smoothed_flag
 
-        print("Smoothing flags with batch method")
         slices = self._get_anomalous_slices(flags, ad_config.time_period)
-        print(f"Found {len(slices)} slices")
-        print(f"Slices: {slices}")
         for start_idx, end_idx in slices:
             flags[start_idx:end_idx] = self._batch_smooth_flags(
                 flags, start_idx, end_idx, ad_config, smooth_size, vote_threshold

--- a/src/seer/anomaly_detection/detectors/smoothers.py
+++ b/src/seer/anomaly_detection/detectors/smoothers.py
@@ -124,7 +124,7 @@ class MajorityVoteStreamFlagSmoother(FlagSmoother):
     """
 
     stream_smooth_context_sizes: dict[int, int] = Field(
-        default={5: 19, 15: 11, 30: 7, 60: 5},
+        default={5: 17, 15: 11, 30: 7, 60: 5},
         description="History size for stream smoothing based on the function smooth_size = floor(43 / sqrt(time_period))",
     )
 
@@ -158,7 +158,7 @@ class MajorityVoteStreamFlagSmoother(FlagSmoother):
         original_flags: list,
         ad_config: AnomalyDetectionConfig,
         smooth_size: int = 0,
-        vote_threshold: float = 0.5,
+        vote_threshold: float = 0.25,
         cur_flag: list = [],
     ) -> list:
         """

--- a/src/seer/anomaly_detection/detectors/smoothers.py
+++ b/src/seer/anomaly_detection/detectors/smoothers.py
@@ -42,9 +42,9 @@ class MajorityVoteFlagSmoother(FlagSmoother):
         """
         slices = []
 
-        num_gap = self.period_to_smooth_size[
-            time_period
-        ]  # Number of non-consistent flags allowed between points based on the smoothing size
+        num_gap = (
+            self.period_to_smooth_size[time_period] // 2
+        )  # Number of non-consistent flags allowed between points based on the smoothing size
 
         # Sliding window O(n)
         i = 0
@@ -139,7 +139,10 @@ class MajorityVoteFlagSmoother(FlagSmoother):
             smoothed_flag = self._stream_smooth_flags(flags, vote_threshold, cur_flag)
             return smoothed_flag
 
+        print("Smoothing flags with batch method")
         slices = self._get_anomalous_slices(flags, ad_config.time_period)
+        print(f"Found {len(slices)} slices")
+        print(f"Slices: {slices}")
         for start_idx, end_idx in slices:
             flags[start_idx:end_idx] = self._batch_smooth_flags(
                 flags, start_idx, end_idx, ad_config, smooth_size, vote_threshold

--- a/src/seer/anomaly_detection/detectors/window_size_selectors.py
+++ b/src/seer/anomaly_detection/detectors/window_size_selectors.py
@@ -149,5 +149,4 @@ class SuSSWindowSizeSelector(WindowSizeSelector):
             sentry_sdk.set_tag(AnomalyDetectionTags.WINDOW_SEARCH_FAILED, 1)
             return 3
         sentry_sdk.set_tag(AnomalyDetectionTags.WINDOW_SEARCH_FAILED, 0)
-        # return window_size
-        return 10
+        return window_size

--- a/src/seer/anomaly_detection/detectors/window_size_selectors.py
+++ b/src/seer/anomaly_detection/detectors/window_size_selectors.py
@@ -149,4 +149,5 @@ class SuSSWindowSizeSelector(WindowSizeSelector):
             sentry_sdk.set_tag(AnomalyDetectionTags.WINDOW_SEARCH_FAILED, 1)
             return 3
         sentry_sdk.set_tag(AnomalyDetectionTags.WINDOW_SEARCH_FAILED, 0)
-        return window_size
+        # return window_size
+        return 10

--- a/src/seer/anomaly_detection/models/timeseries.py
+++ b/src/seer/anomaly_detection/models/timeseries.py
@@ -32,14 +32,6 @@ class TimeSeries(BaseModel):
     def get_anomaly_algo_data(self) -> Optional[dict]:
         return None
 
-    # @root_validator(pre=False)
-    # def validate_lengths_should_match(cls, field_values):
-    #     # Do the validation instead of printing
-    #     if len(field_values.get("timestamps")) != len(field_values.get("values")):
-    #         raise ValidationError("TIme stamps and the values need to be of the same length.")
-
-    #     return field_values  # this is the value written to the class field
-
 
 class MPTimeSeries(TimeSeries):
     timestamps: npt.NDArray[np.float64] = Field(

--- a/src/seer/anomaly_detection/models/timeseries_anomalies.py
+++ b/src/seer/anomaly_detection/models/timeseries_anomalies.py
@@ -47,15 +47,34 @@ class MPTimeSeriesAnomalies(TimeSeriesAnomalies):
 
     window_size: int = Field(..., description="Window size used to build the matrix profile")
 
+    original_flags: Optional[list[str]] = Field(
+        None, description="The original flags of the time series"
+    )
+
     def get_anomaly_algo_data(self, front_pad_to_len: int) -> List[Optional[Dict]]:
         algo_data: List[Optional[Dict]] = []
         if len(self.matrix_profile) < front_pad_to_len:
             algo_data = [None] * (front_pad_to_len - len(self.matrix_profile))
 
-        for dist, index, l_index, r_index in self.matrix_profile:
-            algo_data.append({"dist": dist, "idx": index, "l_idx": l_index, "r_idx": r_index})
+        for (dist, index, l_index, r_index), flag in zip(self.matrix_profile, self.flags):
+            algo_data.append(
+                {
+                    "dist": dist,
+                    "idx": index,
+                    "l_idx": l_index,
+                    "r_idx": r_index,
+                    "original_flag": flag,
+                }
+            )
+
         return algo_data
 
     @staticmethod
     def extract_algo_data(map: dict):
-        return map.get("dist"), map.get("idx"), map.get("l_idx"), map.get("r_idx")
+        return (
+            map.get("dist"),
+            map.get("idx"),
+            map.get("l_idx"),
+            map.get("r_idx"),
+            map.get("original_flag"),
+        )

--- a/src/seer/anomaly_detection/models/timeseries_anomalies.py
+++ b/src/seer/anomaly_detection/models/timeseries_anomalies.py
@@ -56,7 +56,8 @@ class MPTimeSeriesAnomalies(TimeSeriesAnomalies):
         if len(self.matrix_profile) < front_pad_to_len:
             algo_data = [None] * (front_pad_to_len - len(self.matrix_profile))
 
-        for (dist, index, l_index, r_index), flag in zip(self.matrix_profile, self.flags):
+        for i, (dist, index, l_index, r_index) in enumerate(self.matrix_profile):
+            flag = self.original_flags[i] if self.original_flags else "none"
             algo_data.append(
                 {
                     "dist": dist,

--- a/src/seer/anomaly_detection/models/timeseries_anomalies.py
+++ b/src/seer/anomaly_detection/models/timeseries_anomalies.py
@@ -47,8 +47,8 @@ class MPTimeSeriesAnomalies(TimeSeriesAnomalies):
 
     window_size: int = Field(..., description="Window size used to build the matrix profile")
 
-    original_flags: Optional[list[str]] = Field(
-        None, description="The original flags of the time series"
+    original_flags: list[str | None] = Field(
+        default=[], description="The original flags of the time series"
     )
 
     def get_anomaly_algo_data(self, front_pad_to_len: int) -> List[Optional[Dict]]:
@@ -57,14 +57,14 @@ class MPTimeSeriesAnomalies(TimeSeriesAnomalies):
             algo_data = [None] * (front_pad_to_len - len(self.matrix_profile))
 
         for i, (dist, index, l_index, r_index) in enumerate(self.matrix_profile):
-            flag = self.original_flags[i] if self.original_flags else "none"
+            original_flag = self.original_flags[i] if i < len(self.original_flags) else "none"
             algo_data.append(
                 {
                     "dist": dist,
                     "idx": index,
                     "l_idx": l_index,
                     "r_idx": r_index,
-                    "original_flag": flag,
+                    "original_flag": original_flag,
                 }
             )
 

--- a/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
+++ b/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
@@ -310,6 +310,8 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
                 history_values=np.array(history_ts),
                 history_mp=np.array([0.1, 0.2, 0.3, 0.4]),
                 window_size=3,
+                history_flags=[None, None, None],
+                anomaly_algo_data=[None, None, None],
             )
             stream_detector.detect(
                 timeseries=TimeSeries(

--- a/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
+++ b/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
@@ -140,8 +140,6 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
             history_mp=np.array([[0.3, 0.3, 0.3, 0.3], [0.4, 0.5, 0.6, 0.7]]),
             window_size=3,
             original_flags=["none", "none", "none"],
-            # history_flags=[None, None, None],
-            # anomaly_algo_data=[None, None, None],
         )
         self.timeseries = TimeSeries(
             timestamps=np.array([1, 2, 3]), values=np.array([1.1, 2.1, 3.1])

--- a/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
+++ b/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
@@ -139,8 +139,9 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
             history_values=np.array([1.0, 2.0, 3.0, 4.0]),
             history_mp=np.array([[0.3, 0.3, 0.3, 0.3], [0.4, 0.5, 0.6, 0.7]]),
             window_size=3,
-            history_flags=[None, None, None],
-            anomaly_algo_data=[None, None, None],
+            original_flags=["none", "none", "none"],
+            # history_flags=[None, None, None],
+            # anomaly_algo_data=[None, None, None],
         )
         self.timeseries = TimeSeries(
             timestamps=np.array([1, 2, 3]), values=np.array([1.1, 2.1, 3.1])
@@ -211,8 +212,7 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
             history_values=np.array(history_ts),
             history_mp=history_mp,
             window_size=window_size,
-            history_flags=[None, None, None],
-            anomaly_algo_data=[None, None, None],
+            original_flags=["none", "none", "none"],
         )
         stream_ts_timestamps = np.array(list(range(1, len(stream_ts) + 1))) + len(history_ts)
         stream_anomalies = stream_detector.detect(
@@ -302,6 +302,7 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
         history_ts = [0.5] * 200
         history_ts_timestamps = np.arange(1, len(history_ts))  # one off error
         stream_ts = [0.5] * 10
+        original_flags = ["none"] * 200
         with self.assertRaises(
             ServerError, msg="History values and timestamps are not of the same length"
         ):
@@ -310,8 +311,7 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
                 history_values=np.array(history_ts),
                 history_mp=np.array([0.1, 0.2, 0.3, 0.4]),
                 window_size=3,
-                history_flags=[None, None, None],
-                anomaly_algo_data=[None, None, None],
+                original_flags=original_flags,
             )
             stream_detector.detect(
                 timeseries=TimeSeries(

--- a/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
+++ b/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
@@ -139,6 +139,8 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
             history_values=np.array([1.0, 2.0, 3.0, 4.0]),
             history_mp=np.array([[0.3, 0.3, 0.3, 0.3], [0.4, 0.5, 0.6, 0.7]]),
             window_size=3,
+            history_flags=[None, None, None],
+            anomaly_algo_data=[None, None, None],
         )
         self.timeseries = TimeSeries(
             timestamps=np.array([1, 2, 3]), values=np.array([1.1, 2.1, 3.1])
@@ -209,6 +211,8 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
             history_values=np.array(history_ts),
             history_mp=history_mp,
             window_size=window_size,
+            history_flags=[None, None, None],
+            anomaly_algo_data=[None, None, None],
         )
         stream_ts_timestamps = np.array(list(range(1, len(stream_ts) + 1))) + len(history_ts)
         stream_anomalies = stream_detector.detect(

--- a/tests/seer/anomaly_detection/detectors/test_smoothers.py
+++ b/tests/seer/anomaly_detection/detectors/test_smoothers.py
@@ -35,7 +35,7 @@ def test_smooth_single_anomaly(flag_smoother, ad_config):
         "none",
         "none",
     ]
-    result = flag_smoother.smooth(flags, ad_config)
+    result = flag_smoother.smooth(flags, ad_config, stream_smoothing=False)
     assert result == [
         "none",
         "anomaly_higher_confidence",

--- a/tests/seer/anomaly_detection/detectors/test_smoothers.py
+++ b/tests/seer/anomaly_detection/detectors/test_smoothers.py
@@ -171,7 +171,6 @@ class TestMajorityVoteStreamFlagSmoother(unittest.TestCase):
 
         self.mp_config = MPConfig(ignore_trivial=False, normalize_mp=False)
 
-    # TODO: Add tests for stream smoother
     def test_stream_smooth_no_anomalies(self):
         flags = ["none"] * 5
         result = self.smoother.smooth(flags, self.ad_config, vote_threshold=0.5)

--- a/tests/seer/anomaly_detection/detectors/test_smoothers.py
+++ b/tests/seer/anomaly_detection/detectors/test_smoothers.py
@@ -1,191 +1,250 @@
-import pytest
+import unittest
 
-from seer.anomaly_detection.detectors.smoothers import MajorityVoteFlagSmoother
+from seer.anomaly_detection.detectors.mp_config import MPConfig
+from seer.anomaly_detection.detectors.smoothers import (
+    MajorityVoteBatchFlagSmoother,
+    MajorityVoteStreamFlagSmoother,
+)
 from seer.anomaly_detection.models.external import AnomalyDetectionConfig
 
 
-@pytest.fixture
-def flag_smoother():
-    return MajorityVoteFlagSmoother()
+class TestMajorityVoteBatchFlagSmoother(unittest.TestCase):
+
+    def setUp(self):
+        self.smoother = MajorityVoteBatchFlagSmoother()
+
+        self.ad_config = AnomalyDetectionConfig(
+            time_period=60, sensitivity="low", direction="up", expected_seasonality="auto"
+        )
+
+        self.mp_config = MPConfig(ignore_trivial=False, normalize_mp=False)
+
+    def test_smooth_no_anomalies(self):
+        flags = ["none"] * 5
+        result = self.smoother.smooth(flags, self.ad_config)
+        assert result == flags
+
+    def test_smooth_single_anomaly(self):
+        flags = [
+            "none",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "none",
+            "anomaly_higher_confidence",
+            "none",
+            "none",
+            "none",
+        ]
+        result = self.smoother.smooth(flags, self.ad_config, stream_smoothing=False)
+        assert result == [
+            "none",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "none",
+            "none",
+            "none",
+        ]
+
+    def test_smooth_multiple_anomalies(self):
+        flags = ["none"] * 300
+        flags[100:110] = ["anomaly_higher_confidence"] * 10
+        flags[111:120] = ["anomaly_higher_confidence"] * 9
+
+        flags[200:210] = ["anomaly_higher_confidence"] * 10
+        flags[211:220] = ["anomaly_higher_confidence"] * 9
+
+        result = self.smoother.smooth(flags, self.ad_config)
+        expected = ["none"] * 300
+        expected[100:120] = ["anomaly_higher_confidence"] * 20
+        expected[200:220] = ["anomaly_higher_confidence"] * 20
+        assert result == expected
+
+    def test_smooth_with_custom_smooth_size(self):
+        flags = [
+            "none",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "none",
+            "anomaly_higher_confidence",
+            "none",
+            "none",
+        ]
+        result = self.smoother.smooth(flags, self.ad_config, smooth_size=3)
+        assert result == [
+            "none",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "none",
+            "none",
+        ]
+
+    def test_smooth_with_custom_vote_threshold(self):
+        flags_success = [
+            "none",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "none",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "none",
+            "none",
+        ]
+        expected_success = [
+            "none",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "none",
+            "none",
+        ]
+        result_success = self.smoother.smooth(flags_success, self.ad_config, vote_threshold=0.75)
+        assert result_success == expected_success
+
+        flags_failure = [
+            "none",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "none",
+            "none",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "none",
+            "none",
+        ]
+        expected_failure = [
+            "none",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "none",
+            "none",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "none",
+            "none",
+        ]
+        result_failure = self.smoother.smooth(flags_failure, self.ad_config, vote_threshold=0.75)
+        assert result_failure == expected_failure
+
+    def test_smooth_with_different_time_periods(self):
+        flags = ["none"] * 300
+        flags[100:110] = ["anomaly_higher_confidence"] * 10
+        flags[112:120] = ["anomaly_higher_confidence"] * 8
+
+        flags[200:210] = ["anomaly_higher_confidence"] * 10
+        flags[212:220] = ["anomaly_higher_confidence"] * 8
+
+        expected = ["none"] * 300
+        expected[100:120] = ["anomaly_higher_confidence"] * 20
+        expected[200:220] = ["anomaly_higher_confidence"] * 20
+
+        ad_config_5 = AnomalyDetectionConfig(
+            time_period=5, sensitivity="medium", direction="both", expected_seasonality="auto"
+        )
+        result_5 = self.smoother.smooth(flags, ad_config_5)
+        assert result_5 == expected
 
 
-@pytest.fixture
-def ad_config():
-    return AnomalyDetectionConfig(
-        time_period=60, sensitivity="medium", direction="both", expected_seasonality="auto"
-    )
+class TestMajorityVoteStreamFlagSmoother(unittest.TestCase):
 
+    def setUp(self):
+        self.smoother = MajorityVoteStreamFlagSmoother()
 
-def test_smooth_no_anomalies(flag_smoother, ad_config):
-    flags = ["none"] * 5
-    result = flag_smoother.smooth(flags, ad_config)
-    assert result == flags
+        self.ad_config = AnomalyDetectionConfig(
+            time_period=60, sensitivity="low", direction="up", expected_seasonality="auto"
+        )
 
+        self.mp_config = MPConfig(ignore_trivial=False, normalize_mp=False)
 
-def test_smooth_single_anomaly(flag_smoother, ad_config):
-    flags = [
-        "none",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "none",
-        "anomaly_higher_confidence",
-        "none",
-        "none",
-        "none",
-    ]
-    result = flag_smoother.smooth(flags, ad_config, stream_smoothing=False)
-    assert result == [
-        "none",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "none",
-        "none",
-        "none",
-    ]
+    # TODO: Add tests for stream smoother
+    def test_stream_smooth_no_anomalies(self):
+        flags = ["none"] * 5
+        result = self.smoother.smooth(flags, self.ad_config, vote_threshold=0.5)
+        assert result == []
 
+    def test_stream_smooth_single_anomaly(self):
+        flags = [
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "none",
+            "none",
+        ]
+        result = self.smoother.smooth(flags, self.ad_config, vote_threshold=0.5)
+        assert result == ["anomaly_higher_confidence"]
 
-def test_smooth_multiple_anomalies(flag_smoother, ad_config):
-    flags = ["none"] * 300
-    flags[100:110] = ["anomaly_higher_confidence"] * 10
-    flags[111:120] = ["anomaly_higher_confidence"] * 9
+    def test_stream_smooth_with_custom_vote_threshold(self):
+        # Test case where threshold is met
+        flags_success = [
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "anomaly_higher_confidence",
+            "none",
+        ]
+        result = self.smoother.smooth(flags_success, self.ad_config, vote_threshold=0.75)
+        assert result == ["anomaly_higher_confidence"]
 
-    flags[200:210] = ["anomaly_higher_confidence"] * 10
-    flags[211:220] = ["anomaly_higher_confidence"] * 9
+        # Test case where threshold is not met
+        flags_failure = ["anomaly_higher_confidence", "none", "none", "none"]
+        result = self.smoother.smooth(flags_failure, self.ad_config, vote_threshold=0.75)
+        assert result == []
 
-    result = flag_smoother.smooth(flags, ad_config)
-    expected = ["none"] * 300
-    expected[100:120] = ["anomaly_higher_confidence"] * 20
-    expected[200:220] = ["anomaly_higher_confidence"] * 20
-    assert result == expected
+    def test_stream_smooth_with_current_flag(self):
+        flags = ["anomaly_higher_confidence", "none", "none"]
+        cur_flag = ["anomaly_higher_confidence"]
 
+        # Test where threshold is not met but current flag is anomalous
+        result = self.smoother.smooth(flags, self.ad_config, vote_threshold=0.5, cur_flag=cur_flag)
+        assert result == ["anomaly_higher_confidence"]
 
-def test_smooth_with_custom_smooth_size(flag_smoother, ad_config):
-    flags = [
-        "none",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "none",
-        "anomaly_higher_confidence",
-        "none",
-        "none",
-    ]
-    result = flag_smoother.smooth(flags, ad_config, smooth_size=3)
-    assert result == [
-        "none",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "none",
-        "none",
-    ]
+        # Test where threshold is not met and current flag is none
+        result = self.smoother.smooth(flags, self.ad_config, vote_threshold=0.5, cur_flag=["none"])
+        assert result == ["none"]
 
+    def test_stream_smooth_with_different_time_periods(self):
+        # Test with time_period=5
+        ad_config_5 = AnomalyDetectionConfig(
+            time_period=5, sensitivity="low", direction="up", expected_seasonality="auto"
+        )
+        flags = ["anomaly_higher_confidence"] * 10 + ["none"]
+        result = self.smoother.smooth(flags, ad_config_5, vote_threshold=0.5, cur_flag=["none"])
+        assert result == ["anomaly_higher_confidence"]
 
-def test_smooth_with_custom_vote_threshold(flag_smoother, ad_config):
-    flags_success = [
-        "none",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "none",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "none",
-        "none",
-    ]
-    expected_success = [
-        "none",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "none",
-        "none",
-    ]
-    result_success = flag_smoother.smooth(flags_success, ad_config, vote_threshold=0.75)
-    assert result_success == expected_success
+        # Test with time_period=15
+        ad_config_15 = AnomalyDetectionConfig(
+            time_period=15, sensitivity="low", direction="up", expected_seasonality="auto"
+        )
+        flags = ["anomaly_higher_confidence"] * 6 + ["none"] * 2
+        result = self.smoother.smooth(flags, ad_config_15, vote_threshold=0.5, cur_flag=["none"])
+        assert result == ["anomaly_higher_confidence"]
 
-    flags_failure = [
-        "none",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "none",
-        "none",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "none",
-        "none",
-    ]
-    expected_failure = [
-        "none",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "none",
-        "none",
-        "anomaly_higher_confidence",
-        "anomaly_higher_confidence",
-        "none",
-        "none",
-    ]
-    result_failure = flag_smoother.smooth(flags_failure, ad_config, vote_threshold=0.75)
-    assert result_failure == expected_failure
+        # Test with time_period=30
+        ad_config_30 = AnomalyDetectionConfig(
+            time_period=30, sensitivity="low", direction="up", expected_seasonality="auto"
+        )
+        flags = ["anomaly_higher_confidence"] * 4 + ["none"] * 1
+        result = self.smoother.smooth(flags, ad_config_30, vote_threshold=0.5, cur_flag=["none"])
+        assert result == ["anomaly_higher_confidence"]
 
-
-def test_smooth_with_different_time_periods(flag_smoother):
-    flags = ["none"] * 300
-    flags[100:110] = ["anomaly_higher_confidence"] * 10
-    flags[112:120] = ["anomaly_higher_confidence"] * 8
-
-    flags[200:210] = ["anomaly_higher_confidence"] * 10
-    flags[212:220] = ["anomaly_higher_confidence"] * 8
-
-    expected = ["none"] * 300
-    expected[100:120] = ["anomaly_higher_confidence"] * 20
-    expected[200:220] = ["anomaly_higher_confidence"] * 20
-
-    ad_config_5 = AnomalyDetectionConfig(
-        time_period=5, sensitivity="medium", direction="both", expected_seasonality="auto"
-    )
-    result_5 = flag_smoother.smooth(flags, ad_config_5)
-    assert result_5 == expected
-
-
-def test_stream_smooth(flag_smoother):
-    flags = ["none", "anomaly_higher_confidence", "anomaly_higher_confidence", "none", "none"]
-    ad_config = AnomalyDetectionConfig(
-        time_period=5, sensitivity="medium", direction="both", expected_seasonality="auto"
-    )
-
-    # Test with empty current flag
-    result = flag_smoother.smooth(
-        flags=flags, ad_config=ad_config, vote_threshold=0.4, stream_smoothing=True, cur_flag=[]
-    )
-    assert result == ["anomaly_higher_confidence"]
-
-    # Test with threshold that's too high
-    result = flag_smoother.smooth(
-        flags=flags, ad_config=ad_config, vote_threshold=0.5, stream_smoothing=True, cur_flag=[]
-    )
-    assert result == []
-
-    # Test with existing current flag
-    result = flag_smoother.smooth(
-        flags=flags,
-        ad_config=ad_config,
-        vote_threshold=0.4,
-        stream_smoothing=True,
-        cur_flag=["none"],
-    )
-    assert result == ["anomaly_higher_confidence"]
+        # Test with time_period=60
+        ad_config_60 = AnomalyDetectionConfig(
+            time_period=60, sensitivity="low", direction="up", expected_seasonality="auto"
+        )
+        flags = ["anomaly_higher_confidence"] * 3 + ["none"] * 1
+        result = self.smoother.smooth(flags, ad_config_60, vote_threshold=0.5, cur_flag=["none"])
+        assert result == ["anomaly_higher_confidence"]

--- a/tests/seer/anomaly_detection/detectors/test_smoothers.py
+++ b/tests/seer/anomaly_detection/detectors/test_smoothers.py
@@ -160,3 +160,32 @@ def test_smooth_with_different_time_periods(flag_smoother):
     )
     result_5 = flag_smoother.smooth(flags, ad_config_5)
     assert result_5 == expected
+
+
+def test_stream_smooth(flag_smoother):
+    flags = ["none", "anomaly_higher_confidence", "anomaly_higher_confidence", "none", "none"]
+    ad_config = AnomalyDetectionConfig(
+        time_period=5, sensitivity="medium", direction="both", expected_seasonality="auto"
+    )
+
+    # Test with empty current flag
+    result = flag_smoother.smooth(
+        flags=flags, ad_config=ad_config, vote_threshold=0.4, stream_smoothing=True, cur_flag=[]
+    )
+    assert result == ["anomaly_higher_confidence"]
+
+    # Test with threshold that's too high
+    result = flag_smoother.smooth(
+        flags=flags, ad_config=ad_config, vote_threshold=0.5, stream_smoothing=True, cur_flag=[]
+    )
+    assert result == []
+
+    # Test with existing current flag
+    result = flag_smoother.smooth(
+        flags=flags,
+        ad_config=ad_config,
+        vote_threshold=0.4,
+        stream_smoothing=True,
+        cur_flag=["none"],
+    )
+    assert result == ["anomaly_higher_confidence"]

--- a/tests/seer/anomaly_detection/detectors/test_smoothers.py
+++ b/tests/seer/anomaly_detection/detectors/test_smoothers.py
@@ -37,7 +37,7 @@ class TestMajorityVoteBatchFlagSmoother(unittest.TestCase):
             "none",
             "none",
         ]
-        result = self.smoother.smooth(flags, self.ad_config, stream_smoothing=False)
+        result = self.smoother.smooth(flags, self.ad_config)
         assert result == [
             "none",
             "anomaly_higher_confidence",

--- a/tests/seer/anomaly_detection/models/test_timeseries_anomalies.py
+++ b/tests/seer/anomaly_detection/models/test_timeseries_anomalies.py
@@ -23,8 +23,8 @@ class TestConverters(unittest.TestCase):
             None,
             None,
             None,
-            {"dist": 0.1, "idx": 0, "l_idx": 1, "r_idx": 2},
-            {"dist": 0.2, "idx": 1, "l_idx": 2, "r_idx": 3},
+            {"dist": 0.1, "idx": 0, "l_idx": 1, "r_idx": 2, "original_flag": "none"},
+            {"dist": 0.2, "idx": 1, "l_idx": 2, "r_idx": 3, "original_flag": "none"},
         ]
 
         algo_data = self.anomalies.get_anomaly_algo_data(front_pad_to_len)
@@ -35,8 +35,8 @@ class TestConverters(unittest.TestCase):
         # Test with front_pad_to_len equal to the length of matrix_profile
         front_pad_to_len = 2
         expected_data = [
-            {"dist": 0.1, "idx": 0, "l_idx": 1, "r_idx": 2},
-            {"dist": 0.2, "idx": 1, "l_idx": 2, "r_idx": 3},
+            {"dist": 0.1, "idx": 0, "l_idx": 1, "r_idx": 2, "original_flag": "none"},
+            {"dist": 0.2, "idx": 1, "l_idx": 2, "r_idx": 3, "original_flag": "none"},
         ]
 
         algo_data = self.anomalies.get_anomaly_algo_data(front_pad_to_len)

--- a/tests/seer/anomaly_detection/test_accessors.py
+++ b/tests/seer/anomaly_detection/test_accessors.py
@@ -125,6 +125,7 @@ class TestDbAlertDataAccessor(unittest.TestCase):
                 matrix_profile=np.array([[1.0, 10, -1, -1]]),
                 window_size=1,
                 thresholds=[0.0],
+                original_flags=["none"],
             ),
             anomaly_algo_data={"dummy": 10},
         )

--- a/tests/seer/anomaly_detection/test_anomaly_detection.py
+++ b/tests/seer/anomaly_detection/test_anomaly_detection.py
@@ -110,11 +110,12 @@ class TestAnomalyDetection(unittest.TestCase):
                 values=ts_values,
             ),
             anomalies=MPTimeSeriesAnomalies(
-                flags=np.array(["anomaly_higher_confidence"]),
-                scores=np.array([0.4]),
+                flags=np.array(["anomaly_higher_confidence"] * len(ts_timestamps)),
+                scores=np.array([0.4] * len(ts_timestamps)),
                 matrix_profile=dummy_mp,
                 window_size=window_size,
-                thresholds=np.array([0.0]),
+                thresholds=np.array([0.0] * len(ts_timestamps)),
+                original_flags=np.array(["none"] * len(ts_timestamps)),
             ),
             cleanup_config=cleanup_config,
         )
@@ -150,11 +151,12 @@ class TestAnomalyDetection(unittest.TestCase):
                 values=ts_values,
             ),
             anomalies=MPTimeSeriesAnomalies(
-                flags=np.array(["anomaly_higher_confidence"]),
-                scores=np.array([0.4]),
+                flags=np.array(["anomaly_higher_confidence"] * len(ts_timestamps[:100])),
+                scores=np.array([0.4] * len(ts_timestamps[:100])),
                 matrix_profile=dummy_mp,
                 window_size=window_size,
-                thresholds=np.array([0.0]),
+                thresholds=np.array([0.0] * len(ts_timestamps[:100])),
+                original_flags=np.array(["none"] * len(ts_timestamps[:100])),
             ),
             cleanup_config=cleanup_config,
         )

--- a/tests/seer/anomaly_detection/test_anomaly_detection.py
+++ b/tests/seer/anomaly_detection/test_anomaly_detection.py
@@ -110,7 +110,7 @@ class TestAnomalyDetection(unittest.TestCase):
                 values=ts_values,
             ),
             anomalies=MPTimeSeriesAnomalies(
-                flags=np.array(["anomaly_high_confidence"]),
+                flags=np.array(["anomaly_higher_confidence"]),
                 scores=np.array([0.4]),
                 matrix_profile=dummy_mp,
                 window_size=window_size,
@@ -150,7 +150,7 @@ class TestAnomalyDetection(unittest.TestCase):
                 values=ts_values,
             ),
             anomalies=MPTimeSeriesAnomalies(
-                flags=np.array(["anomaly_high_confidence"]),
+                flags=np.array(["anomaly_higher_confidence"]),
                 scores=np.array([0.4]),
                 matrix_profile=dummy_mp,
                 window_size=window_size,

--- a/tests/seer/anomaly_detection/test_anomaly_detection.py
+++ b/tests/seer/anomaly_detection/test_anomaly_detection.py
@@ -182,6 +182,31 @@ class TestAnomalyDetection(unittest.TestCase):
             AnomalyDetection().detect_anomalies(request=request)
         assert "Invalid state" in str(e.exception)
 
+        # Test validation of original flags length matching timeseries length
+        mock_query.return_value = DynamicAlert(
+            organization_id=0,
+            project_id=0,
+            external_alert_id=0,
+            config=config,
+            timeseries=MPTimeSeries(
+                timestamps=ts_timestamps,
+                values=ts_values,
+            ),
+            anomalies=MPTimeSeriesAnomalies(
+                flags=["none"] * len(ts_timestamps),
+                scores=[0.0] * len(ts_timestamps),
+                matrix_profile=dummy_mp,
+                window_size=window_size,
+                thresholds=[0.0] * len(ts_timestamps),
+                original_flags=["none"] * (len(ts_timestamps) - 1),  # One less than timestamps
+            ),
+            cleanup_config=cleanup_config,
+        )
+
+        with self.assertRaises(ServerError) as e:
+            AnomalyDetection().detect_anomalies(request=request)
+        assert "Invalid state" in str(e.exception)
+
     def test_detect_anomalies_combo(self):
 
         config = AnomalyDetectionConfig(


### PR DESCRIPTION
- Fix stream smoothing by keeping track of `original_flag` in the `anomaly_algo_data` for each flag
- Use a voting threshold smoothing for the last set of points and their original flags