### PR TITLE
fix(autofix): Use source_start instead of target_start in hunk applies

### DIFF
--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -570,8 +570,8 @@ class FilePatch(BaseModel):
 
         for hunk in self.hunks:
             # Add unchanged lines before the hunk
-            result.extend(lines[current_line : hunk.target_start - 1])
-            current_line = hunk.target_start - 1
+            result.extend(lines[current_line : hunk.source_start - 1])
+            current_line = hunk.source_start - 1
 
             for line in hunk.lines:
                 if line.line_type == "+":

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -555,7 +555,10 @@ class FilePatch(BaseModel):
             return None
 
         # For M type
-        new_contents = self._apply_hunks(file_contents.splitlines(keepends=True))
+        try:
+            new_contents = self._apply_hunks(file_contents.splitlines(keepends=True))
+        except Exception as e:
+            raise FileChangeError(f"Error applying hunks: {e}")
 
         # Preserve any trailing characters from original
         if file_contents:


### PR DESCRIPTION
We should be using `source_start` when accessing a line index in the original file.
 
This hunk apply function was fine for simple changes, but when the change gets complex with multiple hunks, previous hunks will cause the resulting ("`target`") output to have more lines than the original ("`source`") file, causing it to try to access a line that was out of bounds.

These new test cases catch that case, and fail before this change is made.