### PR TITLE
fix(autofix): Fix duplicate step creation on interactive plan+code

### DIFF
--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -130,7 +130,10 @@ class AutofixEventManager:
 
     def send_coding_start(self):
         with self.state.update() as cur:
-            plan_step = cur.add_step(self.plan_step)
+            plan_step = cur.find_or_add(self.plan_step)
+            if plan_step.status != AutofixStatus.PROCESSING:
+                plan_step = cur.add_step(self.plan_step)
+
             plan_step.status = AutofixStatus.PROCESSING
 
             cur.status = AutofixStatus.PROCESSING


### PR DESCRIPTION
When rethinking or giving feedback, plan+code would often create unnecessary extra DEFAULT (insight) steps. This caused lots of visual bugs.  #1444 

This PR adds a check to stop duplication, the same way the root cause step already does this.