### PR TITLE
feat(anomaly detection): Dynamic Window for Matrix Profiling

### DIFF
--- a/src/seer/anomaly_detection/accessors.py
+++ b/src/seer/anomaly_detection/accessors.py
@@ -402,7 +402,7 @@ class DbAlertDataAccessor(AlertDataAccessor):
             thresholds=anomalies_suss.thresholds,  # Use thresholds from either one since they're the same
             matrix_profile_suss=anomalies_suss.matrix_profile,
             matrix_profile_fixed=(
-                anomalies_fixed.matrix_profile if anomalies_fixed is not None else None
+                anomalies_fixed.matrix_profile if anomalies_fixed is not None else np.array([])
             ),
             window_size=anomalies_suss.window_size,
             original_flags=anomalies_suss.original_flags,

--- a/src/seer/anomaly_detection/accessors.py
+++ b/src/seer/anomaly_detection/accessors.py
@@ -92,29 +92,38 @@ class DbAlertDataAccessor(AlertDataAccessor):
             flags.append(point.anomaly_type)
             scores.append(point.anomaly_score)
 
-            algo_data = MPTimeSeriesAnomalies.extract_algo_data(point.anomaly_algo_data)
-            mp_suss_data = None
-            if algo_data["mp_suss"]:
-                mp_suss_data = [
-                    algo_data["mp_suss"]["dist"],
-                    algo_data["mp_suss"]["idx"],
-                    algo_data["mp_suss"]["l_idx"],
-                    algo_data["mp_suss"]["r_idx"],
-                ]
-            mp_suss.append(mp_suss_data)
+            if point.anomaly_algo_data is not None:
+                print("POINT ALGO DATA##################################")
+                print(point.anomaly_algo_data)
+                print("##########################")
+                algo_data = MPTimeSeriesAnomalies.extract_algo_data(point.anomaly_algo_data)
 
-            mp_fixed_data = None
-            if algo_data["mp_fixed"]:
-                mp_fixed_data = [
-                    algo_data["mp_fixed"]["dist"],
-                    algo_data["mp_fixed"]["idx"],
-                    algo_data["mp_fixed"]["l_idx"],
-                    algo_data["mp_fixed"]["r_idx"],
-                ]
-            mp_fixed.append(mp_fixed_data)
+                print("EXTRACTED POINT ALGO DATA##################################")
+                print(algo_data)
+                print("##########################")
 
-            original_flags.append(algo_data["original_flag"])
-            use_suss.append(algo_data["use_suss"])
+                mp_suss_data = None
+                if algo_data["mp_suss"]:
+                    mp_suss_data = [
+                        algo_data["mp_suss"]["dist"],
+                        algo_data["mp_suss"]["idx"],
+                        algo_data["mp_suss"]["l_idx"],
+                        algo_data["mp_suss"]["r_idx"],
+                    ]
+                mp_suss.append(mp_suss_data)
+
+                mp_fixed_data = None
+                if algo_data["mp_fixed"]:
+                    mp_fixed_data = [
+                        algo_data["mp_fixed"]["dist"],
+                        algo_data["mp_fixed"]["idx"],
+                        algo_data["mp_fixed"]["l_idx"],
+                        algo_data["mp_fixed"]["r_idx"],
+                    ]
+                mp_fixed.append(mp_fixed_data)
+
+                original_flags.append(algo_data["original_flag"])
+                use_suss.append(algo_data["use_suss"])
             if point.timestamp.timestamp() < timestamp_threshold:
                 num_old_points += 1
 

--- a/src/seer/anomaly_detection/accessors.py
+++ b/src/seer/anomaly_detection/accessors.py
@@ -93,16 +93,8 @@ class DbAlertDataAccessor(AlertDataAccessor):
             scores.append(point.anomaly_score)
 
             if point.anomaly_algo_data is not None:
-                print("POINT ALGO DATA##################################")
-                print(point.anomaly_algo_data)
-                print("##########################")
                 algo_data = MPTimeSeriesAnomalies.extract_algo_data(point.anomaly_algo_data)
 
-                print("EXTRACTED POINT ALGO DATA##################################")
-                print(algo_data)
-                print("##########################")
-
-                mp_suss_data = None
                 if algo_data["mp_suss"]:
                     mp_suss_data = [
                         algo_data["mp_suss"]["dist"],
@@ -110,9 +102,8 @@ class DbAlertDataAccessor(AlertDataAccessor):
                         algo_data["mp_suss"]["l_idx"],
                         algo_data["mp_suss"]["r_idx"],
                     ]
-                mp_suss.append(mp_suss_data)
+                    mp_suss.append(mp_suss_data)
 
-                mp_fixed_data = None
                 if algo_data["mp_fixed"]:
                     mp_fixed_data = [
                         algo_data["mp_fixed"]["dist"],
@@ -120,14 +111,13 @@ class DbAlertDataAccessor(AlertDataAccessor):
                         algo_data["mp_fixed"]["l_idx"],
                         algo_data["mp_fixed"]["r_idx"],
                     ]
-                mp_fixed.append(mp_fixed_data)
+                    mp_fixed.append(mp_fixed_data)
 
                 original_flags.append(algo_data["original_flag"])
                 use_suss.append(algo_data["use_suss"])
             if point.timestamp.timestamp() < timestamp_threshold:
                 num_old_points += 1
 
-        # TODO: Can optimize this by using extend or list comprehension
         # Default value is "none" for original flags
         if len(original_flags) < len(ts):
             original_flags = ["none"] * (len(ts) - len(original_flags)) + original_flags

--- a/src/seer/anomaly_detection/accessors.py
+++ b/src/seer/anomaly_detection/accessors.py
@@ -138,7 +138,7 @@ class DbAlertDataAccessor(AlertDataAccessor):
             matrix_profile_fixed=stumpy.mparray.mparray(
                 mp_fixed,
                 k=1,
-                m=10,  # TODO: this should not be hardcoded
+                m=10,
                 excl_zone_denom=stumpy.config.STUMPY_EXCL_ZONE_DENOM,
             ),
             window_size=window_size,

--- a/src/seer/anomaly_detection/accessors.py
+++ b/src/seer/anomaly_detection/accessors.py
@@ -125,7 +125,7 @@ class DbAlertDataAccessor(AlertDataAccessor):
             if point.anomaly_algo_data is not None:
                 algo_data = MPTimeSeriesAnomalies.extract_algo_data(point.anomaly_algo_data)
 
-                if "mp_suss" in algo_data:
+                if "mp_suss" in algo_data and algo_data["mp_suss"]:
                     mp_suss_data = [
                         algo_data["mp_suss"]["dist"],
                         algo_data["mp_suss"]["idx"],
@@ -134,7 +134,7 @@ class DbAlertDataAccessor(AlertDataAccessor):
                     ]
                     mp_suss.append(mp_suss_data)
 
-                if algo_data["mp_fixed"]:
+                if "mp_fixed" in algo_data and algo_data["mp_fixed"]:
                     mp_fixed_data = [
                         algo_data["mp_fixed"]["dist"],
                         algo_data["mp_fixed"]["idx"],

--- a/src/seer/anomaly_detection/accessors.py
+++ b/src/seer/anomaly_detection/accessors.py
@@ -10,13 +10,16 @@ import stumpy  # type: ignore # mypy throws "missing library stubs"
 from pydantic import BaseModel
 from sqlalchemy import delete
 
+from seer.anomaly_detection.detectors import MPBatchAnomalyDetector
 from seer.anomaly_detection.models import (
     DynamicAlert,
     MPTimeSeries,
     MPTimeSeriesAnomalies,
+    MPTimeSeriesAnomaliesSingleWindow,
     TimeSeriesAnomalies,
 )
 from seer.anomaly_detection.models.cleanup import CleanupConfig
+from seer.anomaly_detection.models.converters import convert_external_ts_to_internal
 from seer.anomaly_detection.models.external import AnomalyDetectionConfig, TimeSeriesPoint
 from seer.db import DbDynamicAlert, DbDynamicAlertTimeSeries, Session, TaskStatus
 from seer.exceptions import ClientError
@@ -69,6 +72,15 @@ class AlertDataAccessor(BaseModel, abc.ABC):
     def reset_cleanup_task(self, external_alert_id: int):
         return NotImplemented
 
+    @abc.abstractmethod
+    def combine_anomalies(
+        self,
+        anomalies_suss: MPTimeSeriesAnomaliesSingleWindow,
+        anomalies_fixed: MPTimeSeriesAnomaliesSingleWindow,
+        use_suss: list[bool],
+    ):
+        return NotImplemented
+
 
 class DbAlertDataAccessor(AlertDataAccessor):
 
@@ -86,6 +98,17 @@ class DbAlertDataAccessor(AlertDataAccessor):
         values = []
         original_flags = []
         use_suss = []
+
+        # If the timeseries does not have both matrix profiles, then we need to recalculate them using batch detection
+        last_point = db_alert.timeseries[-1]
+        if (
+            last_point.anomaly_algo_data is None
+            or "mp_suss" not in last_point.anomaly_algo_data
+            or "mp_fixed" not in last_point.anomaly_algo_data
+        ):
+            self._recalculate_batch_detection(db_alert)
+            db_alert = self.query(db_alert.external_alert_id)
+
         for point in db_alert.timeseries:
             ts.append(point.timestamp.timestamp())
             values.append(point.value)
@@ -117,7 +140,6 @@ class DbAlertDataAccessor(AlertDataAccessor):
                 use_suss.append(algo_data["use_suss"])
             if point.timestamp.timestamp() < timestamp_threshold:
                 num_old_points += 1
-
         # Default value is "none" for original flags
         if len(original_flags) < len(ts):
             original_flags = ["none"] * (len(ts) - len(original_flags)) + original_flags
@@ -161,6 +183,45 @@ class DbAlertDataAccessor(AlertDataAccessor):
                 timestamp_threshold=timestamp_threshold,
                 num_acceptable_points=24 * 4 * 2,  # Num alerts for 2 days
             ),
+        )
+
+    @sentry_sdk.trace
+    def _recalculate_batch_detection(self, db_alert: DbDynamicAlert):
+
+        batch_detector = MPBatchAnomalyDetector()
+        timeseries = [
+            TimeSeriesPoint(timestamp=point.timestamp.timestamp(), value=point.value)
+            for point in db_alert.timeseries
+        ]
+
+        ad_config = AnomalyDetectionConfig(
+            time_period=db_alert.config.get("time_period"),
+            sensitivity=db_alert.config.get("sensitivity"),
+            direction=db_alert.config.get("direction"),
+            expected_seasonality=db_alert.config.get("expected_seasonality"),
+        )
+
+        anomalies_suss = batch_detector.detect(
+            convert_external_ts_to_internal(timeseries),
+            ad_config,
+            window_size=db_alert.anomaly_algo_data.get("window_size"),
+        )
+        anomalies_fixed = batch_detector.detect(
+            convert_external_ts_to_internal(timeseries), ad_config, window_size=10
+        )
+        recalculated_anomalies = self.combine_anomalies(
+            anomalies_suss, anomalies_fixed, [True] * len(timeseries)
+        )
+
+        self.save_alert(
+            organization_id=db_alert.organization_id,
+            project_id=db_alert.project_id,
+            external_alert_id=db_alert.external_alert_id,
+            config=ad_config,
+            timeseries=timeseries,
+            anomalies=recalculated_anomalies,
+            anomaly_algo_data=db_alert.anomaly_algo_data,
+            data_purge_flag=db_alert.data_purge_flag,
         )
 
     @sentry_sdk.trace
@@ -329,3 +390,42 @@ class DbAlertDataAccessor(AlertDataAccessor):
             dynamic_alert.last_queued_at = None
             dynamic_alert.data_purge_flag = TaskStatus.NOT_QUEUED
             session.commit()
+
+    def combine_anomalies(
+        self,
+        anomalies_suss: MPTimeSeriesAnomaliesSingleWindow,
+        anomalies_fixed: MPTimeSeriesAnomaliesSingleWindow,
+        use_suss: list[bool],
+    ) -> MPTimeSeriesAnomalies:
+        """
+        Combines anomalies detected using SuSS and fixed window approaches into a single MPTimeSeriesAnomalies object.
+        For each point, uses either the SuSS or fixed window anomaly based on the use_suss flag.
+
+        Parameters:
+        anomalies_suss: MPTimeSeriesAnomalies
+            Anomalies detected using the SuSS window
+        anomalies_fixed: MPTimeSeriesAnomalies
+            Anomalies detected using the fixed window
+        use_suss: list[bool]
+            Flags indicating whether to use the SuSS or fixed window for each point
+
+        Returns:
+        MPTimeSeriesAnomalies
+            Combined anomalies object containing flags, scores and metadata from both approaches
+        """
+        return MPTimeSeriesAnomalies(
+            flags=[
+                (anomalies_suss.flags[i] if use_suss[i] else anomalies_fixed.flags[i])
+                for i in range(len(anomalies_suss.flags))
+            ],
+            scores=[
+                (anomalies_suss.scores[i] if use_suss[i] else anomalies_fixed.scores[i])
+                for i in range(len(anomalies_suss.scores))
+            ],
+            thresholds=anomalies_suss.thresholds,  # Use thresholds from either one since they're the same
+            matrix_profile_suss=anomalies_suss.matrix_profile,
+            matrix_profile_fixed=anomalies_fixed.matrix_profile,
+            window_size=anomalies_suss.window_size,
+            original_flags=anomalies_suss.original_flags,
+            use_suss=use_suss,
+        )

--- a/src/seer/anomaly_detection/accessors.py
+++ b/src/seer/anomaly_detection/accessors.py
@@ -185,7 +185,7 @@ class DbAlertDataAccessor(AlertDataAccessor):
         )
 
     @sentry_sdk.trace
-    def _recalculate_batch_detection(self, db_alert: DbDynamicAlert):
+    def _recalculate_batch_detection(self, db_alert: DbDynamicAlert) -> DbDynamicAlert | None:
         """
         Recalculates the matrix profiles for SuSS and Fixed windows for an alert then returns the updated alert
         """
@@ -240,6 +240,8 @@ class DbAlertDataAccessor(AlertDataAccessor):
                     },
                 )
                 return None
+
+            print(alert)
 
             return alert
 

--- a/src/seer/anomaly_detection/accessors.py
+++ b/src/seer/anomaly_detection/accessors.py
@@ -93,35 +93,39 @@ class DbAlertDataAccessor(AlertDataAccessor):
             scores.append(point.anomaly_score)
 
             algo_data = MPTimeSeriesAnomalies.extract_algo_data(point.anomaly_algo_data)
+            mp_suss_data = None
             if algo_data["mp_suss"]:
-                mp_suss.append(
-                    [
-                        algo_data["mp_suss"]["dist"],
-                        algo_data["mp_suss"]["idx"],
-                        algo_data["mp_suss"]["l_idx"],
-                        algo_data["mp_suss"]["r_idx"],
-                    ]
-                )
-            else:
-                mp_suss.append(None)
+                mp_suss_data = [
+                    algo_data["mp_suss"]["dist"],
+                    algo_data["mp_suss"]["idx"],
+                    algo_data["mp_suss"]["l_idx"],
+                    algo_data["mp_suss"]["r_idx"],
+                ]
+            mp_suss.append(mp_suss_data)
+
+            mp_fixed_data = None
             if algo_data["mp_fixed"]:
-                mp_fixed.append(
-                    [
-                        algo_data["mp_fixed"]["dist"],
-                        algo_data["mp_fixed"]["idx"],
-                        algo_data["mp_fixed"]["l_idx"],
-                        algo_data["mp_fixed"]["r_idx"],
-                    ]
-                )
-            else:
-                mp_fixed.append(None)
+                mp_fixed_data = [
+                    algo_data["mp_fixed"]["dist"],
+                    algo_data["mp_fixed"]["idx"],
+                    algo_data["mp_fixed"]["l_idx"],
+                    algo_data["mp_fixed"]["r_idx"],
+                ]
+            mp_fixed.append(mp_fixed_data)
+
             original_flags.append(algo_data["original_flag"])
             use_suss.append(algo_data["use_suss"])
             if point.timestamp.timestamp() < timestamp_threshold:
                 num_old_points += 1
 
+        # TODO: Can optimize this by using extend or list comprehension
+        # Default value is "none" for original flags
         if len(original_flags) < len(ts):
             original_flags = ["none"] * (len(ts) - len(original_flags)) + original_flags
+
+        # Default value is True for use_suss
+        if len(use_suss) < len(ts):
+            use_suss = [True] * (len(ts) - len(use_suss)) + use_suss
 
         anomalies = MPTimeSeriesAnomalies(
             flags=flags,

--- a/src/seer/anomaly_detection/anomaly_detection.py
+++ b/src/seer/anomaly_detection/anomaly_detection.py
@@ -151,9 +151,6 @@ class AnomalyDetection(BaseModel):
                 f"Not enough timeseries data. At least {min_data} data points required"
             )
         anomalies: MPTimeSeriesAnomalies = historic.anomalies
-        print("ANOMALIES##################################")
-        print(anomalies.matrix_profile_suss)
-        # print(anomalies.matrix_profile_fixed)
 
         # TODO: Need to check the time gap between historic data and the new datapoint against the alert configuration
 

--- a/src/seer/anomaly_detection/anomaly_detection.py
+++ b/src/seer/anomaly_detection/anomaly_detection.py
@@ -8,7 +8,11 @@ from pydantic import BaseModel
 
 from seer.anomaly_detection.accessors import AlertDataAccessor, DbAlertDataAccessor
 from seer.anomaly_detection.anomaly_detection_di import anomaly_detection_module
-from seer.anomaly_detection.detectors import MPBatchAnomalyDetector, MPStreamAnomalyDetector
+from seer.anomaly_detection.detectors import (
+    MPBatchAnomalyDetector,
+    MPConfig,
+    MPStreamAnomalyDetector,
+)
 from seer.anomaly_detection.models import MPTimeSeriesAnomalies
 from seer.anomaly_detection.models.converters import convert_external_ts_to_internal
 from seer.anomaly_detection.models.external import (
@@ -81,7 +85,9 @@ class AnomalyDetection(BaseModel):
             convert_external_ts_to_internal(timeseries), config, window_size=window_size
         )
         anomalies_fixed = batch_detector.detect(
-            convert_external_ts_to_internal(timeseries), config, window_size=10
+            convert_external_ts_to_internal(timeseries),
+            config,
+            window_size=MPConfig().fixed_window_size,
         )
         anomalies = DbAlertDataAccessor().combine_anomalies(
             anomalies_suss, anomalies_fixed, [True] * len(timeseries)
@@ -335,7 +341,7 @@ class AnomalyDetection(BaseModel):
                 historic_anomalies_fixed.scores[-trim_current_by:] + streamed_anomalies_fixed.scores
             )
 
-        anomalies = AlertDataAccessor().combine_anomalies(
+        anomalies = DbAlertDataAccessor().combine_anomalies(
             streamed_anomalies_suss,
             streamed_anomalies_fixed,
             [True]

--- a/src/seer/anomaly_detection/anomaly_detection.py
+++ b/src/seer/anomaly_detection/anomaly_detection.py
@@ -57,12 +57,14 @@ class AnomalyDetection(BaseModel):
         )
         stream.update(6.0)
 
+    @inject
     @sentry_sdk.trace
     def _batch_detect(
         self,
         timeseries: List[TimeSeriesPoint],
         config: AnomalyDetectionConfig,
         window_size: int | None = None,
+        mp_config: MPConfig = injected,
     ) -> Tuple[List[TimeSeriesPoint], MPTimeSeriesAnomalies]:
         """
         Stateless batch anomaly detection on entire timeseries as provided. In batch mode, analysis of a
@@ -87,7 +89,7 @@ class AnomalyDetection(BaseModel):
         anomalies_fixed = batch_detector.detect(
             convert_external_ts_to_internal(timeseries),
             config,
-            window_size=MPConfig().fixed_window_size,
+            window_size=mp_config.fixed_window_size,
         )
         anomalies = DbAlertDataAccessor().combine_anomalies(
             anomalies_suss, anomalies_fixed, [True] * len(timeseries)

--- a/src/seer/anomaly_detection/anomaly_detection.py
+++ b/src/seer/anomaly_detection/anomaly_detection.py
@@ -304,7 +304,7 @@ class AnomalyDetection(BaseModel):
         stream_detector_suss = MPStreamAnomalyDetector(
             history_timestamps=historic.timestamps,
             history_values=historic.values,
-            history_mp=historic_anomalies_suss.matrix_profile_suss,
+            history_mp=historic_anomalies_suss.matrix_profile,
             window_size=historic_anomalies_suss.window_size,
             original_flags=historic_anomalies_suss.original_flags,
         )
@@ -316,7 +316,7 @@ class AnomalyDetection(BaseModel):
         stream_detector_fixed = MPStreamAnomalyDetector(
             history_timestamps=historic.timestamps,
             history_values=historic.values,
-            history_mp=historic_anomalies_fixed.matrix_profile_fixed,
+            history_mp=historic_anomalies_fixed.matrix_profile,
             window_size=historic_anomalies_fixed.window_size,
             original_flags=historic_anomalies_fixed.original_flags,
         )
@@ -338,7 +338,15 @@ class AnomalyDetection(BaseModel):
             streamed_anomalies_fixed.scores = (
                 historic_anomalies_fixed.scores[-trim_current_by:] + streamed_anomalies_fixed.scores
             )
-        anomalies = self._combine_anomalies(streamed_anomalies_suss, streamed_anomalies_fixed)
+
+        anomalies = self._combine_anomalies(
+            streamed_anomalies_suss,
+            streamed_anomalies_fixed,
+            [True]
+            * len(
+                ts_external
+            ),  # Defaulting to using SuSS window because switching logic is for streaming only
+        )
 
         return ts_external, anomalies
 

--- a/src/seer/anomaly_detection/anomaly_detection.py
+++ b/src/seer/anomaly_detection/anomaly_detection.py
@@ -338,20 +338,13 @@ class AnomalyDetection(BaseModel):
     def _update_anomalies(
         self,
         ts_external: List[TimeSeriesPoint],
-        anomalies_suss: MPTimeSeriesAnomalies,
-        anomalies_fixed: MPTimeSeriesAnomalies,
+        anomalies: MPTimeSeriesAnomalies,
     ):
         for i, point in enumerate(ts_external):
-            if anomalies_suss.use_suss[i]:
-                point.anomaly = Anomaly(
-                    anomaly_score=anomalies_suss.scores[i],
-                    anomaly_type=anomalies_suss.flags[i],
-                )
-            else:
-                point.anomaly = Anomaly(
-                    anomaly_score=anomalies_fixed.scores[i],
-                    anomaly_type=anomalies_fixed.flags[i],
-                )
+            point.anomaly = Anomaly(
+                anomaly_score=anomalies.scores[i],
+                anomaly_type=anomalies.flags[i],
+            )
 
     def _combine_anomalies(
         self, anomalies_suss: MPTimeSeriesAnomalies, anomalies_fixed: MPTimeSeriesAnomalies

--- a/src/seer/anomaly_detection/anomaly_detection.py
+++ b/src/seer/anomaly_detection/anomaly_detection.py
@@ -203,7 +203,7 @@ class AnomalyDetection(BaseModel):
         if (
             not use_suss_window
             and streamed_anomalies_fixed.flags[-1] == "none"
-            and streamed_anomalies_fixed.flags[-1] == "none"
+            and streamed_anomalies_suss.flags[-1] == "none"
         ):
             use_suss_window = True
 

--- a/src/seer/anomaly_detection/anomaly_detection.py
+++ b/src/seer/anomaly_detection/anomaly_detection.py
@@ -6,7 +6,7 @@ import sentry_sdk
 import stumpy  # type: ignore # mypy throws "missing library stubs"
 from pydantic import BaseModel
 
-from seer.anomaly_detection.accessors import AlertDataAccessor
+from seer.anomaly_detection.accessors import AlertDataAccessor, DbAlertDataAccessor
 from seer.anomaly_detection.anomaly_detection_di import anomaly_detection_module
 from seer.anomaly_detection.detectors import MPBatchAnomalyDetector, MPStreamAnomalyDetector
 from seer.anomaly_detection.models import MPTimeSeriesAnomalies
@@ -83,7 +83,7 @@ class AnomalyDetection(BaseModel):
         anomalies_fixed = batch_detector.detect(
             convert_external_ts_to_internal(timeseries), config, window_size=10
         )
-        anomalies = AlertDataAccessor().combine_anomalies(
+        anomalies = DbAlertDataAccessor().combine_anomalies(
             anomalies_suss, anomalies_fixed, [True] * len(timeseries)
         )
 

--- a/src/seer/anomaly_detection/anomaly_detection.py
+++ b/src/seer/anomaly_detection/anomaly_detection.py
@@ -184,7 +184,7 @@ class AnomalyDetection(BaseModel):
             history_timestamps=historic.timeseries.timestamps,
             history_values=historic.timeseries.values,
             history_mp=anomalies.matrix_profile_fixed,
-            window_size=10,  # TODO: Make this custom/dynamic
+            window_size=10,
             original_flags=original_flags,
         )
         streamed_anomalies_fixed = stream_detector_fixed.detect(
@@ -291,13 +291,10 @@ class AnomalyDetection(BaseModel):
 
         historic = convert_external_ts_to_internal(ts_with_history.history)
 
-        # TODO: Run batch detection for both suss and fixed windows
         # Run batch detect on history data
         batch_detector = MPBatchAnomalyDetector()
         historic_anomalies_suss = batch_detector.detect(historic, config)
-        historic_anomalies_fixed = batch_detector.detect(
-            historic, config, window_size=10
-        )  # TODO: window size should not be hardcoded
+        historic_anomalies_fixed = batch_detector.detect(historic, config, window_size=10)
 
         # Run stream detection on current data
         # SuSS Window

--- a/src/seer/anomaly_detection/anomaly_detection_di.py
+++ b/src/seer/anomaly_detection/anomaly_detection_di.py
@@ -32,7 +32,7 @@ def mp_scorer_provider() -> MPScorer:
 @anomaly_detection_module.provider
 def mpconfig_provider() -> MPConfig:
     return MPConfig(
-        ignore_trivial=True, normalize_mp=False
+        ignore_trivial=True, normalize_mp=False, fixed_window_size=10
     )  # Avoiding complexities around normalizing matrix profile across stream computation for now.
 
 

--- a/src/seer/anomaly_detection/detectors/anomaly_detectors.py
+++ b/src/seer/anomaly_detection/detectors/anomaly_detectors.py
@@ -184,6 +184,11 @@ class MPStreamAnomalyDetector(AnomalyDetector):
             raise ServerError("History values and timestamps are not of the same length")
 
         if len(self.history_values) - self.window_size + 1 != len(self.history_mp):
+            print("HISTORY MATRIX PROFILE##################################")
+            # print(self.history_values)
+            print(self.history_mp)
+            # print(len(self.history_values) - self.window_size + 1, len(self.history_mp))
+            # print(len(self.history_values), self.window_size, len(self.history_mp))
             raise ServerError("Matrix profile is not of the right length.")
         stream = None
         with sentry_sdk.start_span(description="Initializing MP stream"):

--- a/src/seer/anomaly_detection/detectors/anomaly_detectors.py
+++ b/src/seer/anomaly_detection/detectors/anomaly_detectors.py
@@ -139,7 +139,6 @@ class MPBatchAnomalyDetector(AnomalyDetector):
 
 
 class MPStreamAnomalyDetector(AnomalyDetector):
-    # TODO: Likely need to update fields for both suss and fixed windows???
     history_timestamps: npt.NDArray[np.float64] = Field(
         ..., description="Baseline timeseries to which streaming points will be added."
     )

--- a/src/seer/anomaly_detection/detectors/anomaly_detectors.py
+++ b/src/seer/anomaly_detection/detectors/anomaly_detectors.py
@@ -184,11 +184,6 @@ class MPStreamAnomalyDetector(AnomalyDetector):
             raise ServerError("History values and timestamps are not of the same length")
 
         if len(self.history_values) - self.window_size + 1 != len(self.history_mp):
-            print("HISTORY MATRIX PROFILE##################################")
-            # print(self.history_values)
-            print(self.history_mp)
-            # print(len(self.history_values) - self.window_size + 1, len(self.history_mp))
-            # print(len(self.history_values), self.window_size, len(self.history_mp))
             raise ServerError("Matrix profile is not of the right length.")
         stream = None
         with sentry_sdk.start_span(description="Initializing MP stream"):

--- a/src/seer/anomaly_detection/detectors/anomaly_detectors.py
+++ b/src/seer/anomaly_detection/detectors/anomaly_detectors.py
@@ -132,7 +132,8 @@ class MPBatchAnomalyDetector(AnomalyDetector):
         return MPTimeSeriesAnomalies(
             flags=flags_and_scores.flags,
             scores=flags_and_scores.scores,
-            matrix_profile=mp,
+            matrix_profile_suss=mp,
+            matrix_profile_fixed=mp,  # TODO: This kinda doesn't make sense
             window_size=window_size,
             thresholds=flags_and_scores.thresholds,
         )
@@ -248,7 +249,13 @@ class MPStreamAnomalyDetector(AnomalyDetector):
             return MPTimeSeriesAnomalies(
                 flags=flags,
                 scores=scores,
-                matrix_profile=stumpy.mparray.mparray(
+                matrix_profile_suss=stumpy.mparray.mparray(
+                    streamed_mp,
+                    k=1,
+                    m=self.window_size,
+                    excl_zone_denom=stumpy.config.STUMPY_EXCL_ZONE_DENOM,
+                ),
+                matrix_profile_fixed=stumpy.mparray.mparray(
                     streamed_mp,
                     k=1,
                     m=self.window_size,

--- a/src/seer/anomaly_detection/detectors/mp_config.py
+++ b/src/seer/anomaly_detection/detectors/mp_config.py
@@ -7,10 +7,14 @@ class MPConfig(BaseModel):
     """
 
     ignore_trivial: bool = Field(
-        ...,
+        True,
         description="Flag that tells the stumpy library to ignore trivial matches to speed up MP computation",
     )
     normalize_mp: bool = Field(
-        ...,
+        False,
         description="Flag to control if the matrix profile is normalized first",
+    )
+    fixed_window_size: int = Field(
+        10,
+        description="Fixed window size for the matrix profile",
     )

--- a/src/seer/anomaly_detection/detectors/mp_config.py
+++ b/src/seer/anomaly_detection/detectors/mp_config.py
@@ -7,11 +7,11 @@ class MPConfig(BaseModel):
     """
 
     ignore_trivial: bool = Field(
-        True,
+        ...,
         description="Flag that tells the stumpy library to ignore trivial matches to speed up MP computation",
     )
     normalize_mp: bool = Field(
-        False,
+        ...,
         description="Flag to control if the matrix profile is normalized first",
     )
     fixed_window_size: int = Field(

--- a/src/seer/anomaly_detection/models/__init__.py
+++ b/src/seer/anomaly_detection/models/__init__.py
@@ -4,6 +4,7 @@ DynamicAlert = dynamic_alert.DynamicAlert
 MPTimeSeries = timeseries.MPTimeSeries
 TimeSeries = timeseries.TimeSeries
 MPTimeSeriesAnomalies = timeseries_anomalies.MPTimeSeriesAnomalies
+MPTimeSeriesAnomaliesSingleWindow = timeseries_anomalies.MPTimeSeriesAnomaliesSingleWindow
 TimeSeriesAnomalies = timeseries_anomalies.TimeSeriesAnomalies
 Sensitivities = external.Sensitivities
 Directions = external.Directions

--- a/src/seer/anomaly_detection/models/dynamic_alert.py
+++ b/src/seer/anomaly_detection/models/dynamic_alert.py
@@ -18,3 +18,4 @@ class DynamicAlert(BaseModel):
     timeseries: TimeSeries
     anomalies: TimeSeriesAnomalies
     cleanup_config: CleanupConfig
+    only_suss: bool

--- a/src/seer/anomaly_detection/models/timeseries_anomalies.py
+++ b/src/seer/anomaly_detection/models/timeseries_anomalies.py
@@ -172,6 +172,7 @@ class MPTimeSeriesAnomalies(TimeSeriesAnomalies):
     @staticmethod
     def extract_algo_data(map: dict):
         # Matrix profile for SuSS and fixed windows could be None so much check for that
+        # TODO: FIX THIS THE VALUES ARE NOT BEING PROPERLY EXTRACTED
         mp_suss = (
             {
                 "dist": map.get("dist_suss"),

--- a/src/seer/anomaly_detection/models/timeseries_anomalies.py
+++ b/src/seer/anomaly_detection/models/timeseries_anomalies.py
@@ -171,33 +171,26 @@ class MPTimeSeriesAnomalies(TimeSeriesAnomalies):
 
     @staticmethod
     def extract_algo_data(map: dict):
-        # Matrix profile for SuSS and fixed windows could be None so much check for that
-        # TODO: FIX THIS THE VALUES ARE NOT BEING PROPERLY EXTRACTED
+        # Matrix profile for SuSS and fixed windows could be None so we check for that
         mp_suss = (
             {
-                "dist": map.get("dist_suss"),
-                "idx": map.get("idx_suss"),
-                "l_idx": map.get("l_idx_suss"),
-                "r_idx": map.get("r_idx_suss"),
+                "dist": map.get("mp_suss").get("dist"),
+                "idx": map.get("mp_suss").get("idx"),
+                "l_idx": map.get("mp_suss").get("l_idx"),
+                "r_idx": map.get("mp_suss").get("r_idx"),
             }
-            if any(
-                map.get(key) is not None
-                for key in ["dist_suss", "idx_suss", "l_idx_suss", "r_idx_suss"]
-            )
+            if map.get("mp_suss") is not None
             else None
         )
 
         mp_fixed = (
             {
-                "dist": map.get("dist_fixed"),
-                "idx": map.get("idx_fixed"),
-                "l_idx": map.get("l_idx_fixed"),
-                "r_idx": map.get("r_idx_fixed"),
+                "dist": map.get("mp_fixed").get("dist"),
+                "idx": map.get("mp_fixed").get("idx"),
+                "l_idx": map.get("mp_fixed").get("l_idx"),
+                "r_idx": map.get("mp_fixed").get("r_idx"),
             }
-            if any(
-                map.get(key) is not None
-                for key in ["dist_fixed", "idx_fixed", "l_idx_fixed", "r_idx_fixed"]
-            )
+            if map.get("mp_fixed") is not None
             else None
         )
 

--- a/src/seer/anomaly_detection/models/timeseries_anomalies.py
+++ b/src/seer/anomaly_detection/models/timeseries_anomalies.py
@@ -41,8 +41,14 @@ class MPTimeSeriesAnomalies(TimeSeriesAnomalies):
 
     thresholds: list[float] = Field(..., description="Score thresholds")
 
-    matrix_profile: npt.NDArray = Field(
-        ..., description="The matrix profile of the time series using which anomalies were detected"
+    matrix_profile_suss: npt.NDArray = Field(
+        ...,
+        description="The matrix profile of the time series using which anomalies were detected using the SuSS window",
+    )
+
+    matrix_profile_fixed: npt.NDArray = Field(
+        ...,
+        description="The matrix profile of the time series using which anomalies were detected using the fixed window",
     )
 
     window_size: int = Field(..., description="Window size used to build the matrix profile")
@@ -51,20 +57,58 @@ class MPTimeSeriesAnomalies(TimeSeriesAnomalies):
         default=[], description="The original flags of the time series"
     )
 
+    use_suss: list[bool] = Field(
+        ..., description="Whether the SuSS window was used to detect anomalies"
+    )
+
     def get_anomaly_algo_data(self, front_pad_to_len: int) -> List[Optional[Dict]]:
         algo_data: List[Optional[Dict]] = []
-        if len(self.matrix_profile) < front_pad_to_len:
-            algo_data = [None] * (front_pad_to_len - len(self.matrix_profile))
 
-        for i, (dist, index, l_index, r_index) in enumerate(self.matrix_profile):
+        # Pad the algo_data with None to based on the size of the largest matrix profile
+        padding_suss = front_pad_to_len - len(self.matrix_profile_suss)
+        padding_fixed = front_pad_to_len - len(self.matrix_profile_fixed)
+
+        algo_data = [None] * min(padding_suss, padding_fixed)
+
+        for i in range(min(padding_suss, padding_fixed), front_pad_to_len):
+            # if algo_data[i] is None:
+            #     continue
+
+            mp_suss = None
+            if i >= padding_suss:
+                suss_idx = i - padding_suss
+                dist_suss, index_suss, l_index_suss, r_index_suss = self.matrix_profile_suss[
+                    suss_idx
+                ]
+                mp_suss = {
+                    "dist": dist_suss,
+                    "idx": index_suss,
+                    "l_idx": l_index_suss,
+                    "r_idx": r_index_suss,
+                }
+
+            mp_fixed = None
+            if i >= padding_fixed:
+                fixed_idx = i - padding_fixed
+                dist_fixed, index_fixed, l_index_fixed, r_index_fixed = self.matrix_profile_fixed[
+                    fixed_idx
+                ]
+                mp_fixed = {
+                    "dist": dist_fixed,
+                    "idx": index_fixed,
+                    "l_idx": l_index_fixed,
+                    "r_idx": r_index_fixed,
+                }
+            # TODO: Confirm that these indexes are correct
             original_flag = self.original_flags[i] if i < len(self.original_flags) else "none"
+            use_suss = self.use_suss[i] if i < len(self.use_suss) else True
+
             algo_data.append(
                 {
-                    "dist": dist,
-                    "idx": index,
-                    "l_idx": l_index,
-                    "r_idx": r_index,
+                    "mp_suss": mp_suss,
+                    "mp_fixed": mp_fixed,
                     "original_flag": original_flag,
+                    "use_suss": use_suss,
                 }
             )
 
@@ -72,10 +116,38 @@ class MPTimeSeriesAnomalies(TimeSeriesAnomalies):
 
     @staticmethod
     def extract_algo_data(map: dict):
-        return (
-            map.get("dist"),
-            map.get("idx"),
-            map.get("l_idx"),
-            map.get("r_idx"),
-            map.get("original_flag"),
+        # Matrix profile for SuSS and fixed windows could be None so much check for that
+        mp_suss = (
+            {
+                "dist": map.get("dist_suss"),
+                "idx": map.get("idx_suss"),
+                "l_idx": map.get("l_idx_suss"),
+                "r_idx": map.get("r_idx_suss"),
+            }
+            if any(
+                map.get(key) is not None
+                for key in ["dist_suss", "idx_suss", "l_idx_suss", "r_idx_suss"]
+            )
+            else None
         )
+
+        mp_fixed = (
+            {
+                "dist": map.get("dist_fixed"),
+                "idx": map.get("idx_fixed"),
+                "l_idx": map.get("l_idx_fixed"),
+                "r_idx": map.get("r_idx_fixed"),
+            }
+            if any(
+                map.get(key) is not None
+                for key in ["dist_fixed", "idx_fixed", "l_idx_fixed", "r_idx_fixed"]
+            )
+            else None
+        )
+
+        return {
+            "mp_suss": mp_suss,
+            "mp_fixed": mp_fixed,
+            "original_flag": map.get("original_flag"),
+            "use_suss": map.get("use_suss", True),
+        }

--- a/src/seer/anomaly_detection/models/timeseries_anomalies.py
+++ b/src/seer/anomaly_detection/models/timeseries_anomalies.py
@@ -171,25 +171,37 @@ class MPTimeSeriesAnomalies(TimeSeriesAnomalies):
     @staticmethod
     def extract_algo_data(map: dict):
         # Matrix profile for SuSS and fixed windows could be None so we check for that
-        mp_suss_data = map.get("mp_suss")
-        mp_suss = None
-        if mp_suss_data is not None:
-            mp_suss = {
-                "dist": mp_suss_data.get("dist"),
-                "idx": mp_suss_data.get("idx"),
-                "l_idx": mp_suss_data.get("l_idx"),
-                "r_idx": mp_suss_data.get("r_idx"),
-            }
 
-        mp_fixed_data = map.get("mp_fixed")
+        mp_suss = None
         mp_fixed = None
-        if mp_fixed_data is not None:
-            mp_fixed = {
-                "dist": mp_fixed_data.get("dist"),
-                "idx": mp_fixed_data.get("idx"),
-                "l_idx": mp_fixed_data.get("l_idx"),
-                "r_idx": mp_fixed_data.get("r_idx"),
+        # Indicating older algo_data format
+        if "dist" in map:
+            mp_suss = {
+                "dist": map.get("dist"),
+                "idx": map.get("idx"),
+                "l_idx": map.get("l_idx"),
+                "r_idx": map.get("r_idx"),
             }
+        else:
+            mp_suss_data = map.get("mp_suss")
+
+            if mp_suss_data is not None:
+                mp_suss = {
+                    "dist": mp_suss_data.get("dist"),
+                    "idx": mp_suss_data.get("idx"),
+                    "l_idx": mp_suss_data.get("l_idx"),
+                    "r_idx": mp_suss_data.get("r_idx"),
+                }
+
+            mp_fixed_data = map.get("mp_fixed")
+
+            if mp_fixed_data is not None:
+                mp_fixed = {
+                    "dist": mp_fixed_data.get("dist"),
+                    "idx": mp_fixed_data.get("idx"),
+                    "l_idx": mp_fixed_data.get("l_idx"),
+                    "r_idx": mp_fixed_data.get("r_idx"),
+                }
 
         return {
             "mp_suss": mp_suss,

--- a/src/seer/anomaly_detection/models/timeseries_anomalies.py
+++ b/src/seer/anomaly_detection/models/timeseries_anomalies.py
@@ -172,27 +172,25 @@ class MPTimeSeriesAnomalies(TimeSeriesAnomalies):
     @staticmethod
     def extract_algo_data(map: dict):
         # Matrix profile for SuSS and fixed windows could be None so we check for that
-        mp_suss = (
-            {
-                "dist": map.get("mp_suss").get("dist"),
-                "idx": map.get("mp_suss").get("idx"),
-                "l_idx": map.get("mp_suss").get("l_idx"),
-                "r_idx": map.get("mp_suss").get("r_idx"),
+        mp_suss_data = map.get("mp_suss")
+        mp_suss = None
+        if mp_suss_data is not None:
+            mp_suss = {
+                "dist": mp_suss_data.get("dist"),
+                "idx": mp_suss_data.get("idx"),
+                "l_idx": mp_suss_data.get("l_idx"),
+                "r_idx": mp_suss_data.get("r_idx"),
             }
-            if map.get("mp_suss") is not None
-            else None
-        )
 
-        mp_fixed = (
-            {
-                "dist": map.get("mp_fixed").get("dist"),
-                "idx": map.get("mp_fixed").get("idx"),
-                "l_idx": map.get("mp_fixed").get("l_idx"),
-                "r_idx": map.get("mp_fixed").get("r_idx"),
+        mp_fixed_data = map.get("mp_fixed")
+        mp_fixed = None
+        if mp_fixed_data is not None:
+            mp_fixed = {
+                "dist": mp_fixed_data.get("dist"),
+                "idx": mp_fixed_data.get("idx"),
+                "l_idx": mp_fixed_data.get("l_idx"),
+                "r_idx": mp_fixed_data.get("r_idx"),
             }
-            if map.get("mp_fixed") is not None
-            else None
-        )
 
         return {
             "mp_suss": mp_suss,

--- a/src/seer/anomaly_detection/models/timeseries_anomalies.py
+++ b/src/seer/anomaly_detection/models/timeseries_anomalies.py
@@ -58,7 +58,7 @@ class MPTimeSeriesAnomalies(TimeSeriesAnomalies):
     )
 
     use_suss: list[bool] = Field(
-        ..., description="Whether the SuSS window was used to detect anomalies"
+        default=[], description="Whether the SuSS window was used to detect anomalies"
     )
 
     def get_anomaly_algo_data(self, front_pad_to_len: int) -> List[Optional[Dict]]:

--- a/src/seer/anomaly_detection/models/timeseries_anomalies.py
+++ b/src/seer/anomaly_detection/models/timeseries_anomalies.py
@@ -154,7 +154,6 @@ class MPTimeSeriesAnomalies(TimeSeriesAnomalies):
                     "l_idx": l_index_fixed,
                     "r_idx": r_index_fixed,
                 }
-            # TODO: Confirm that these indexes are correct
             original_flag = self.original_flags[i] if i < len(self.original_flags) else "none"
             use_suss = self.use_suss[i] if i < len(self.use_suss) else True
 

--- a/src/seer/anomaly_detection/models/timeseries_anomalies.py
+++ b/src/seer/anomaly_detection/models/timeseries_anomalies.py
@@ -126,9 +126,6 @@ class MPTimeSeriesAnomalies(TimeSeriesAnomalies):
         algo_data = [None] * min(padding_suss, padding_fixed)
 
         for i in range(min(padding_suss, padding_fixed), front_pad_to_len):
-            # if algo_data[i] is None:
-            #     continue
-
             mp_suss = None
             if i >= padding_suss:
                 suss_idx = i - padding_suss
@@ -155,7 +152,7 @@ class MPTimeSeriesAnomalies(TimeSeriesAnomalies):
                     "r_idx": r_index_fixed,
                 }
             original_flag = self.original_flags[i] if i < len(self.original_flags) else "none"
-            use_suss = self.use_suss[i] if i < len(self.use_suss) else True
+            use_suss = self.use_suss[len(self.use_suss) - front_pad_to_len + i]
 
             algo_data.append(
                 {

--- a/src/seer/anomaly_detection/tasks.py
+++ b/src/seer/anomaly_detection/tasks.py
@@ -70,6 +70,7 @@ def delete_old_timeseries_points(alert: DbDynamicAlert, date_threshold: float):
     return deleted_count
 
 
+# TODO: Update to use the new anomaly_algo_data and to use SuSS and fixed windows
 def update_matrix_profiles(alert: DbDynamicAlert, anomaly_detection_config: AnomalyDetectionConfig):
 
     timeseries = TimeSeries(

--- a/src/seer/anomaly_detection/tasks.py
+++ b/src/seer/anomaly_detection/tasks.py
@@ -70,7 +70,6 @@ def delete_old_timeseries_points(alert: DbDynamicAlert, date_threshold: float):
     return deleted_count
 
 
-# TODO: Update to use the new anomaly_algo_data and to use SuSS and fixed windows
 def update_matrix_profiles(alert: DbDynamicAlert, anomaly_detection_config: AnomalyDetectionConfig):
 
     timeseries = TimeSeries(

--- a/src/seer/db.py
+++ b/src/seer/db.py
@@ -338,7 +338,6 @@ class DbDynamicAlertTimeSeries(Base):
         "DbDynamicAlert",
         back_populates="timeseries",
     )
-    # reported_anomaly: Mapped[str] = mapped_column(String, nullable=False)
 
     def __str__(self):
         return f"timstamp: {self.timestamp}, value: {self.value}, anomaly_type:{self.anomaly_type}"

--- a/src/seer/db.py
+++ b/src/seer/db.py
@@ -338,6 +338,7 @@ class DbDynamicAlertTimeSeries(Base):
         "DbDynamicAlert",
         back_populates="timeseries",
     )
+    # reported_anomaly: Mapped[str] = mapped_column(String, nullable=False)
 
     def __str__(self):
         return f"timstamp: {self.timestamp}, value: {self.value}, anomaly_type:{self.anomaly_type}"

--- a/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
+++ b/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
@@ -14,7 +14,7 @@ from seer.anomaly_detection.detectors.anomaly_detectors import (
     MPBatchAnomalyDetector,
     MPStreamAnomalyDetector,
 )
-from seer.anomaly_detection.models import MPTimeSeriesAnomalies
+from seer.anomaly_detection.models import MPTimeSeriesAnomaliesSingleWindow
 from seer.anomaly_detection.models.external import AnomalyDetectionConfig
 from seer.anomaly_detection.models.timeseries import TimeSeries
 from seer.exceptions import ServerError
@@ -76,7 +76,7 @@ class TestMPBatchAnomalyDetector(unittest.TestCase):
             mp_utils=self.mp_utils,
         )
 
-        assert isinstance(result, MPTimeSeriesAnomalies)
+        assert isinstance(result, MPTimeSeriesAnomaliesSingleWindow)
         assert isinstance(result.flags, list)
         assert result.scores == [0.1, 6.5, 4.8, 0.2]
         assert isinstance(result.scores, list)
@@ -171,7 +171,7 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
 
         anomalies = self.detector.detect(self.timeseries, self.config, mock_scorer, mock_utils)
 
-        assert isinstance(anomalies, MPTimeSeriesAnomalies)
+        assert isinstance(anomalies, MPTimeSeriesAnomaliesSingleWindow)
         assert isinstance(anomalies.flags, list)
         assert isinstance(anomalies.scores, list)
         assert isinstance(anomalies.matrix_profile, np.ndarray)

--- a/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
+++ b/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
@@ -242,7 +242,7 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
             "anomaly_higher_confidence",
         ]
         history_anomalies, stream_anomalies = self._detect_anomalies(history_ts, stream_ts)
-        print(f"test_stream_detect_spiked_history_spiked_stream_long_ts: {stream_anomalies.flags}")
+        # print(f"test_stream_detect_spiked_history_spiked_stream_long_ts: {stream_anomalies.flags}")
         assert stream_anomalies.flags == expected_stream_flags
         # assert stream_anomalies.flags[2] == "anomaly_higher_confidence"
         # # Fourth and fifth may or may not be flagged depending on prophet's prediction which has some randomness
@@ -269,7 +269,7 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
             "none",
             "none",
         ]
-        print(f"test_stream_detect_spiked_history_spiked_stream: {stream_anomalies.flags}")
+        # print(f"test_stream_detect_spiked_history_spiked_stream: {stream_anomalies.flags}")
         assert history_anomalies.window_size == 3
         assert stream_anomalies.flags == expected_stream_flags
         # assert stream_anomalies.flags[0] == "none"
@@ -312,7 +312,6 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
         ]
 
         history_anomalies, stream_anomalies = self._detect_anomalies(history_ts, stream_ts)
-        print(f"test_stream_detect_flat_history_spiked_stream: {stream_anomalies.flags}")
         assert history_anomalies.window_size == 3
         assert stream_anomalies.flags == expected_stream_flags
         # assert stream_anomalies.flags[0] == "none"

--- a/tests/seer/anomaly_detection/models/test_timeseries.py
+++ b/tests/seer/anomaly_detection/models/test_timeseries.py
@@ -15,9 +15,12 @@ class TestTimeSeries(unittest.TestCase):
             anomalies=MPTimeSeriesAnomalies(
                 flags=["none"],
                 scores=[0.8],
-                matrix_profile=np.array([[0.1, 0, 1, 2]]),
+                matrix_profile_suss=np.array([[0.1, 0, 1, 2]]),
+                matrix_profile_fixed=np.array([[0.1, 0, 1, 2]]),
                 window_size=2,
                 thresholds=[0.0],
+                original_flags=["none"],
+                use_suss=[True],
             ),
         )
 

--- a/tests/seer/anomaly_detection/models/test_timeseries_anomalies.py
+++ b/tests/seer/anomaly_detection/models/test_timeseries_anomalies.py
@@ -11,9 +11,12 @@ class TestConverters(unittest.TestCase):
         self.anomalies = MPTimeSeriesAnomalies(
             flags=["none", "none"],
             scores=[0.8, 0.9],
-            matrix_profile=np.array([[0.1, 0, 1, 2], [0.2, 1, 2, 3]]),
+            matrix_profile_suss=np.array([[0.1, 0, 1, 2], [0.3, 1, 2, 3]]),
+            matrix_profile_fixed=np.array([[0.2, 1, 2, 3], [0.4, 2, 3, 4]]),
             window_size=2,
             thresholds=[0.0, 0.0],
+            original_flags=["none", "none"],
+            use_suss=[True, True],
         )
 
     def test_get_anomaly_algo_data_with_padding(self):
@@ -23,8 +26,18 @@ class TestConverters(unittest.TestCase):
             None,
             None,
             None,
-            {"dist": 0.1, "idx": 0, "l_idx": 1, "r_idx": 2, "original_flag": "none"},
-            {"dist": 0.2, "idx": 1, "l_idx": 2, "r_idx": 3, "original_flag": "none"},
+            {
+                "mp_suss": {"dist": 0.1, "idx": 0, "l_idx": 1, "r_idx": 2},
+                "mp_fixed": {"dist": 0.2, "idx": 1, "l_idx": 2, "r_idx": 3},
+                "original_flag": "none",
+                "use_suss": True,
+            },
+            {
+                "mp_suss": {"dist": 0.3, "idx": 1, "l_idx": 2, "r_idx": 3},
+                "mp_fixed": {"dist": 0.4, "idx": 2, "l_idx": 3, "r_idx": 4},
+                "original_flag": "none",
+                "use_suss": True,
+            },
         ]
 
         algo_data = self.anomalies.get_anomaly_algo_data(front_pad_to_len)
@@ -35,8 +48,18 @@ class TestConverters(unittest.TestCase):
         # Test with front_pad_to_len equal to the length of matrix_profile
         front_pad_to_len = 2
         expected_data = [
-            {"dist": 0.1, "idx": 0, "l_idx": 1, "r_idx": 2, "original_flag": "none"},
-            {"dist": 0.2, "idx": 1, "l_idx": 2, "r_idx": 3, "original_flag": "none"},
+            {
+                "mp_suss": {"dist": 0.1, "idx": 0, "l_idx": 1, "r_idx": 2},
+                "mp_fixed": {"dist": 0.2, "idx": 1, "l_idx": 2, "r_idx": 3},
+                "original_flag": "none",
+                "use_suss": True,
+            },
+            {
+                "mp_suss": {"dist": 0.3, "idx": 1, "l_idx": 2, "r_idx": 3},
+                "mp_fixed": {"dist": 0.4, "idx": 2, "l_idx": 3, "r_idx": 4},
+                "original_flag": "none",
+                "use_suss": True,
+            },
         ]
 
         algo_data = self.anomalies.get_anomaly_algo_data(front_pad_to_len)

--- a/tests/seer/anomaly_detection/test_accessors.py
+++ b/tests/seer/anomaly_detection/test_accessors.py
@@ -22,9 +22,12 @@ class TestDbAlertDataAccessor(unittest.TestCase):
         anomalies = MPTimeSeriesAnomalies(
             flags=["none", "none"],
             scores=[1.0, 0.95],
-            matrix_profile=np.array([[1.0, 10, -1, -1], [1.5, 15, -1, -1]]),
+            matrix_profile_suss=np.array([[1.0, 10, -1, -1], [1.5, 15, -1, -1]]),
+            matrix_profile_fixed=np.array([[1.0, 10, -1, -1], [1.5, 15, -1, -1]]),
             window_size=1,
             thresholds=[0.0, 0.0],
+            original_flags=["none", "none"],
+            use_suss=[True, True],
         )
         # Verify saving
         alert_data_accessor = DbAlertDataAccessor()
@@ -122,10 +125,12 @@ class TestDbAlertDataAccessor(unittest.TestCase):
             anomaly=MPTimeSeriesAnomalies(
                 flags=["none"],
                 scores=[0.8],
-                matrix_profile=np.array([[1.0, 10, -1, -1]]),
+                matrix_profile_suss=np.array([[1.0, 10, -1, -1]]),
+                matrix_profile_fixed=np.array([[1.0, 10, -1, -1]]),
                 window_size=1,
                 thresholds=[0.0],
                 original_flags=["none"],
+                use_suss=[True],
             ),
             anomaly_algo_data={"dummy": 10},
         )
@@ -154,9 +159,12 @@ class TestDbAlertDataAccessor(unittest.TestCase):
             anomalies=MPTimeSeriesAnomalies(
                 flags=["none"],
                 scores=[1.0],
-                matrix_profile=np.array([[1.0, 10, -1, -1]]),
+                matrix_profile_suss=np.array([[1.0, 10, -1, -1]]),
+                matrix_profile_fixed=np.array([[1.0, 10, -1, -1]]),
                 window_size=1,
                 thresholds=[0.0],
+                original_flags=["none"],
+                use_suss=[True],
             ),
             anomaly_algo_data={"window_size": 1},
             data_purge_flag=TaskStatus.NOT_QUEUED,
@@ -234,10 +242,12 @@ class TestDbAlertDataAccessor(unittest.TestCase):
         anomalies = MPTimeSeriesAnomalies(
             flags=["none"] * 5,
             scores=[1.0] * 5,
-            matrix_profile=np.array([[1.0, 10, -1, -1]] * 5),
+            matrix_profile_suss=np.array([[1.0, 10, -1, -1]] * 5),
+            matrix_profile_fixed=np.array([[1.0, 10, -1, -1]] * 5),
             window_size=1,
             thresholds=[0.0] * 5,
             original_flags=["none", "none"],
+            use_suss=[True, True],
         )
 
         alert_data_accessor = DbAlertDataAccessor()
@@ -282,9 +292,12 @@ class TestDbAlertDataAccessor(unittest.TestCase):
         anomalies = MPTimeSeriesAnomalies(
             flags=["none", "none"],
             scores=[1.0, 0.95],
-            matrix_profile=np.array([[1.0, 10, -1, -1], [1.5, 15, -1, -1]]),
+            matrix_profile_suss=np.array([[1.0, 10, -1, -1], [1.5, 15, -1, -1]]),
+            matrix_profile_fixed=np.array([[1.0, 10, -1, -1], [1.5, 15, -1, -1]]),
             window_size=1,
             thresholds=[0.0, 0.0],
+            original_flags=["none", "none"],
+            use_suss=[True, True],
         )
         alert_data_accessor = DbAlertDataAccessor()
         alert_data_accessor.save_alert(
@@ -331,9 +344,12 @@ class TestDbAlertDataAccessor(unittest.TestCase):
         anomalies = MPTimeSeriesAnomalies(
             flags=["none", "none"],
             scores=[1.0, 0.95],
-            matrix_profile=np.array([[1.0, 10, -1, -1], [1.5, 15, -1, -1]]),
+            matrix_profile_suss=np.array([[1.0, 10, -1, -1], [1.5, 15, -1, -1]]),
+            matrix_profile_fixed=np.array([[1.0, 10, -1, -1], [1.5, 15, -1, -1]]),
             window_size=1,
             thresholds=[0.0, 0.0],
+            original_flags=["none", "none"],
+            use_suss=[True, True],
         )
         alert_data_accessor = DbAlertDataAccessor()
         alert_data_accessor.save_alert(
@@ -381,9 +397,12 @@ class TestDbAlertDataAccessor(unittest.TestCase):
         anomalies = MPTimeSeriesAnomalies(
             flags=["none", "none"],
             scores=[1.0, 0.95],
-            matrix_profile=np.array([[1.0, 10, -1, -1], [1.5, 15, -1, -1]]),
+            matrix_profile_suss=np.array([[1.0, 10, -1, -1], [1.5, 15, -1, -1]]),
+            matrix_profile_fixed=np.array([[1.0, 10, -1, -1], [1.5, 15, -1, -1]]),
             window_size=1,
             thresholds=[0.0, 0.0],
+            original_flags=["none", "none"],
+            use_suss=[True, True],
         )
         alert_data_accessor = DbAlertDataAccessor()
         alert_data_accessor.save_alert(
@@ -424,9 +443,12 @@ class TestDbAlertDataAccessor(unittest.TestCase):
         anomalies = MPTimeSeriesAnomalies(
             flags=["none", "none"],
             scores=[1.0, 0.95],
-            matrix_profile=np.array([[1.0, 10, -1, -1], [1.5, 15, -1, -1]]),
+            matrix_profile_suss=np.array([[1.0, 10, -1, -1], [1.5, 15, -1, -1]]),
+            matrix_profile_fixed=np.array([[1.0, 10, -1, -1], [1.5, 15, -1, -1]]),
             window_size=1,
             thresholds=[0.0, 0.0],
+            original_flags=["none", "none"],
+            use_suss=[True, True],
         )
         alert_data_accessor = DbAlertDataAccessor()
         alert_data_accessor.save_alert(

--- a/tests/seer/anomaly_detection/test_accessors.py
+++ b/tests/seer/anomaly_detection/test_accessors.py
@@ -301,8 +301,8 @@ class TestDbAlertDataAccessor(unittest.TestCase):
         anomalies = MPTimeSeriesAnomalies(
             flags=["none"] * 5,
             scores=[1.0] * 5,
-            matrix_profile_suss=np.array([[1.0, 10, -1, -1]] * 5),
-            matrix_profile_fixed=np.array([[1.0, 10, -1, -1]] * 5),
+            matrix_profile_suss=np.array([[1.0, 10, -1, -1]] * 2),
+            matrix_profile_fixed=np.array([[1.0, 10, -1, -1]] * 2),
             window_size=1,
             thresholds=[0.0] * 5,
             original_flags=["none", "none"],
@@ -335,6 +335,13 @@ class TestDbAlertDataAccessor(unittest.TestCase):
             alert_from_db.anomalies.original_flags,
             expected_flags,
             "Original flags should be padded with 'none' at the start",
+        )
+
+        expected_use_suss = [True] * 3 + [True, True]
+        self.assertEqual(
+            alert_from_db.anomalies.use_suss,
+            expected_use_suss,
+            "Use suss should be padded with True at the start",
         )
 
     def test_queue_data_purge_flag(self):

--- a/tests/seer/anomaly_detection/test_anomaly_detection.py
+++ b/tests/seer/anomaly_detection/test_anomaly_detection.py
@@ -5,7 +5,11 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 
 from seer.anomaly_detection.anomaly_detection import AnomalyDetection
-from seer.anomaly_detection.models import DynamicAlert, MPTimeSeries
+from seer.anomaly_detection.models import (
+    DynamicAlert,
+    MPTimeSeries,
+    MPTimeSeriesAnomaliesSingleWindow,
+)
 from seer.anomaly_detection.models.cleanup import CleanupConfig
 from seer.anomaly_detection.models.external import (
     AlertInSeer,
@@ -81,7 +85,12 @@ class TestAnomalyDetection(unittest.TestCase):
     @patch("seer.anomaly_detection.accessors.DbAlertDataAccessor.query")
     @patch("seer.anomaly_detection.accessors.DbAlertDataAccessor.save_timepoint")
     @patch("seer.anomaly_detection.accessors.DbAlertDataAccessor.reset_cleanup_task")
-    def test_detect_anomalies_online(self, mock_reset_cleanup, mock_save_timepoint, mock_query):
+    def test_detect_anomalies_online(
+        self,
+        mock_reset_cleanup,
+        mock_save_timepoint,
+        mock_query,
+    ):
 
         fixed_window_size = 10
 
@@ -218,6 +227,122 @@ class TestAnomalyDetection(unittest.TestCase):
         with self.assertRaises(ServerError) as e:
             AnomalyDetection().detect_anomalies(request=request)
         assert "Invalid state" in str(e.exception)
+
+    @patch("seer.anomaly_detection.detectors.MPStreamAnomalyDetector.detect")
+    @patch("seer.anomaly_detection.accessors.DbAlertDataAccessor.query")
+    @patch("seer.anomaly_detection.accessors.DbAlertDataAccessor.save_timepoint")
+    @patch("seer.anomaly_detection.accessors.DbAlertDataAccessor.reset_cleanup_task")
+    def test_detect_anomalies_online_switch_window(
+        self, mock_reset_cleanup, mock_save_timepoint, mock_query, mock_stream_detector
+    ):
+
+        fixed_window_size = 10
+
+        config = AnomalyDetectionConfig(
+            time_period=15, sensitivity="low", direction="both", expected_seasonality="auto"
+        )
+
+        cleanup_config = CleanupConfig(
+            num_old_points=0, timestamp_threshold=0, num_acceptable_points=0
+        )
+
+        loaded_synthetic_data = convert_synthetic_ts(
+            "tests/seer/anomaly_detection/test_data/synthetic_series", as_ts_datatype=False
+        )
+        ts_values = loaded_synthetic_data.timeseries[0]
+        ts_timestamps = np.arange(1, len(ts_values) + 1) + datetime.now().timestamp()
+        window_size = loaded_synthetic_data.window_sizes[0]
+
+        dummy_mp_suss = np.ones((len(ts_values) - window_size + 1, 4))
+        dummy_mp_fixed = np.ones((len(ts_values) - fixed_window_size + 1, 4))
+
+        print(dummy_mp_suss)
+        print()
+        print(dummy_mp_fixed)
+
+        mock_query.return_value = DynamicAlert(
+            organization_id=0,
+            project_id=0,
+            external_alert_id=0,
+            config=config,
+            timeseries=MPTimeSeries(
+                timestamps=ts_timestamps,
+                values=ts_values,
+            ),
+            anomalies=MPTimeSeriesAnomalies(
+                flags=np.array(["anomaly_higher_confidence"] * len(ts_timestamps)),
+                scores=np.array([0.4] * len(ts_timestamps)),
+                matrix_profile_suss=dummy_mp_suss,
+                matrix_profile_fixed=dummy_mp_fixed,
+                window_size=window_size,
+                thresholds=np.array([0.0] * len(ts_timestamps)),
+                original_flags=np.array(["none"] * len(ts_timestamps)),
+                use_suss=np.array([False] * len(ts_timestamps)),
+            ),
+            cleanup_config=cleanup_config,
+            only_suss=False,
+        )
+
+        # Dummy return so we don't hit db
+        mock_save_timepoint.return_value = ""
+        mock_reset_cleanup.return_value = ""
+
+        # Can return back to the SuSS window after using the fixed window
+        mock_stream_detector.return_value = MPTimeSeriesAnomaliesSingleWindow(
+            flags=["none"] * len(ts_timestamps),
+            scores=[0.0] * len(ts_timestamps),
+            matrix_profile=dummy_mp_suss,
+            window_size=window_size,
+            thresholds=[0.0] * len(ts_timestamps),
+            original_flags=["none"] * len(ts_timestamps),
+        )
+
+        new_timestamp = len(ts_values) + datetime.now().timestamp() + 1
+        context = AlertInSeer(id=0, cur_window=TimeSeriesPoint(timestamp=new_timestamp, value=0.5))
+
+        request = DetectAnomaliesRequest(
+            organization_id=0, project_id=0, config=config, context=context
+        )
+        response = AnomalyDetection().detect_anomalies(request=request)
+
+        assert mock_stream_detector.call_count == 2
+        assert isinstance(response, DetectAnomaliesResponse)
+        assert isinstance(response.timeseries, list)
+        assert len(response.timeseries) == 1  # Checking just 1 streamed value
+        assert isinstance(response.timeseries[0], TimeSeriesPoint)
+        assert response.timeseries[0].timestamp == new_timestamp
+
+        mock_query.return_value = DynamicAlert(
+            organization_id=0,
+            project_id=0,
+            external_alert_id=0,
+            config=config,
+            timeseries=MPTimeSeries(
+                timestamps=ts_timestamps,
+                values=ts_values,
+            ),
+            anomalies=MPTimeSeriesAnomalies(
+                flags=np.array(["anomaly_higher_confidence"] * len(ts_timestamps)),
+                scores=np.array([0.4] * len(ts_timestamps)),
+                matrix_profile_suss=dummy_mp_suss,
+                matrix_profile_fixed=dummy_mp_fixed,
+                window_size=window_size,
+                thresholds=np.array([0.0] * len(ts_timestamps)),
+                original_flags=np.array(["none"] * len(ts_timestamps)),
+                use_suss=np.array([True] * len(ts_timestamps)),
+            ),
+            cleanup_config=cleanup_config,
+            only_suss=True,
+        )
+
+        response = AnomalyDetection().detect_anomalies(request=request)
+
+        assert mock_stream_detector.call_count == 3
+        assert isinstance(response, DetectAnomaliesResponse)
+        assert isinstance(response.timeseries, list)
+        assert len(response.timeseries) == 1  # Checking just 1 streamed value
+        assert isinstance(response.timeseries[0], TimeSeriesPoint)
+        assert response.timeseries[0].timestamp == new_timestamp
 
     def test_detect_anomalies_combo(self):
 

--- a/tests/seer/anomaly_detection/test_anomaly_detection.py
+++ b/tests/seer/anomaly_detection/test_anomaly_detection.py
@@ -123,6 +123,7 @@ class TestAnomalyDetection(unittest.TestCase):
                 use_suss=np.array([True] * len(ts_timestamps)),
             ),
             cleanup_config=cleanup_config,
+            only_suss=False,
         )
 
         # Dummy return so we don't hit db
@@ -166,6 +167,7 @@ class TestAnomalyDetection(unittest.TestCase):
                 use_suss=np.array([True] * len(ts_timestamps[:100])),
             ),
             cleanup_config=cleanup_config,
+            only_suss=False,
         )
 
         with self.assertRaises(Exception):
@@ -210,6 +212,7 @@ class TestAnomalyDetection(unittest.TestCase):
                 use_suss=[True] * len(ts_timestamps),
             ),
             cleanup_config=cleanup_config,
+            only_suss=False,
         )
 
         with self.assertRaises(ServerError) as e:

--- a/tests/seer/anomaly_detection/test_anomaly_detection.py
+++ b/tests/seer/anomaly_detection/test_anomaly_detection.py
@@ -256,10 +256,6 @@ class TestAnomalyDetection(unittest.TestCase):
         dummy_mp_suss = np.ones((len(ts_values) - window_size + 1, 4))
         dummy_mp_fixed = np.ones((len(ts_values) - fixed_window_size + 1, 4))
 
-        print(dummy_mp_suss)
-        print()
-        print(dummy_mp_fixed)
-
         mock_query.return_value = DynamicAlert(
             organization_id=0,
             project_id=0,

--- a/tests/seer/anomaly_detection/test_anomaly_detection.py
+++ b/tests/seer/anomaly_detection/test_anomaly_detection.py
@@ -112,10 +112,12 @@ class TestAnomalyDetection(unittest.TestCase):
             anomalies=MPTimeSeriesAnomalies(
                 flags=np.array(["anomaly_higher_confidence"] * len(ts_timestamps)),
                 scores=np.array([0.4] * len(ts_timestamps)),
-                matrix_profile=dummy_mp,
+                matrix_profile_suss=dummy_mp,
+                matrix_profile_fixed=dummy_mp,
                 window_size=window_size,
                 thresholds=np.array([0.0] * len(ts_timestamps)),
                 original_flags=np.array(["none"] * len(ts_timestamps)),
+                use_suss=np.array([True] * len(ts_timestamps)),
             ),
             cleanup_config=cleanup_config,
         )
@@ -195,10 +197,12 @@ class TestAnomalyDetection(unittest.TestCase):
             anomalies=MPTimeSeriesAnomalies(
                 flags=["none"] * len(ts_timestamps),
                 scores=[0.0] * len(ts_timestamps),
-                matrix_profile=dummy_mp,
+                matrix_profile_suss=dummy_mp,
+                matrix_profile_fixed=dummy_mp,
                 window_size=window_size,
                 thresholds=[0.0] * len(ts_timestamps),
                 original_flags=["none"] * (len(ts_timestamps) - 1),  # One less than timestamps
+                use_suss=[True] * len(ts_timestamps),
             ),
             cleanup_config=cleanup_config,
         )

--- a/tests/seer/anomaly_detection/test_cleanup_tasks.py
+++ b/tests/seer/anomaly_detection/test_cleanup_tasks.py
@@ -43,9 +43,12 @@ class TestCleanupTasks(unittest.TestCase):
             anomalies = MPTimeSeriesAnomalies(
                 flags=np.array([]),
                 scores=np.array([]),
-                matrix_profile=np.array([]),
+                matrix_profile_suss=np.array([]),
+                matrix_profile_fixed=np.array([]),
                 window_size=0,
                 thresholds=np.array([]),
+                original_flags=np.array([]),
+                use_suss=np.array([]),
             )
         else:
             anomalies = MPBatchAnomalyDetector().detect(ts, config)

--- a/tests/seer/anomaly_detection/test_cleanup_tasks.py
+++ b/tests/seer/anomaly_detection/test_cleanup_tasks.py
@@ -152,9 +152,6 @@ class TestCleanupTasks(unittest.TestCase):
                 assert new.timestamp.timestamp() > date_threshold
                 assert old.timestamp == new.timestamp
                 assert old.value == new.value
-                print(new.anomaly_algo_data)
-                print(algo_data)
-                print()
                 if new.anomaly_algo_data is not None and algo_data is None:
                     assert new.anomaly_algo_data["mp_suss"] is None
                     assert (

--- a/tests/seer/anomaly_detection/test_cleanup_tasks.py
+++ b/tests/seer/anomaly_detection/test_cleanup_tasks.py
@@ -152,7 +152,32 @@ class TestCleanupTasks(unittest.TestCase):
                 assert new.timestamp.timestamp() > date_threshold
                 assert old.timestamp == new.timestamp
                 assert old.value == new.value
-                assert new.anomaly_algo_data == algo_data
+                print(new.anomaly_algo_data)
+                print(algo_data)
+                print()
+                if new.anomaly_algo_data is not None and algo_data is None:
+                    assert new.anomaly_algo_data["mp_suss"] is None
+                    assert (
+                        "dist" in new.anomaly_algo_data["mp_fixed"]
+                        and "idx" in new.anomaly_algo_data["mp_fixed"]
+                        and "l_idx" in new.anomaly_algo_data["mp_fixed"]
+                        and "r_idx" in new.anomaly_algo_data["mp_fixed"]
+                    )
+
+                if new.anomaly_algo_data is not None and algo_data is not None:
+                    assert (
+                        new.anomaly_algo_data["mp_suss"]["dist"] == algo_data["dist"]
+                        and new.anomaly_algo_data["mp_suss"]["idx"] == algo_data["idx"]
+                        and new.anomaly_algo_data["mp_suss"]["l_idx"] == algo_data["l_idx"]
+                        and new.anomaly_algo_data["mp_suss"]["r_idx"] == algo_data["r_idx"]
+                    )
+                    assert new.anomaly_algo_data["original_flag"] == algo_data["original_flag"]
+                    assert (
+                        "dist" in new.anomaly_algo_data["mp_fixed"]
+                        and "idx" in new.anomaly_algo_data["mp_fixed"]
+                        and "l_idx" in new.anomaly_algo_data["mp_fixed"]
+                        and "r_idx" in new.anomaly_algo_data["mp_fixed"]
+                    )
 
         # Fails due to invalid alert_id
         with self.assertRaises(Exception):


### PR DESCRIPTION
Please review the [validation notebook](https://github.com/getsentry/ml-models/blob/main/anomaly_detection/validation.ipynb) for examples of the dynamic window in action!

- Use 2 windows (1 determined by the SuSS algorithm, and a "fixed" window at size 10) to perform detection reducing the recovery time for the algorithm ultimately making alerts persist for a shorter period of time after anomalous behavior is over
- Performing detection twice for each window to maintain the matrix profiles
- Updated the `anomaly_algo_data` to store matrix profile related information for both windows for a given alert
- Created `MPTimeSeriesAnomaliesSingleWindow` class and updated the `MPTimeSeriesAnomalies` class to effectively manage and store the proper matrix profile related information and the boolean for determining which window logic to use
- Recalculates both matrix profiles and update the respective rows if they are not present to ensure backwards compatibility with the older `MPTimeSeriesAnomalies` class 
- Updated current tests to match the new classes and their fields along with shapes for `anomaly_algo_data`