### PR TITLE
feat(anomaly detection): Cron to cleanup disabled alerts

### DIFF
--- a/src/seer/anomaly_detection/tasks.py
+++ b/src/seer/anomaly_detection/tasks.py
@@ -117,11 +117,11 @@ def toggle_data_purge_flag(alert_id: int):
 @sentry_sdk.trace
 def cleanup_disabled_alerts():
 
-    logger.info(
-        "Cleaning up timeseries data for alerts that have been inactive (detection has not been run) for over 28 days"
-    )
-
     date_threshold = datetime.now() - timedelta(days=28)
+
+    logger.info(
+        f"Cleaning up timeseries data for alerts that have been inactive (detection has not been run) since {date_threshold}"
+    )
 
     with Session() as session:
         # Get and delete alerts that haven't been queued for detection in the last 28 days indicating that they are disabled and are safe to cleanup

--- a/src/seer/anomaly_detection/tasks.py
+++ b/src/seer/anomaly_detection/tasks.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timedelta
 
 import numpy as np
 import sentry_sdk
@@ -109,3 +110,26 @@ def toggle_data_purge_flag(alert_id: int):
         )
         alert.data_purge_flag = new_flag
         session.commit()
+
+
+@celery_app.task
+@sentry_sdk.trace
+def cleanup_disabled_alerts():
+
+    logger.info("Cleaning up timeseries data for alerts that have been inactive for over 28 days")
+
+    date_threshold = datetime.now() - timedelta(days=28)
+
+    with Session() as session:
+        # Get all alerts that haven't been queued in the last 28 days indicating that they are disabled and are safe to cleanup
+        alerts = (
+            session.query(DbDynamicAlert)
+            .filter(DbDynamicAlert.last_queued_at < date_threshold)
+            .all()
+        )
+
+        deleted_count = 0
+        for alert in alerts:
+            deleted_count += delete_old_timeseries_points(alert, date_threshold.timestamp())
+        session.commit()
+        logger.info(f"Deleted {deleted_count} timeseries points")

--- a/tests/seer/anomaly_detection/test_cleanup_tasks.py
+++ b/tests/seer/anomaly_detection/test_cleanup_tasks.py
@@ -159,7 +159,7 @@ class TestCleanupTasks(unittest.TestCase):
         # Create and save alerts with old points
         external_alert_id1, _, _, _ = self._save_alert(1000, 0)
         external_alert_id2, _, _, _ = self._save_alert(500, 0)
-        external_alert_id3, _, _, _ = self._save_alert(500, 0)
+        external_alert_id3, _, _, _ = self._save_alert(0, 500)
 
         # Set last_queued_at to be over 28 days ago for alerts 1 and 2
         with Session() as session:

--- a/tests/seer/anomaly_detection/test_cleanup_tasks.py
+++ b/tests/seer/anomaly_detection/test_cleanup_tasks.py
@@ -10,7 +10,7 @@ from seer.anomaly_detection.models import MPTimeSeriesAnomalies
 from seer.anomaly_detection.models.external import AnomalyDetectionConfig, TimeSeriesPoint
 from seer.anomaly_detection.models.timeseries import TimeSeries
 from seer.anomaly_detection.tasks import cleanup_disabled_alerts, cleanup_timeseries
-from seer.db import DbDynamicAlert, Session, TaskStatus
+from seer.db import DbDynamicAlert, DbDynamicAlertTimeSeries, Session, TaskStatus
 
 
 class TestCleanupTasks(unittest.TestCase):
@@ -195,6 +195,13 @@ class TestCleanupTasks(unittest.TestCase):
                     .one_or_none()
                 )
                 assert alert is None
+
+                timeseries = (
+                    session.query(DbDynamicAlertTimeSeries)
+                    .filter(DbDynamicAlertTimeSeries.dynamic_alert_id == alert_id)
+                    .all()
+                )
+                assert len(timeseries) == 0
 
         # Confirm that alert 4 and its respective timeseries are not deleted
         with Session() as session:

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -13,6 +13,7 @@ def test_detected_celery_jobs():
         assert set(k for k in celery_app.tasks.keys() if not k.startswith("celery.")) == set(
             [
                 "seer.anomaly_detection.tasks.cleanup_timeseries",
+                "seer.anomaly_detection.tasks.cleanup_disabled_alerts",
                 "seer.automation.autofix.steps.change_describer_step.autofix_change_describer_task",
                 "seer.automation.autofix.steps.coding_step.autofix_coding_task",
                 "seer.automation.autofix.steps.root_cause_step.root_cause_task",
@@ -30,6 +31,7 @@ def test_detected_celery_jobs():
             [
                 "Check and mark recent autofix runs every hour",
                 "Delete old Automation runs for 90 day time-to-live",
+                "Clean up old disabled timeseries every week",
             ]
         )
 
@@ -43,7 +45,11 @@ def test_anomaly_beat_jobs():
         app_config.ANOMALY_DETECTION_ENABLED = True
         app.finalize()
 
-        assert set(k for k in app.conf.beat_schedule.keys()) == set([])
+        assert set(k for k in app.conf.beat_schedule.keys()) == set(
+            [
+                "Clean up old disabled timeseries every week",
+            ]
+        )
 
 
 def test_autofix_beat_jobs():


### PR DESCRIPTION
- Currently, cleanup only happens upon detection call leaving stale timestamps for disabled alerts to accumulate
- Created cron which runs weekly to cleanup (delete) disabled alerts based on when they were last queued for detection (28 days) or if last_queued is null then deletes old alerts
- Cleaning alerts as a byproduct cleans the timeseries that are associated with them because of the parent-child relationship