### PR TITLE
fix(autofix): Handle parsing edge case for no root cause termination reason

### DIFF
--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -90,6 +90,8 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
 
                 if "<NO_ROOT_CAUSES>" in response:
                     reason = response.split("<NO_ROOT_CAUSES>")[1].strip()
+                    if "</NO_ROOT_CAUSES>" in reason:
+                        reason = reason.split("</NO_ROOT_CAUSES>")[0].strip()
                     return RootCauseAnalysisOutput(causes=[], termination_reason=reason)
 
                 # Ask for reproduction (NOTE: disabled due to speed; should be relocated to a different step in the future)

--- a/tests/automation/autofix/components/test_root_cause.py
+++ b/tests/automation/autofix/components/test_root_cause.py
@@ -86,6 +86,15 @@ class TestRootCauseComponent:
         # Ensure that the formatter is not called when <NO_ROOT_CAUSES> is returned
         assert mock_agent.return_value.run.call_count == 1
 
+        mock_agent.return_value.run.return_value = "<NO_ROOT_CAUSES> this is too hard, I give up </NO_ROOT_CAUSES> you do it yourself buddy"
+
+        output = component.invoke(MagicMock())
+
+        assert output.causes == []
+        assert output.termination_reason == "this is too hard, I give up"
+        # Ensure that the formatter is not called when <NO_ROOT_CAUSES> is returned
+        assert mock_agent.return_value.run.call_count == 2
+
     def test_agent_run_returns_none(self, component, mock_agent):
         mock_agent.return_value.run.return_value = None
 


### PR DESCRIPTION
Adds parsing to fix this edge case when the agent returns a reason for not finding any root causes. #1480 
<img width="637" alt="Screenshot 2024-11-21 at 9 16 37 AM" src="https://github.com/user-attachments/assets/baeaa30a-df16-4344-acfd-7b66b442901e">
