### PR TITLE
fix(autofix): Handle empty messages and move cleaning calls inside LLMClient

### DIFF
--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -474,9 +474,9 @@ class LlmClient:
         default_temperature = defaults.temperature if defaults else None
         # More defaults to come
 
-        messages = self.clean_message_content(messages if messages else [])
+        messages = LlmClient.clean_message_content(messages if messages else [])
         if not tools:
-            messages = self.clean_tool_call_assistant_messages(messages)
+            messages = LlmClient.clean_tool_call_assistant_messages(messages)
 
         if model.provider_name == LlmProviderType.OPENAI:
             model = cast(OpenAiProvider, model)
@@ -520,8 +520,8 @@ class LlmClient:
         if run_name:
             langfuse_context.update_current_observation(name=run_name + " - Generate Structured")
 
-        messages = self.clean_message_content(messages if messages else [])
-        messages = self.clean_tool_call_assistant_messages(messages)
+        messages = LlmClient.clean_message_content(messages if messages else [])
+        messages = LlmClient.clean_tool_call_assistant_messages(messages)
 
         if model.provider_name == LlmProviderType.OPENAI:
             model = cast(OpenAiProvider, model)
@@ -539,7 +539,8 @@ class LlmClient:
         else:
             raise ValueError(f"Invalid provider: {model.provider_name}")
 
-    def clean_tool_call_assistant_messages(self, messages: list[Message]) -> list[Message]:
+    @staticmethod
+    def clean_tool_call_assistant_messages(messages: list[Message]) -> list[Message]:
         new_messages = []
         for message in messages:
             if message.role == "assistant" and message.tool_calls:
@@ -556,7 +557,8 @@ class LlmClient:
                 new_messages.append(message)
         return new_messages
 
-    def clean_message_content(self, messages: list[Message]) -> list[Message]:
+    @staticmethod
+    def clean_message_content(messages: list[Message]) -> list[Message]:
         new_messages = []
         for message in messages:
             if not message.content:

--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -474,6 +474,8 @@ class LlmClient:
         default_temperature = defaults.temperature if defaults else None
         # More defaults to come
 
+        messages = self.clean_message_content(messages)
+
         if model.provider_name == LlmProviderType.OPENAI:
             model = cast(OpenAiProvider, model)
 
@@ -516,6 +518,8 @@ class LlmClient:
         if run_name:
             langfuse_context.update_current_observation(name=run_name + " - Generate Structured")
 
+        messages = self.clean_message_content(messages)
+
         if model.provider_name == LlmProviderType.OPENAI:
             model = cast(OpenAiProvider, model)
             return model.generate_structured(
@@ -548,6 +552,16 @@ class LlmClient:
                 )
             else:
                 new_messages.append(message)
+        return new_messages
+
+    def clean_message_content(self, messages: list[Message] | None) -> list[Message] | None:
+        if messages is None:
+            return None
+        new_messages = []
+        for message in messages:
+            if not message.content:
+                message.content = "."
+            new_messages.append(message)
         return new_messages
 
 

--- a/src/seer/automation/autofix/components/coding/component.py
+++ b/src/seer/automation/autofix/components/coding/component.py
@@ -99,12 +99,9 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
     ):
         state = self.context.state.get()
 
-        # Clean memory of tool messages since we're running without tools
-        cleaned_memory = LlmClient.clean_tool_call_assistant_messages(memory)
-
         agent = AutofixAgent(
             config=AgentConfig(interactive=True),
-            memory=cleaned_memory,
+            memory=memory,
             context=self.context,
             name="Plan+Code Simple fixer",
         )
@@ -219,11 +216,8 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
             class NeedToSearchCodebaseOutput(BaseModel):
                 need_to_search_codebase: bool
 
-            # Clean message roles to ensure compatibility with OpenAI's API
-            cleaned_memory = LlmClient.clean_tool_call_assistant_messages(memory)
-
             output = llm_client.generate_structured(
-                messages=cleaned_memory,
+                messages=memory,
                 prompt="Given the above instruction, do you need to search the codebase for more context or have an immediate answer?",
                 model=OpenAiProvider.model("gpt-4o-mini"),
                 response_format=NeedToSearchCodebaseOutput,

--- a/src/seer/automation/autofix/components/insight_sharing/component.py
+++ b/src/seer/automation/autofix/components/insight_sharing/component.py
@@ -126,11 +126,7 @@ class InsightSharingComponent(BaseComponent[InsightSharingRequest, InsightSharin
                 insight=insight,
                 latest_thought=request.latest_thought,
             )
-            memory = []
-            for message in llm_client.clean_tool_call_assistant_messages(request.memory):
-                if message.role != "system":
-                    memory.append(message)
-
+            memory = [msg for msg in request.memory if msg.role != "system"]
             completion = llm_client.generate_structured(
                 messages=memory,
                 prompt=prompt_two,

--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -111,7 +111,7 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
                 self.context.event_manager.add_log("Cleaning up the findings...")
 
                 formatted_response = llm_client.generate_structured(
-                    messages=LlmClient.clean_tool_call_assistant_messages(agent.memory),
+                    messages=agent.memory,
                     prompt=RootCauseAnalysisPrompts.root_cause_formatter_msg(),
                     model=OpenAiProvider.model("gpt-4o-2024-08-06"),
                     response_format=MultipleRootCauseAnalysisOutputPrompt,

--- a/tests/automation/agent/test_client.py
+++ b/tests/automation/agent/test_client.py
@@ -287,7 +287,7 @@ def test_clean_tool_call_assistant_messages():
         Message(role="assistant", content="Final response"),
     ]
 
-    cleaned_messages = LlmClient().clean_tool_call_assistant_messages(messages)
+    cleaned_messages = LlmClient.clean_tool_call_assistant_messages(messages)
 
     assert len(cleaned_messages) == 5
     assert cleaned_messages[0].role == "user"
@@ -302,7 +302,7 @@ def test_clean_message_content():
         Message(role="user", content=""),
     ]
 
-    cleaned_messages = LlmClient().clean_message_content(messages)
+    cleaned_messages = LlmClient.clean_message_content(messages)
 
     assert len(cleaned_messages) == 1
     assert cleaned_messages[0].role == "user"

--- a/tests/automation/agent/test_client.py
+++ b/tests/automation/agent/test_client.py
@@ -287,7 +287,7 @@ def test_clean_tool_call_assistant_messages():
         Message(role="assistant", content="Final response"),
     ]
 
-    cleaned_messages = LlmClient.clean_tool_call_assistant_messages(messages)
+    cleaned_messages = LlmClient().clean_tool_call_assistant_messages(messages)
 
     assert len(cleaned_messages) == 5
     assert cleaned_messages[0].role == "user"

--- a/tests/automation/agent/test_client.py
+++ b/tests/automation/agent/test_client.py
@@ -297,6 +297,18 @@ def test_clean_tool_call_assistant_messages():
     assert cleaned_messages[4].role == "assistant"
 
 
+def test_clean_message_content():
+    messages = [
+        Message(role="user", content=""),
+    ]
+
+    cleaned_messages = LlmClient().clean_message_content(messages)
+
+    assert len(cleaned_messages) == 1
+    assert cleaned_messages[0].role == "user"
+    assert cleaned_messages[0].content == "."
+
+
 def test_openai_generate_structured_refusal(mock_openai_client):
     llm_client = LlmClient()
     model = OpenAiProvider.model("gpt-3.5-turbo")


### PR DESCRIPTION
1. Adds a cleaning util for LLM memory that fixes empty content messages
2. Moves the `clean_tool_call_assistant_messages` inside `generate_structured` and `generate_text` so that we don't have to think about cleaning memory when using the LLMClient

Fixes #1483 