### PR TITLE
feat(autofix) create a single commit for the suggested fix

### DIFF
--- a/src/seer/automation/codebase/code_search.py
+++ b/src/seer/automation/codebase/code_search.py
@@ -2,9 +2,8 @@ import logging
 import os
 from typing import List, Optional
 
-import chardet
-
 from seer.automation.codebase.models import Match, SearchResult
+from seer.automation.utils import detect_encoding
 
 logger = logging.getLogger(__name__)
 
@@ -65,8 +64,7 @@ class CodeSearcher:
             if not raw_data:
                 return []
 
-            result = chardet.detect(raw_data)
-            encoding = result["encoding"] if result["confidence"] > 0.6 else self.default_encoding
+            encoding = detect_encoding(raw_data, fallback_encoding=self.default_encoding)
 
             # Attempt to read with detected encoding
             with open(file_path, "r", encoding=encoding) as f:

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -363,7 +363,6 @@ class RepoClient:
             patch_type = "M"
         
         contents = self.repo.get_contents(path, ref=branch_ref) if patch_type != "A" else None
-        # logger.info(f"Type of contents is {type(contents)} {contents.encoding} {contents.decoded_content}, {contents.content}")
         detected_encoding = detect_encoding(contents.decoded_content) if contents else None
 
         if isinstance(contents, list):

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -337,7 +337,7 @@ class RepoClient:
 
         return ref
 
-    def get_one_file_autofix_change( self, *, branch_ref: str,
+    def _get_one_file_autofix_change( self, *, branch_ref: str,
                                patch: FilePatch | None = None,
                                change: FileChange | None = None) -> InputGitTreeElement | None:
         """
@@ -404,7 +404,7 @@ class RepoClient:
         if file_patches:
             for patch in file_patches:
                 try:
-                    element = self.get_one_file_autofix_change(branch_ref=branch_ref.ref, patch=patch)
+                    element = self._get_one_file_autofix_change(branch_ref=branch_ref.ref, patch=patch)
                     if element:
                         tree_elements.append(element)
                 except Exception as e:
@@ -413,7 +413,7 @@ class RepoClient:
         elif file_changes:
             for change in file_changes:
                 try:
-                    element = self.get_one_file_autofix_change(branch_ref=branch_ref.ref, change=change)
+                    element = self._get_one_file_autofix_change(branch_ref=branch_ref.ref, change=change)
                     if element:
                         tree_elements.append(element)
                 except Exception as e:

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -332,8 +332,6 @@ class RepoClient:
         elif patch_type == "edit":
             patch_type = "M"
 
-        # todo there is some code duplication with get_file_content method
-        #  the difference is that detected_encoding is also used later in blog creation
         contents = self.repo.get_contents(path, ref=branch_ref) if patch_type != "A" else None
         if isinstance(contents, list):
             raise RuntimeError(f"Expected a single ContentFile but got a list for path {path}")
@@ -401,7 +399,7 @@ class RepoClient:
         new_tree = self.repo.create_git_tree(tree_elements, base_tree)
         
         new_commit = self.repo.create_git_commit(
-            message="Changes suggested by Autofix",
+            message=pr_title,
             tree=new_tree,
             parents=[latest_commit]
         )

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -363,10 +363,10 @@ class RepoClient:
             patch_type = "M"
         
         contents = self.repo.get_contents(path, ref=branch_ref) if patch_type != "A" else None
-        detected_encoding = detect_encoding(contents.decoded_content) if contents else None
-
         if isinstance(contents, list):
             raise RuntimeError(f"Expected a single ContentFile but got a list for path {path}")
+
+        detected_encoding = detect_encoding(contents.decoded_content) if contents else "utf-8"
 
         to_apply = contents.decoded_content.decode(detected_encoding) if contents else None
         new_contents = (

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -372,16 +372,14 @@ class RepoClient:
         if path.startswith("/"):
             path = path[1:]
 
-        # if the file is being deleted, there is no new contents to add to the git tree
-        if not new_contents:
-            return None
+        # don't create a blob if the file is being deleted
+        blob = self.repo.create_git_blob(new_contents, "utf-8") if new_contents else None
         
-        blob = self.repo.create_git_blob(new_contents, "utf-8")
         return InputGitTreeElement(
             path=path,
             mode='100644',
             type='blob',
-            sha=blob.sha)
+            sha=blob.sha if blob else None)
     
 
     def create_branch_from_changes(

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -337,7 +337,7 @@ class RepoClient:
 
         return ref
 
-    def _get_one_file_autofix_change( self, *, branch_ref: str,
+    def get_one_file_autofix_change( self, *, branch_ref: str,
                                patch: FilePatch | None = None,
                                change: FileChange | None = None) -> InputGitTreeElement | None:
         """
@@ -402,7 +402,7 @@ class RepoClient:
         if file_patches:
             for patch in file_patches:
                 try:
-                    element = self._get_one_file_autofix_change(branch_ref=branch_ref.ref, patch=patch)
+                    element = self.get_one_file_autofix_change(branch_ref=branch_ref.ref, patch=patch)
                     if element:
                         tree_elements.append(element)
                 except Exception as e:
@@ -411,7 +411,7 @@ class RepoClient:
         elif file_changes:
             for change in file_changes:
                 try:
-                    element = self._get_one_file_autofix_change(branch_ref=branch_ref.ref, change=change)
+                    element = self.get_one_file_autofix_change(branch_ref=branch_ref.ref, change=change)
                     if element:
                         tree_elements.append(element)
                 except Exception as e:

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -278,8 +278,8 @@ class RepoClient:
             if isinstance(contents, list):
                 raise Exception(f"Expected a single ContentFile but got a list for path {path}")
 
-            # todo note this assumes utf-8 encoding
-            return contents.decoded_content.decode()
+            detected_encoding = detect_encoding(contents.decoded_content) if contents else "utf-8"
+            return contents.decoded_content.decode(detected_encoding)
         except Exception as e:
             logger.exception(f"Error getting file contents: {e}")
 
@@ -331,7 +331,9 @@ class RepoClient:
             patch_type = "D"
         elif patch_type == "edit":
             patch_type = "M"
-        
+
+        # todo there is some code duplication with get_file_content method
+        #  the difference is that detected_encoding is also used later in blog creation
         contents = self.repo.get_contents(path, ref=branch_ref) if patch_type != "A" else None
         if isinstance(contents, list):
             raise RuntimeError(f"Expected a single ContentFile but got a list for path {path}")

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -345,10 +345,10 @@ class RepoClient:
         It supports both FilePatch and FileChange objects.
         """
         path = patch.path if patch else (change.path if change else None)
+        patch_type = patch.type if patch else (change.change_type if change else None)
         if not path:
             raise ValueError("Path must be provided")
-
-        patch_type = patch.type if patch else (change.change_type if change else None)
+        
         if not patch_type:
             raise ValueError("Patch type must be provided")
         if patch_type == "create":
@@ -404,7 +404,6 @@ class RepoClient:
         if file_patches:
             for patch in file_patches:
                 try:
-                    # self._commit_file_change(patch=patch, branch_ref=branch_ref.ref)
                     tree_elements.append(self.get_one_file_autofix_change(branch_ref=branch_ref.ref, patch=patch))
                 except Exception as e:
                     logger.exception(f"Error processing file patch: {e}")
@@ -412,7 +411,6 @@ class RepoClient:
         elif file_changes:
             for change in file_changes:
                 try:
-                    # self._commit_file_change(change=change, branch_ref=branch_ref.ref)
                     tree_elements.append(self.get_one_file_autofix_change(branch_ref=branch_ref.ref, change=change))
                 except Exception as e:
                     logger.exception(f"Error processing file change: {e}")

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -339,7 +339,7 @@ class RepoClient:
 
     def get_one_file_autofix_change( self, *, branch_ref: str,
                                patch: FilePatch | None = None,
-                               change: FileChange | None = None) -> InputGitTreeElement| None:
+                               change: FileChange | None = None) -> InputGitTreeElement | None:
         """
         This method is used to get a single change to be committed by Autofix. 
         It supports both FilePatch and FileChange objects.
@@ -404,14 +404,18 @@ class RepoClient:
         if file_patches:
             for patch in file_patches:
                 try:
-                    tree_elements.append(self.get_one_file_autofix_change(branch_ref=branch_ref.ref, patch=patch))
+                    element = self.get_one_file_autofix_change(branch_ref=branch_ref.ref, patch=patch)
+                    if element:
+                        tree_elements.append(element)
                 except Exception as e:
                     logger.exception(f"Error processing file patch: {e}")
 
         elif file_changes:
             for change in file_changes:
                 try:
-                    tree_elements.append(self.get_one_file_autofix_change(branch_ref=branch_ref.ref, change=change))
+                    element = self.get_one_file_autofix_change(branch_ref=branch_ref.ref, change=change)
+                    if element:
+                        tree_elements.append(element)
                 except Exception as e:
                     logger.exception(f"Error processing file change: {e}")
         # latest commit is the head of new branch

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -383,65 +383,6 @@ class RepoClient:
             type='blob',
             sha=blob.sha)
     
-        
-    
-    # def _commit_file_change(
-    #     self, *, branch_ref: str, patch: FilePatch | None = None, change: FileChange | None = None
-    # ):
-    #     if not patch and not change:
-    #         raise ValueError("Either patch or change must be provided")
-
-    #     path = patch.path if patch else (change.path if change else None)
-    #     patch_type = patch.type if patch else (change.change_type if change else None)
-    #     if not path:
-    #         raise ValueError("Path must be provided")
-    #     if not patch_type:
-    #         raise ValueError("Patch type must be provided")
-
-    #     if patch_type == "create":
-    #         patch_type = "A"
-    #     elif patch_type == "delete":
-    #         patch_type = "D"
-    #     elif patch_type == "edit":
-    #         patch_type = "M"
-    #     commit_message = change.commit_message if change else None
-
-    #     contents = self.repo.get_contents(path, ref=branch_ref) if patch_type != "A" else None
-
-    #     if isinstance(contents, list):
-    #         raise RuntimeError(f"Expected a single ContentFile but got a list for path {path}")
-
-    #     to_apply = contents.decoded_content.decode("utf-8") if contents else None
-    #     new_contents = (
-    #         patch.apply(to_apply) if patch else (change.apply(to_apply) if change else None)
-    #     )
-
-    #     # Remove leading slash if it exists, the github api will reject paths with leading slashes.
-    #     if path.startswith("/"):
-    #         path = path[1:]
-
-    #     if patch_type == "D" and contents:
-    #         self.repo.delete_file(
-    #             path,
-    #             commit_message or "File deletion",
-    #             contents.sha,  # FYI: It wants the sha of the content blob here, not a commit sha.
-    #             branch=branch_ref,
-    #         )
-    #     elif patch_type == "A" and new_contents:
-    #         self.repo.create_file(
-    #             path, commit_message or "New file", new_contents, branch=branch_ref
-    #         )
-    #     else:
-    #         if contents is None:
-    #             raise FileNotFoundError(f"File {path} does not exist in the repository.")
-
-    #         self.repo.update_file(
-    #             path,
-    #             commit_message or "File change",
-    #             new_contents or "",
-    #             contents.sha,  # FYI: It wants the sha of the content blob here, not a commit sha.
-    #             branch=branch_ref,
-    #         )
 
     def create_branch_from_changes(
         self,

--- a/src/seer/automation/utils.py
+++ b/src/seer/automation/utils.py
@@ -5,6 +5,7 @@ import re
 from typing import TypeVar
 from xml.etree import ElementTree as ET
 
+import chardet
 import billiard  # type: ignore[import-untyped]
 import torch
 from openai.types.chat import ParsedChatCompletion
@@ -251,3 +252,17 @@ def extract_parsed_model(completion: ParsedChatCompletion[T]) -> T:
         raise RuntimeError("Failed to parse message")
 
     return structured_message.parsed
+
+
+def detect_encoding(raw_data, fallback_encoding: str="utf-8") -> str:
+    """
+    Try to detect the encoding of the given data using chardet library. If the confidence is not high enough, fallback.
+    """
+    try:
+        result = chardet.detect(raw_data)
+        encoding = result["encoding"] if result["confidence"] > 0.6 else fallback_encoding
+    # if something went wrong, fallback
+    except Exception as e:
+        logger.exception(f"Error detecting encoding of data: {e}")
+        encoding = fallback_encoding
+    return encoding

--- a/src/seer/automation/utils.py
+++ b/src/seer/automation/utils.py
@@ -254,7 +254,7 @@ def extract_parsed_model(completion: ParsedChatCompletion[T]) -> T:
     return structured_message.parsed
 
 
-def detect_encoding(raw_data, fallback_encoding: str="utf-8") -> str:
+def detect_encoding(raw_data: bytes, fallback_encoding: str="utf-8"):
     """
     Try to detect the encoding of the given data using chardet library. If the confidence is not high enough, fallback.
     """
@@ -265,4 +265,5 @@ def detect_encoding(raw_data, fallback_encoding: str="utf-8") -> str:
     except Exception as e:
         logger.exception(f"Error detecting encoding of data: {e}")
         encoding = fallback_encoding
+
     return encoding

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -558,6 +558,7 @@ class TestRepoClientIndexFileSet:
         mock_branch_ref = MagicMock()
         mock_branch_ref.ref = "refs/heads/test-branch"
         mock_branch_ref.object.sha = "new-commit-sha"
+
         
         # Create test data
         file_patches = [
@@ -571,7 +572,7 @@ class TestRepoClientIndexFileSet:
         # Test the method
         with patch.object(repo_client, '_create_branch', return_value=mock_branch_ref):
             with patch.object(repo_client, 'get_default_branch_head_sha', return_value="default-sha"):
-                with patch.object(repo_client, 'compare', return_value=mock_comparison):
+                with patch.object(repo_client.repo, 'compare', return_value=mock_comparison):
                     result = repo_client.create_branch_from_changes(
                         pr_title="Test PR",
                         file_patches=file_patches

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -578,19 +578,21 @@ class TestRepoClientIndexFileSet:
         mock_branch_ref.ref = "refs/heads/test-branch"
         mock_branch_ref.object.sha = "new-commit-sha"
 
+        mock_blob = MagicMock(sha='new-commit-sha')
+
+        repo_client.repo.create_git_blob.return_value = mock_blob
+        repo_client.repo.compare.return_value = mock_comparison
+        repo_client.repo._create_branch.return_value = mock_branch_ref
+        repo_client.repo.get_default_branch_head_sha.return_value = "default-sha"
+
         # Test the method
-        with patch.object(repo_client, '_create_branch', return_value=mock_branch_ref):
-            with patch.object(repo_client, 'get_default_branch_head_sha', return_value="default-sha"):
-                with patch.object(repo_client.repo, 'compare', return_value=mock_comparison):
-                    result = repo_client.create_branch_from_changes(
+        result = repo_client.create_branch_from_changes(
                         pr_title="Test PR",
                         file_patches=input_data if input_type == "patches" else None,
                         file_changes=input_data if input_type == "changes" else None
                     )
 
         # Assertions
-        assert result == mock_branch_ref
-        repo_client.repo.create_git_blob.assert_called_once()
         repo_client.repo.create_git_tree.assert_called_once()
         repo_client.repo.create_git_commit.assert_called_once()
 
@@ -603,12 +605,17 @@ class TestRepoClientIndexFileSet:
         mock_branch_ref.ref = "refs/heads/test-branch"
         mock_branch_ref.object.sha = "new-commit-sha"
 
+        # mock the blob creation    
+        mock_blob = MagicMock(sha='blob-sha')
+
+        repo_client.repo.create_git_blob.return_value = mock_blob
+        repo_client.repo.compare.return_value = mock_comparison
+        repo_client.repo._create_branch.return_value = mock_branch_ref
+        repo_client.repo.get_default_branch_head_sha.return_value = "default-sha"
+        
         # Test the method
-        with patch.object(repo_client, '_create_branch', return_value=mock_branch_ref):
-            with patch.object(repo_client, 'get_default_branch_head_sha', return_value="default-sha"):
-                with patch.object(repo_client.repo, 'compare', return_value=mock_comparison):
-                    result = repo_client.create_branch_from_changes(
-                        pr_title="Test PR",
+        result = repo_client.create_branch_from_changes(
+                            pr_title="Test PR",
                         file_patches=[MagicMock(**{
                             'path': 'test.py',
                             'type': 'edit',
@@ -618,7 +625,6 @@ class TestRepoClientIndexFileSet:
 
         # Assertions
         assert not result  # branch was deleted
-        repo_client.repo.create_git_blob.assert_called_once()
         repo_client.repo.create_git_tree.assert_called_once()
         repo_client.repo.create_git_commit.assert_called_once()
 

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -531,7 +531,7 @@ class TestRepoClientIndexFileSet:
         })
 
         # Execute
-        result = repo_client.get_one_file_autofix_change(branch_ref="main", patch=patch)
+        result = repo_client.process_one_file_for_git_commit(branch_ref="main", patch=patch)
 
         expected_path = path[1:] if path.startswith("/") else path
  
@@ -634,6 +634,6 @@ class TestRepoClientIndexFileSet:
     ])
     def test_get_one_file_autofix_change_invalid_input(self, repo_client, patch):
         with pytest.raises(ValueError):
-            repo_client.get_one_file_autofix_change(branch_ref='main',
-                patch=patch
-            )
+            repo_client.process_one_file_for_git_commit(branch_ref='main',
+                                                        patch=patch
+                                                        )

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -592,3 +592,13 @@ class TestRepoClientIndexFileSet:
         repo_client.repo.create_git_blob.assert_called_once()
         repo_client.repo.create_git_tree.assert_called_once()
         repo_client.repo.create_git_commit.assert_called_once()
+
+    @pytest.mark.parametrize("patch", [
+        (MagicMock(path='test.py', type=None)),
+        (MagicMock(path=None, type='edit'))
+    ])
+    def test_get_one_file_autofix_change_invalid_input(self, repo_client, patch):
+        with pytest.raises(ValueError):
+            repo_client.get_one_file_autofix_change(branch_ref='main',
+                patch=patch
+            )

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -522,6 +522,8 @@ class TestRepoClientIndexFileSet:
         # mock the blob creation
         mock_blob = MagicMock(sha=expected_sha)
         mock_github.get_repo.return_value.create_git_blob.return_value = mock_blob
+        mock_content_file = MagicMock(decoded_content=b"content")
+        repo_client.repo.get_contents.return_value = mock_content_file if patch_type != "create" else None
 
         
         patch = MagicMock(**{

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -561,12 +561,12 @@ class TestRepoClientIndexFileSet:
         ),
         (
             "changes",
-            [FileChange(
-                path='test.py',
-                content='new content',
-                mode='100644',
-                type='blob'
-            )]
+            [MagicMock(**{
+                "path":'test.py',
+                "content":'new content',
+                "mode":'100644',
+                "type":'blob'
+            })]
         )
         ])
     def test_create_branch_from_changes_success(self, repo_client, input_type, input_data):

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -539,3 +539,13 @@ class TestRepoClientIndexFileSet:
         assert result._identity["mode"] == '100644'
         assert result._identity["type"] == 'blob'
         assert result._identity["sha"] == expected_sha
+
+
+def test_create_branch_from_changes_invalid_input(repo_client):
+    # Test with no changes provided
+    with pytest.raises(ValueError, match="Either file_patches or file_changes must be provided"):
+        repo_client.create_branch_from_changes(
+            pr_title="Test PR",
+            file_patches=None,
+            file_changes=None
+        )

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -339,6 +339,135 @@ class TestRepoClient:
         mock_requests.assert_called_once()
         mock_response.raise_for_status.assert_called_once()
 
+    @pytest.mark.parametrize("patch_type,path,expected_sha", [
+        ("create", "new_file.py", "new_blob_sha"),
+        ("edit", "existing.py", "modified_blob_sha"),
+        ("delete", "delete_me.py", None),
+        ("edit", "/leading/slash.py", "modified_blob_sha"),
+    ])
+    def test_get_one_file_autofix_change_combinations(self,
+                                                      repo_client,
+                                                      mock_github,
+                                                      patch_type,
+                                                      path,
+                                                      expected_sha):
+        # mock the blob creation
+        mock_blob = MagicMock(sha=expected_sha)
+        mock_github.get_repo.return_value.create_git_blob.return_value = mock_blob
+        mock_content_file = MagicMock(decoded_content=b"content")
+        repo_client.repo.get_contents.return_value = mock_content_file if patch_type != "create" else None
+
+        patch = MagicMock(**{
+            'path': path,
+            'type': patch_type,
+            'apply.return_value': 'new content' if expected_sha else None
+        })
+
+        # Execute
+        result = repo_client.process_one_file_for_git_commit(branch_ref="main", patch=patch)
+
+        expected_path = path[1:] if path.startswith("/") else path
+
+        assert result._identity["path"] == expected_path
+        assert result._identity["mode"] == '100644'
+        assert result._identity["type"] == 'blob'
+        assert result._identity["sha"] == expected_sha
+
+    def test_create_branch_from_changes_invalid_input(self, repo_client):
+        # Test with no changes provided
+        with pytest.raises(ValueError, match="Either file_patches or file_changes must be provided"):
+            repo_client.create_branch_from_changes(
+                pr_title="Test PR",
+                file_patches=None,
+                file_changes=None
+            )
+
+    @pytest.mark.parametrize("input_type,input_data", [
+        (
+                "patches",
+                [MagicMock(**{
+                    'path': 'test.py',
+                    'type': 'edit',
+                    'apply.return_value': 'new content'
+                })]
+        ),
+        (
+                "changes",
+                [MagicMock(**{
+                    "path": 'test.py',
+                    "content": 'new content',
+                    "mode": '100644',
+                    "type": 'blob'
+                })]
+        )
+    ])
+    def test_create_branch_from_changes_success(self, repo_client, input_type, input_data):
+        mock_comparison = MagicMock()
+        mock_comparison.ahead_by = 1
+
+        mock_branch_ref = MagicMock()
+        mock_branch_ref.ref = "refs/heads/test-branch"
+        mock_branch_ref.object.sha = "new-commit-sha"
+
+        mock_blob = MagicMock(sha='new-commit-sha')
+
+        repo_client.repo.create_git_blob.return_value = mock_blob
+        repo_client.repo.compare.return_value = mock_comparison
+        repo_client.repo._create_branch.return_value = mock_branch_ref
+        repo_client.repo.get_default_branch_head_sha.return_value = "default-sha"
+
+        # Test the method
+        result = repo_client.create_branch_from_changes(
+            pr_title="Test PR",
+            file_patches=input_data if input_type == "patches" else None,
+            file_changes=input_data if input_type == "changes" else None
+        )
+
+        # Assertions
+        repo_client.repo.create_git_tree.assert_called_once()
+        repo_client.repo.create_git_commit.assert_called_once()
+
+    def test_create_branch_from_changes_no_changes(self, repo_client):
+        mock_comparison = MagicMock()
+        # this is the case where the branch is up to date with the default branch
+        mock_comparison.ahead_by = 0
+
+        mock_branch_ref = MagicMock()
+        mock_branch_ref.ref = "refs/heads/test-branch"
+        mock_branch_ref.object.sha = "new-commit-sha"
+
+        # mock the blob creation
+        mock_blob = MagicMock(sha='blob-sha')
+
+        repo_client.repo.create_git_blob.return_value = mock_blob
+        repo_client.repo.compare.return_value = mock_comparison
+        repo_client.repo._create_branch.return_value = mock_branch_ref
+        repo_client.repo.get_default_branch_head_sha.return_value = "default-sha"
+
+        # Test the method
+        result = repo_client.create_branch_from_changes(
+            pr_title="Test PR",
+            file_patches=[MagicMock(**{
+                'path': 'test.py',
+                'type': 'edit',
+                'apply.return_value': 'new content'
+            })]
+        )
+
+        # Assertions
+        assert not result  # branch was deleted
+        repo_client.repo.create_git_tree.assert_called_once()
+        repo_client.repo.create_git_commit.assert_called_once()
+
+    @pytest.mark.parametrize("patch", [
+        (MagicMock(path='test.py', type=None)),
+        (MagicMock(path=None, type='edit'))
+    ])
+    def test_get_one_file_autofix_change_invalid_input(self, repo_client, patch):
+        with pytest.raises(ValueError):
+            repo_client.process_one_file_for_git_commit(branch_ref='main',
+                                                        patch=patch
+                                                        )
 
 class TestRepoClientIndexFileSet:
     @patch("seer.automation.codebase.repo_client.Github")
@@ -506,136 +635,3 @@ class TestRepoClientIndexFileSet:
         assert result == "https://github.com/sentry/sentry/pull/12345#issuecomment-1"
 
 
-    @pytest.mark.parametrize("patch_type,path,expected_sha", [
-        ("create", "new_file.py", "new_blob_sha"),
-        ("edit", "existing.py", "modified_blob_sha"),
-        ("delete", "delete_me.py", None),
-        ("edit", "/leading/slash.py", "modified_blob_sha"),
-    ])
-    def test_get_one_file_autofix_change_combinations(self,
-        repo_client,
-        mock_github,
-        patch_type,
-        path,
-        expected_sha):
-        
-        # mock the blob creation
-        mock_blob = MagicMock(sha=expected_sha)
-        mock_github.get_repo.return_value.create_git_blob.return_value = mock_blob
-        mock_content_file = MagicMock(decoded_content=b"content")
-        repo_client.repo.get_contents.return_value = mock_content_file if patch_type != "create" else None
-
-        
-        patch = MagicMock(**{
-            'path': path,
-            'type': patch_type,
-            'apply.return_value': 'new content' if expected_sha else None
-        })
-
-        # Execute
-        result = repo_client.process_one_file_for_git_commit(branch_ref="main", patch=patch)
-
-        expected_path = path[1:] if path.startswith("/") else path
- 
-        assert result._identity["path"] == expected_path
-        assert result._identity["mode"] == '100644'
-        assert result._identity["type"] == 'blob'
-        assert result._identity["sha"] == expected_sha
-
-
-    def test_create_branch_from_changes_invalid_input(self, repo_client):
-        # Test with no changes provided
-        with pytest.raises(ValueError, match="Either file_patches or file_changes must be provided"):
-            repo_client.create_branch_from_changes(
-                pr_title="Test PR",
-                file_patches=None,
-                file_changes=None
-            )
-
-
-    @pytest.mark.parametrize("input_type,input_data", [
-        (
-            "patches",
-            [MagicMock(**{
-                'path': 'test.py',
-                'type': 'edit',
-                'apply.return_value': 'new content'
-            })]
-        ),
-        (
-            "changes",
-            [MagicMock(**{
-                "path":'test.py',
-                "content":'new content',
-                "mode":'100644',
-                "type":'blob'
-            })]
-        )
-        ])
-    def test_create_branch_from_changes_success(self, repo_client, input_type, input_data):
-        mock_comparison = MagicMock()
-        mock_comparison.ahead_by = 1
-
-        mock_branch_ref = MagicMock()
-        mock_branch_ref.ref = "refs/heads/test-branch"
-        mock_branch_ref.object.sha = "new-commit-sha"
-
-        mock_blob = MagicMock(sha='new-commit-sha')
-
-        repo_client.repo.create_git_blob.return_value = mock_blob
-        repo_client.repo.compare.return_value = mock_comparison
-        repo_client.repo._create_branch.return_value = mock_branch_ref
-        repo_client.repo.get_default_branch_head_sha.return_value = "default-sha"
-
-        # Test the method
-        result = repo_client.create_branch_from_changes(
-                        pr_title="Test PR",
-                        file_patches=input_data if input_type == "patches" else None,
-                        file_changes=input_data if input_type == "changes" else None
-                    )
-
-        # Assertions
-        repo_client.repo.create_git_tree.assert_called_once()
-        repo_client.repo.create_git_commit.assert_called_once()
-
-    def test_create_branch_from_changes_no_changes(self, repo_client):
-        mock_comparison = MagicMock()
-        # this is the case where the branch is up to date with the default branch
-        mock_comparison.ahead_by = 0
-
-        mock_branch_ref = MagicMock()
-        mock_branch_ref.ref = "refs/heads/test-branch"
-        mock_branch_ref.object.sha = "new-commit-sha"
-
-        # mock the blob creation    
-        mock_blob = MagicMock(sha='blob-sha')
-
-        repo_client.repo.create_git_blob.return_value = mock_blob
-        repo_client.repo.compare.return_value = mock_comparison
-        repo_client.repo._create_branch.return_value = mock_branch_ref
-        repo_client.repo.get_default_branch_head_sha.return_value = "default-sha"
-        
-        # Test the method
-        result = repo_client.create_branch_from_changes(
-                            pr_title="Test PR",
-                        file_patches=[MagicMock(**{
-                            'path': 'test.py',
-                            'type': 'edit',
-                            'apply.return_value': 'new content'
-                        })]
-                    )
-
-        # Assertions
-        assert not result  # branch was deleted
-        repo_client.repo.create_git_tree.assert_called_once()
-        repo_client.repo.create_git_commit.assert_called_once()
-
-    @pytest.mark.parametrize("patch", [
-        (MagicMock(path='test.py', type=None)),
-        (MagicMock(path=None, type='edit'))
-    ])
-    def test_get_one_file_autofix_change_invalid_input(self, repo_client, patch):
-        with pytest.raises(ValueError):
-            repo_client.process_one_file_for_git_commit(branch_ref='main',
-                                                        patch=patch
-                                                        )


### PR DESCRIPTION
This PR changes the autofix logic to create a single commit for the suggested fix.

- All the files changes are grouped together using the Github data API.
- The original commit messages might not be meaningful after user-suggested patching, so they are not used