### PR TITLE
feat(autofix): Add line numbers to code context snippet

### DIFF
--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -125,8 +125,8 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
                 cause_model = formatted_response.parsed.cause.to_model()
                 cause_model.id = 0
                 if cause_model.code_context:
-                    for j, item in enumerate(cause_model.code_context):
-                        item.id = j
+                    for i, item in enumerate(cause_model.code_context):
+                        item.id = i
                         # Find line range for the snippet
                         if item.snippet.file_path and item.snippet.snippet:
                             try:

--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -18,6 +18,7 @@ from seer.automation.autofix.components.root_cause.models import (
 )
 from seer.automation.autofix.components.root_cause.prompts import RootCauseAnalysisPrompts
 from seer.automation.autofix.tools import BaseTools
+from seer.automation.autofix.utils import find_original_snippet
 from seer.automation.component import BaseComponent
 from seer.dependency_injection import inject, injected
 
@@ -124,8 +125,28 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
                 cause_model = formatted_response.parsed.cause.to_model()
                 cause_model.id = 0
                 if cause_model.code_context:
-                    for j, snippet in enumerate(cause_model.code_context):
-                        snippet.id = j
+                    for j, item in enumerate(cause_model.code_context):
+                        item.id = j
+                        # Find line range for the snippet
+                        if item.snippet.file_path and item.snippet.snippet:
+                            try:
+                                file_contents = self.context.get_file_contents(
+                                    item.snippet.file_path,
+                                )
+                                if file_contents:
+                                    found_snippet = find_original_snippet(
+                                        item.snippet.snippet,
+                                        file_contents,
+                                        threshold=0.95,
+                                    )
+                                    if found_snippet:
+                                        _, start_line, end_line = found_snippet
+                                        item.snippet.start_line = start_line
+                                        item.snippet.end_line = end_line
+                            except Exception as e:
+                                logger.warning(
+                                    f"Failed to find line numbers for code context snippet: {e}"
+                                )
 
                 causes = [cause_model]
                 return RootCauseAnalysisOutput(causes=causes, termination_reason=None)

--- a/src/seer/automation/autofix/components/root_cause/models.py
+++ b/src/seer/automation/autofix/components/root_cause/models.py
@@ -28,6 +28,8 @@ class RootCauseRelevantCodeSnippet(BaseModel):
     file_path: str
     repo_name: Optional[str]
     snippet: str
+    start_line: int | None = None
+    end_line: int | None = None
 
 
 class RootCauseRelevantContext(BaseModel):

--- a/tests/automation/autofix/components/test_root_cause.py
+++ b/tests/automation/autofix/components/test_root_cause.py
@@ -16,7 +16,10 @@ from seer.automation.autofix.components.root_cause.component import RootCauseAna
 from seer.automation.autofix.components.root_cause.models import (
     MultipleRootCauseAnalysisOutputPrompt,
     RootCauseAnalysisItemPrompt,
+    RootCauseAnalysisRelevantContext,
     RootCauseAnalysisRequest,
+    RootCauseRelevantCodeSnippet,
+    RootCauseRelevantContext,
 )
 from seer.automation.models import EventDetails
 from seer.dependency_injection import Module
@@ -227,3 +230,150 @@ class TestRootCauseComponent:
         mock_agent.assert_called_once()
         tools_arg = mock_agent.call_args[1]["tools"]
         assert tools_arg is not None
+
+    def test_root_cause_with_line_numbers(self, component, mock_agent):
+        mock_agent.return_value.run.side_effect = [
+            "Some root cause analysis",
+            "Formatter",
+        ]
+
+        mock_llm_client = MagicMock()
+        mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
+            parsed=MultipleRootCauseAnalysisOutputPrompt(
+                cause=RootCauseAnalysisItemPrompt(
+                    title="Test Root Cause",
+                    description="Description",
+                    relevant_code=RootCauseAnalysisRelevantContext(
+                        snippets=[
+                            RootCauseRelevantContext(
+                                id=0,
+                                title="Test Context",
+                                description="Test function",
+                                snippet=RootCauseRelevantCodeSnippet(
+                                    file_path="test.py",
+                                    snippet="def test_function():\n    return True",
+                                    repo_name=None,
+                                ),
+                            )
+                        ]
+                    ),
+                )
+            ),
+            metadata=LlmResponseMetadata(
+                model="test-model",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+            ),
+        )
+
+        # Mock file contents
+        file_contents = (
+            "# Some comment\n" "def test_function():\n" "    return True\n" "# More code\n"
+        )
+        component.context.get_file_contents = MagicMock(return_value=file_contents)
+
+        module = Module()
+        module.constant(LlmClient, mock_llm_client)
+
+        with module:
+            output = component.invoke(MagicMock())
+
+        assert output.causes[0].code_context[0].snippet.start_line == 1
+        assert output.causes[0].code_context[0].snippet.end_line == 3
+
+    def test_root_cause_line_numbers_file_not_found(self, component, mock_agent):
+        mock_agent.return_value.run.side_effect = [
+            "Some root cause analysis",
+            "Formatter",
+        ]
+
+        mock_llm_client = MagicMock()
+        mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
+            parsed=MultipleRootCauseAnalysisOutputPrompt(
+                cause=RootCauseAnalysisItemPrompt(
+                    title="Test Root Cause",
+                    description="Description",
+                    relevant_code=RootCauseAnalysisRelevantContext(
+                        snippets=[
+                            RootCauseRelevantContext(
+                                id=0,
+                                title="Test Context",
+                                description="Test function",
+                                snippet=RootCauseRelevantCodeSnippet(
+                                    file_path="nonexistent.py",
+                                    snippet="def test_function():\n    return True",
+                                    repo_name=None,
+                                ),
+                            )
+                        ]
+                    ),
+                )
+            ),
+            metadata=LlmResponseMetadata(
+                model="test-model",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+            ),
+        )
+
+        # Mock file contents to raise an exception
+        component.context.get_file_contents = MagicMock(side_effect=FileNotFoundError)
+
+        module = Module()
+        module.constant(LlmClient, mock_llm_client)
+
+        with module:
+            output = component.invoke(MagicMock())
+
+        # Verify that the output is still generated but without line numbers
+        assert output.causes[0].code_context[0].snippet.start_line is None
+        assert output.causes[0].code_context[0].snippet.end_line is None
+
+    def test_root_cause_line_numbers_no_match(self, component, mock_agent):
+        mock_agent.return_value.run.side_effect = [
+            "Some root cause analysis",
+            "Formatter",
+        ]
+
+        mock_llm_client = MagicMock()
+        mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
+            parsed=MultipleRootCauseAnalysisOutputPrompt(
+                cause=RootCauseAnalysisItemPrompt(
+                    title="Test Root Cause",
+                    description="Description",
+                    relevant_code=RootCauseAnalysisRelevantContext(
+                        snippets=[
+                            RootCauseRelevantContext(
+                                id=0,
+                                title="Test Context",
+                                description="Test function",
+                                snippet=RootCauseRelevantCodeSnippet(
+                                    file_path="test.py",
+                                    snippet="def test_function():\n    return True",
+                                    repo_name=None,
+                                ),
+                            )
+                        ]
+                    ),
+                )
+            ),
+            metadata=LlmResponseMetadata(
+                model="test-model",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+            ),
+        )
+
+        # Mock file contents with different code
+        file_contents = "def different_function():\n    return False"
+        component.context.get_file_contents = MagicMock(return_value=file_contents)
+
+        module = Module()
+        module.constant(LlmClient, mock_llm_client)
+
+        with module:
+            output = component.invoke(MagicMock())
+
+        # Verify that the output is still generated but without line numbers
+        assert output.causes[0].code_context[0].snippet.start_line is None
+        assert output.causes[0].code_context[0].snippet.end_line is None


### PR DESCRIPTION
Uses our fuzzy matcher to find the matching snippets for the generated relevant code context snippets, then saves the line number range in the output. Issue #1529 

Frontend PR will make them show up, but nothing breaks if this backend PR is merged.