### PR TITLE
chore(autofix): Remove dead endpoints

### DIFF
--- a/src/seer/app.py
+++ b/src/seer/app.py
@@ -39,12 +39,7 @@ from seer.automation.autofix.tasks import (
     run_autofix_root_cause,
     update_code_change,
 )
-from seer.automation.codebase.models import (
-    CodebaseStatusCheckRequest,
-    CodebaseStatusCheckResponse,
-    RepoAccessCheckRequest,
-    RepoAccessCheckResponse,
-)
+from seer.automation.codebase.models import RepoAccessCheckRequest, RepoAccessCheckResponse
 from seer.automation.codebase.repo_client import RepoClient
 from seer.automation.codegen.models import (
     CodegenPrReviewRequest,
@@ -165,24 +160,11 @@ def repo_access_check_endpoint(data: RepoAccessCheckRequest) -> RepoAccessCheckR
     return RepoAccessCheckResponse(has_access=RepoClient.check_repo_write_access(data.repo))
 
 
-@json_api(blueprint, "/v1/automation/codebase/index/status")
-def get_codebase_index_status_endpoint(
-    data: CodebaseStatusCheckRequest,
-) -> CodebaseStatusCheckResponse:
-    # TODO: Remove this once sentry side is updated
-    return CodebaseStatusCheckResponse(status="up_to_date")
-
-
 @json_api(blueprint, "/v1/automation/autofix/start")
 def autofix_start_endpoint(data: AutofixRequest) -> AutofixEndpointResponse:
     raise_if_no_genai_consent(data.organization_id)
     run_id = run_autofix_root_cause(data)
     return AutofixEndpointResponse(started=True, run_id=run_id)
-
-
-@json_api(blueprint, "/v1/automation/autofix/raise-error")  # TODO remove this endpoint
-def autofix_test_copilot_endpoint(data: AutofixRequest) -> AutofixEndpointResponse:
-    raise Exception("This is a test error to create a Sentry issue")
 
 
 @json_api(blueprint, "/v1/automation/autofix/update")

--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -26,19 +26,8 @@ class RepoAccessCheckRequest(BaseModel):
     repo: RepoDefinition
 
 
-# TODO: Remove this once sentry side is updated
-class CodebaseStatusCheckRequest(BaseModel):
-    organization_id: int
-    project_id: int
-    repo: RepoDefinition
-
-
 class RepoAccessCheckResponse(BaseModel):
     has_access: bool
-
-
-class CodebaseStatusCheckResponse(BaseModel):
-    status: str  # CodebaseIndexStatus, but not using the enum here because it breaks JSON schema generation
 
 
 class MatchXml(PromptXmlModel, tag="result"):

--- a/tests/test_seer.py
+++ b/tests/test_seer.py
@@ -20,8 +20,6 @@ from seer.automation.autofix.models import (
     AutofixUpdateRequest,
     AutofixUpdateType,
 )
-from seer.automation.codebase.models import CodebaseStatusCheckRequest, CodebaseStatusCheckResponse
-from seer.automation.models import RepoDefinition
 from seer.automation.state import LocalMemoryState
 from seer.automation.summarize.models import SummarizeIssueRequest
 from seer.configuration import AppConfig, provide_test_defaults
@@ -530,37 +528,6 @@ class TestSeer(unittest.TestCase):
 
         assert response.status_code == 500  # InternalServerError
         mock_run_summarize_issue.assert_called_once_with(test_data)
-
-
-class TestGetCodebaseIndexStatusEndpoint(unittest.TestCase):
-    @mock.patch("seer.app.CodebaseStatusCheckResponse")
-    def test_get_codebase_index_status_endpoint(self, mock_response):
-        # Prepare test data
-        test_data = CodebaseStatusCheckRequest(
-            organization_id=123,
-            project_id=456,
-            repo=RepoDefinition(
-                provider="github", owner="test-owner", name="test-repo", external_id="test-repo-id"
-            ),
-        )
-
-        # Mock the response
-        mock_response.return_value = CodebaseStatusCheckResponse(status="up_to_date")
-
-        # Make a POST request to the endpoint
-        response = app.test_client().post(
-            "/v1/automation/codebase/index/status",
-            data=test_data.json(),
-            content_type="application/json",
-        )
-
-        # Assert that the response is correct
-        self.assertEqual(response.status_code, 200)
-        response_data = json.loads(response.get_data(as_text=True))
-        self.assertEqual(response_data, {"status": "up_to_date"})
-
-        # Assert that CodebaseStatusCheckResponse was called with the correct status
-        mock_response.assert_called_once_with(status="up_to_date")
 
 
 @parametrize(count=1)


### PR DESCRIPTION
Remove copilot testing endpoint and codebase indexing endpoint since they are unused now (correct me if I'm wrong)