### PR TITLE
fix(autofix): Bump updated_at BEFORE throwing the state in the dbmodel

### DIFF
--- a/src/seer/automation/autofix/state.py
+++ b/src/seer/automation/autofix/state.py
@@ -11,7 +11,9 @@ class ContinuationState(DbState[AutofixContinuation]):
     model: type[AutofixContinuation] = AutofixContinuation
     type: DbStateRunTypes = dataclasses.field(default=DbStateRunTypes.AUTOFIX)
 
-    def apply_to_run_state(self, state: AutofixContinuation, run_state: DbRunState):
+    def before_update(self, state: AutofixContinuation):
         state.mark_updated()
+
+    def apply_to_run_state(self, state: AutofixContinuation, run_state: DbRunState):
         run_state.updated_at = state.updated_at
         run_state.last_triggered_at = state.last_triggered_at

--- a/src/seer/automation/codegen/state.py
+++ b/src/seer/automation/codegen/state.py
@@ -11,7 +11,9 @@ class CodegenContinuationState(DbState[CodegenContinuation]):
     model: type[CodegenContinuation] = CodegenContinuation
     type: DbStateRunTypes = dataclasses.field(default=DbStateRunTypes.UNIT_TEST)
 
-    def apply_to_run_state(self, state: CodegenContinuation, run_state: DbRunState):
+    def before_update(self, state: CodegenContinuation):
         state.mark_updated()
+
+    def apply_to_run_state(self, state: CodegenContinuation, run_state: DbRunState):
         run_state.updated_at = state.updated_at
         run_state.last_triggered_at = state.last_triggered_at

--- a/src/seer/automation/state.py
+++ b/src/seer/automation/state.py
@@ -104,6 +104,12 @@ class DbState(State[_State]):
         """
         pass
 
+    def before_update(self, value: _State):
+        """
+        Can be used to run some logic before the update is applied to the db
+        """
+        pass
+
     @contextlib.contextmanager
     def update(self):
         """
@@ -120,6 +126,7 @@ class DbState(State[_State]):
             assert r
             value = self.model.model_validate(r.value)
             yield value
+            self.before_update(value)
             db_state = DbRunState(id=self.id, value=value.model_dump(mode="json"))
             self.apply_to_run_state(value, db_state)
             session.merge(db_state)

--- a/tests/automation/autofix/test_autofix_state.py
+++ b/tests/automation/autofix/test_autofix_state.py
@@ -7,24 +7,6 @@ from seer.automation.autofix.state import ContinuationState
 from seer.automation.state import DbStateRunTypes
 
 
-def test_update_preserves_last_triggered():
-    """Test that update preserves last_triggered_at while updated_at is set to current time"""
-    continuation = next(generate(AutofixContinuation))
-    trigger_time = datetime.datetime(2023, 1, 2)
-    continuation.last_triggered_at = trigger_time
-    state = ContinuationState.new(group_id=1, value=continuation, t=DbStateRunTypes.AUTOFIX)
-
-    with state.update():
-        # Don't make any changes
-        pass
-
-    result = state.get()
-    assert result.last_triggered_at == trigger_time
-    # updated_at should be set to current time
-    assert isinstance(result.updated_at, datetime.datetime)
-    assert result.updated_at > datetime.datetime(2023, 1, 1)
-
-
 def test_before_update_marks_updated():
     """Test that before_update correctly marks the state as updated with current time"""
     continuation = next(generate(AutofixContinuation))

--- a/tests/automation/autofix/test_autofix_state.py
+++ b/tests/automation/autofix/test_autofix_state.py
@@ -14,9 +14,9 @@ def test_update_preserves_last_triggered():
     continuation.last_triggered_at = trigger_time
     state = ContinuationState.new(group_id=1, value=continuation, t=DbStateRunTypes.AUTOFIX)
 
-    with state.update() as cur:
-        # Even if we try to set updated_at, it will be overridden by before_update
-        cur.last_triggered_at = trigger_time
+    with state.update():
+        # Don't make any changes
+        pass
 
     result = state.get()
     assert result.last_triggered_at == trigger_time

--- a/tests/automation/autofix/test_autofix_state.py
+++ b/tests/automation/autofix/test_autofix_state.py
@@ -7,16 +7,53 @@ from seer.automation.autofix.state import ContinuationState
 from seer.automation.state import DbStateRunTypes
 
 
-class TestContinuationState:
-    def test_update(self):
-        continuation = next(generate(AutofixContinuation))
-        continuation.updated_at = "2023-01-01"
-        continuation.last_triggered_at = "2023-01-02"
-        state = ContinuationState.new(group_id=1, value=continuation, t=DbStateRunTypes.AUTOFIX)
+def test_update_preserves_last_triggered():
+    """Test that update preserves last_triggered_at while updated_at is set to current time"""
+    continuation = next(generate(AutofixContinuation))
+    trigger_time = datetime.datetime(2023, 1, 2)
+    continuation.last_triggered_at = trigger_time
+    state = ContinuationState.new(group_id=1, value=continuation, t=DbStateRunTypes.AUTOFIX)
 
-        with state.update() as cur:
-            cur.updated_at = "2023-01-01"
-            cur.last_triggered_at = "2023-01-02"
+    with state.update() as cur:
+        # Even if we try to set updated_at, it will be overridden by before_update
+        cur.last_triggered_at = trigger_time
 
-        assert state.get().updated_at == datetime.datetime(2023, 1, 1, 0, 0)
-        assert state.get().last_triggered_at == datetime.datetime(2023, 1, 2, 0, 0)
+    result = state.get()
+    assert result.last_triggered_at == trigger_time
+    # updated_at should be set to current time
+    assert isinstance(result.updated_at, datetime.datetime)
+    assert result.updated_at > datetime.datetime(2023, 1, 1)
+
+
+def test_before_update_marks_updated():
+    """Test that before_update correctly marks the state as updated with current time"""
+    continuation = next(generate(AutofixContinuation))
+    initial_time = datetime.datetime(2023, 1, 1)
+    continuation.updated_at = initial_time
+    state = ContinuationState.new(group_id=1, value=continuation, t=DbStateRunTypes.AUTOFIX)
+
+    with state.update() as cur:
+        # Make some change to trigger update
+        cur.last_triggered_at = datetime.datetime(2023, 1, 2)
+
+    # After update, updated_at should be more recent than initial_time
+    result = state.get()
+    assert result.updated_at > initial_time
+    assert isinstance(result.updated_at, datetime.datetime)
+
+
+def test_before_update_always_updates_timestamp():
+    """Test that before_update always updates the timestamp, even without changes"""
+    continuation = next(generate(AutofixContinuation))
+    initial_time = datetime.datetime(2023, 1, 1)
+    continuation.updated_at = initial_time
+    state = ContinuationState.new(group_id=1, value=continuation, t=DbStateRunTypes.AUTOFIX)
+
+    with state.update():
+        # Don't make any changes
+        pass
+
+    # Even without changes, updated_at should still be updated
+    result = state.get()
+    assert result.updated_at > initial_time
+    assert isinstance(result.updated_at, datetime.datetime)


### PR DESCRIPTION
Runs were timing out because there actually are two `updated_at` fields, the main one being used in the class instances are the ones inside the `value` json. We're supposed to be syncing the field on the db model with the one from the json for the sake of db querying, but there was a bug in the big PR that updates this field in the value AFTER the value json was set.

So the updated_at inside the json was the original one, never bumped.