### PR TITLE
fix(anomaly detection): Use thresholds for dynamic window

### DIFF
--- a/src/seer/anomaly_detection/accessors.py
+++ b/src/seer/anomaly_detection/accessors.py
@@ -387,29 +387,17 @@ class DbAlertDataAccessor(AlertDataAccessor):
         combined_thresholds = anomalies_suss.thresholds
         combined_original_flags = anomalies_suss.original_flags
         if anomalies_fixed is not None:
-            combined_flags = [
-                (anomalies_suss.flags[i] if use_suss[i] else anomalies_fixed.flags[i])
-                for i in range(len(anomalies_suss.flags))
-            ]
-
-            combined_scores = [
-                (anomalies_suss.scores[i] if use_suss[i] else anomalies_fixed.scores[i])
-                for i in range(len(anomalies_suss.scores))
-            ]
-
-            combined_thresholds = [
-                (anomalies_suss.thresholds[i] if use_suss[i] else anomalies_fixed.thresholds[i])
-                for i in range(len(anomalies_suss.thresholds))
-            ]
-
-            combined_original_flags = [
-                (
-                    anomalies_suss.original_flags[i]
-                    if use_suss[i]
-                    else anomalies_fixed.original_flags[i]
-                )
-                for i in range(len(anomalies_suss.original_flags))
-            ]
+            for i in range(len(anomalies_suss.flags)):
+                if use_suss[i]:
+                    combined_flags[i] = anomalies_suss.flags[i]
+                    combined_scores[i] = anomalies_suss.scores[i]
+                    combined_thresholds[i] = anomalies_suss.thresholds[i]
+                    combined_original_flags[i] = anomalies_suss.original_flags[i]
+                else:
+                    combined_flags[i] = anomalies_fixed.flags[i]
+                    combined_scores[i] = anomalies_fixed.scores[i]
+                    combined_thresholds[i] = anomalies_fixed.thresholds[i]
+                    combined_original_flags[i] = anomalies_fixed.original_flags[i]
 
         return MPTimeSeriesAnomalies(
             flags=combined_flags,

--- a/src/seer/anomaly_detection/accessors.py
+++ b/src/seer/anomaly_detection/accessors.py
@@ -391,13 +391,15 @@ class DbAlertDataAccessor(AlertDataAccessor):
                 if use_suss[i]:
                     combined_flags[i] = anomalies_suss.flags[i]
                     combined_scores[i] = anomalies_suss.scores[i]
-                    combined_thresholds[i] = anomalies_suss.thresholds[i]
                     combined_original_flags[i] = anomalies_suss.original_flags[i]
+                    if i < len(anomalies_suss.thresholds):
+                        combined_thresholds[i] = anomalies_suss.thresholds[i]
                 else:
                     combined_flags[i] = anomalies_fixed.flags[i]
                     combined_scores[i] = anomalies_fixed.scores[i]
-                    combined_thresholds[i] = anomalies_fixed.thresholds[i]
                     combined_original_flags[i] = anomalies_fixed.original_flags[i]
+                    if i < len(anomalies_fixed.thresholds):
+                        combined_thresholds[i] = anomalies_fixed.thresholds[i]
 
         return MPTimeSeriesAnomalies(
             flags=combined_flags,

--- a/src/seer/anomaly_detection/accessors.py
+++ b/src/seer/anomaly_detection/accessors.py
@@ -382,29 +382,44 @@ class DbAlertDataAccessor(AlertDataAccessor):
         MPTimeSeriesAnomalies
             Combined anomalies object containing flags, scores and metadata from both approaches
         """
-        return MPTimeSeriesAnomalies(
-            flags=[
-                (
-                    (anomalies_suss.flags[i] if use_suss[i] else anomalies_fixed.flags[i])
-                    if anomalies_fixed is not None
-                    else anomalies_suss.flags[i]
-                )
+        combined_flags = anomalies_suss.flags
+        combined_scores = anomalies_suss.scores
+        combined_thresholds = anomalies_suss.thresholds
+        combined_original_flags = anomalies_suss.original_flags
+        if anomalies_fixed is not None:
+            combined_flags = [
+                (anomalies_suss.flags[i] if use_suss[i] else anomalies_fixed.flags[i])
                 for i in range(len(anomalies_suss.flags))
-            ],
-            scores=[
-                (
-                    (anomalies_suss.scores[i] if use_suss[i] else anomalies_fixed.scores[i])
-                    if anomalies_fixed is not None
-                    else anomalies_suss.scores[i]
-                )
+            ]
+
+            combined_scores = [
+                (anomalies_suss.scores[i] if use_suss[i] else anomalies_fixed.scores[i])
                 for i in range(len(anomalies_suss.scores))
-            ],
-            thresholds=anomalies_suss.thresholds,  # Use thresholds from either one since they're the same
+            ]
+
+            combined_thresholds = [
+                (anomalies_suss.thresholds[i] if use_suss[i] else anomalies_fixed.thresholds[i])
+                for i in range(len(anomalies_suss.thresholds))
+            ]
+
+            combined_original_flags = [
+                (
+                    anomalies_suss.original_flags[i]
+                    if use_suss[i]
+                    else anomalies_fixed.original_flags[i]
+                )
+                for i in range(len(anomalies_suss.original_flags))
+            ]
+
+        return MPTimeSeriesAnomalies(
+            flags=combined_flags,
+            scores=combined_scores,
+            thresholds=combined_thresholds,
             matrix_profile_suss=anomalies_suss.matrix_profile,
             matrix_profile_fixed=(
                 anomalies_fixed.matrix_profile if anomalies_fixed is not None else np.array([])
             ),
             window_size=anomalies_suss.window_size,
-            original_flags=anomalies_suss.original_flags,
+            original_flags=combined_original_flags,
             use_suss=use_suss,
         )

--- a/src/seer/anomaly_detection/anomaly_detection.py
+++ b/src/seer/anomaly_detection/anomaly_detection.py
@@ -214,8 +214,9 @@ class AnomalyDetection(BaseModel):
         else:
             anomalies.use_suss.append(True)
 
+        num_anomlies = len(streamed_anomalies_suss.flags)
         streamed_anomalies = alert_data_accessor.combine_anomalies(
-            streamed_anomalies_suss, streamed_anomalies_fixed, anomalies.use_suss
+            streamed_anomalies_suss, streamed_anomalies_fixed, anomalies.use_suss[-num_anomlies:]
         )
 
         # Save new data point

--- a/src/seer/anomaly_detection/anomaly_detection.py
+++ b/src/seer/anomaly_detection/anomaly_detection.py
@@ -350,7 +350,7 @@ class AnomalyDetection(BaseModel):
             streamed_anomalies_fixed,
             [True]
             * len(
-                ts_external
+                streamed_anomalies_suss.flags
             ),  # Defaulting to using SuSS window because switching logic is for streaming only
         )
 

--- a/src/seer/anomaly_detection/detectors/anomaly_detectors.py
+++ b/src/seer/anomaly_detection/detectors/anomaly_detectors.py
@@ -131,13 +131,6 @@ class MPBatchAnomalyDetector(AnomalyDetector):
         # Update the flags in flags_and_scores with the smoothed flags
         flags_and_scores.flags = smoothed_flags
 
-        print("Batch Detect (compute matrix profile)")
-        print("len flags", len(smoothed_flags))
-        print("len scores", len(flags_and_scores.scores))
-        print("len thresholds", len(flags_and_scores.thresholds))
-        print("len original_flags", len(original_flags))
-        print()
-
         return MPTimeSeriesAnomaliesSingleWindow(
             flags=smoothed_flags,
             scores=flags_and_scores.scores,

--- a/tests/seer/anomaly_detection/test_cleanup_tasks.py
+++ b/tests/seer/anomaly_detection/test_cleanup_tasks.py
@@ -167,7 +167,6 @@ class TestCleanupTasks(unittest.TestCase):
                         and new.anomaly_algo_data["mp_suss"]["l_idx"] == algo_data["l_idx"]
                         and new.anomaly_algo_data["mp_suss"]["r_idx"] == algo_data["r_idx"]
                     )
-                    assert new.anomaly_algo_data["original_flag"] == algo_data["original_flag"]
                     assert (
                         "dist" in new.anomaly_algo_data["mp_fixed"]
                         and "idx" in new.anomaly_algo_data["mp_fixed"]


### PR DESCRIPTION
- `thresholds` and `original_flags` for the respective detector (SuSS vs. fixed) were not being properly used and therefore defaulting to just SuSS
- Ensure that use_suss flag is being properly used (entire history was being sent not the required portion)
- Clean up `combine_anomalies` for readability and performance (if no fixed window is being used, should not perform list iteration)