### PR TITLE
fix(autofix): Mark triggered for interactive starts

### DIFF
--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -70,6 +70,7 @@ class AutofixEventManager:
             cur_step.progress = []
             cur_step.completedMessage = None  # type: ignore[assignment]
             cur.status = AutofixStatus.PROCESSING
+            cur.mark_triggered()
 
     def send_root_cause_analysis_will_start(self):
         with self.state.update() as cur:


### PR DESCRIPTION
When starting a new step due to rethinking or Q&A, mark the state as triggered to prevent premature timeouts.