### PR TITLE
fix(issue-summary): Rename connected issues in prompt to session related

### DIFF
--- a/src/seer/automation/autofix/prompts.py
+++ b/src/seer/automation/autofix/prompts.py
@@ -39,6 +39,6 @@ def format_summary(summary: IssueSummary | None) -> str:
         """
     ).format(
         whats_wrong=summary.whats_wrong,
-        trace=summary.trace,
+        trace=summary.session_related_issues,
         possible_cause=summary.possible_cause,
     )

--- a/src/seer/automation/summarize/issue.py
+++ b/src/seer/automation/summarize/issue.py
@@ -18,7 +18,7 @@ class Step(BaseModel):
 class IssueSummary(BaseModel):
     title: str
     whats_wrong: str
-    trace: str
+    session_related_issues: str
     possible_cause: str
 
 
@@ -42,16 +42,16 @@ def summarize_issue(
     if connected_event_details:
         connected_issues = "\n----\n".join(
             [
-                f"Connected Issue:\n{event.format_event()}"
+                f"Issue from the same session:\n{event.format_event()}"
                 for _, event in enumerate(connected_event_details)
             ]
         )
         connected_issues_input = f"""
-        Also, we know about some other issues that occurred in the same application trace, listed below. The issue above occurred somewhere alongside these:
+        Also, we know about some other issues that occurred in the same application session, listed below. The issue above occurred somewhere alongside these:
         {connected_issues}
         """
     else:
-        connected_issues_input = "Connected issues we've found: none"
+        connected_issues_input = "Issues from the same session: none"
 
     prompt = textwrap.dedent(
         f"""Our code is broken! Please summarize the issue below in a few short bullet points so our engineers can immediately understand what's wrong.
@@ -68,8 +68,8 @@ def summarize_issue(
         ###### What's wrong? [not optional]
         summary of the stacktrace, breadcrumbs, and other context
 
-        ###### Trace [optional]
-        insights from the connected issues, if any [return empty string if none]
+        ###### Session related issues [optional]
+        insights from the application session issues, if relevant to this issue [return empty string if none]
 
         ###### Possible cause [optional]
         guess as to the cause, maybe show if there's clear smoking bullet [return empty string if none]
@@ -93,7 +93,7 @@ def summarize_issue(
             group_id=request.group_id,
             headline=completion.parsed.title,
             whats_wrong=completion.parsed.whats_wrong,
-            trace=completion.parsed.trace,
+            trace=completion.parsed.session_related_issues,
             possible_cause=completion.parsed.possible_cause,
         ),
         completion.parsed,

--- a/tests/automation/autofix/steps/test_root_cause_step.py
+++ b/tests/automation/autofix/steps/test_root_cause_step.py
@@ -36,7 +36,7 @@ class TestRootCauseStep(unittest.TestCase):
                 issue_summary=IssueSummary(
                     title="title",
                     whats_wrong="whats wrong",
-                    trace="trace",
+                    session_related_issues="trace",
                     possible_cause="possible cause",
                 ),
             )
@@ -73,7 +73,7 @@ class TestRootCauseStep(unittest.TestCase):
                 issue_summary=IssueSummary(
                     title="title",
                     whats_wrong="whats wrong",
-                    trace="trace",
+                    session_related_issues="trace",
                     possible_cause="possible cause",
                 ),
                 options=AutofixRequestOptions(comment_on_pr_with_url=pr_url),

--- a/tests/automation/autofix/test_autofix_context.py
+++ b/tests/automation/autofix/test_autofix_context.py
@@ -133,7 +133,7 @@ class TestAutofixContext(unittest.TestCase):
             valid_summary_data = {
                 "title": "title",
                 "whats_wrong": "whats wrong",
-                "trace": "trace",
+                "session_related_issues": "session_related_issues",
                 "possible_cause": "possible cause",
             }
             db_issue_summary = DbIssueSummary(group_id=0, summary=valid_summary_data)
@@ -149,7 +149,7 @@ class TestAutofixContext(unittest.TestCase):
         if result:
             self.assertEqual(result.title, "title")
             self.assertEqual(result.whats_wrong, "whats wrong")
-            self.assertEqual(result.trace, "trace")
+            self.assertEqual(result.session_related_issues, "session_related_issues")
             self.assertEqual(result.possible_cause, "possible cause")
 
         with Session() as session:
@@ -281,9 +281,7 @@ class TestAutofixContext(unittest.TestCase):
                 )
             ]
         )
-        test_repo = RepoDefinition(
-            provider="github", owner="test", name="repo", external_id="1", full_name="test/repo"
-        )
+        test_repo = RepoDefinition(provider="github", owner="test", name="repo", external_id="1")
         self.autofix_context.repos = [test_repo]
 
         self.autofix_context._process_stacktrace_paths(stacktrace)

--- a/tests/automation/summarize/test_issue.py
+++ b/tests/automation/summarize/test_issue.py
@@ -24,10 +24,10 @@ class TestSummarizeIssue:
 
     def test_summarize_issue_success(self, mock_llm_client, sample_request):
         mock_structured_completion = MagicMock()
-        mock_raw_summary = MagicMock(
+        mock_raw_summary = IssueSummary(
             title="Test headline",
             whats_wrong="Test what's wrong",
-            trace="Test trace",
+            session_related_issues="Test session related issues",
             possible_cause="Test possible cause",
         )
         mock_structured_completion.choices[0].message.parsed = mock_raw_summary
@@ -47,7 +47,7 @@ class TestSummarizeIssue:
         assert result.group_id == 1
         assert result.headline == "Test headline"
         assert result.whats_wrong == "Test what's wrong"
-        assert result.trace == "Test trace"
+        assert result.trace == "Test session related issues"
         assert result.possible_cause == "Test possible cause"
         assert raw_result == mock_raw_summary
 
@@ -58,10 +58,10 @@ class TestSummarizeIssue:
         mock_from_event.return_value = mock_event_details
 
         mock_llm_client.generate_structured.return_value = LlmGenerateStructuredResponse(
-            parsed=MagicMock(
+            parsed=IssueSummary(
                 title="Test headline",
                 whats_wrong="Test what's wrong",
-                trace="Test trace",
+                session_related_issues="Test session related issues",
                 possible_cause="Test possible cause",
             ),
             metadata=LlmResponseMetadata(
@@ -96,7 +96,7 @@ class TestRunSummarizeIssue:
             IssueSummary(
                 title="Test headline",
                 whats_wrong="Test what's wrong",
-                trace="Test trace",
+                session_related_issues="Test session related issues",
                 possible_cause="Test possible cause",
             ),
         )
@@ -134,7 +134,7 @@ class TestRunSummarizeIssue:
             IssueSummary(
                 title="Test headline",
                 whats_wrong="Test what's wrong",
-                trace="Test trace",
+                session_related_issues="Test session related issues",
                 possible_cause="Test possible cause",
             ),
         )


### PR DESCRIPTION
The LLM could be overindexing on "connected" issues, so we just call it issues from the same application session.

Output stays the same, we just rename it for the LLM