### PR TITLE
fix(autofix): Fix user question not ending agent run

### DIFF
--- a/src/seer/automation/agent/agent.py
+++ b/src/seer/automation/agent/agent.py
@@ -138,7 +138,9 @@ class LlmAgent:
         self.memory.append(Message(role="user", content=content))
 
     def get_last_message_content(self) -> str | None:
-        return self.memory[-1].content if self.memory else None
+        return (
+            self.memory[-1].content if self.memory and self.memory[-1].role == "assistant" else None
+        )
 
     def call_tool(self, tool_call: ToolCall) -> Message:
         logger.debug(f"[{tool_call.id}] Calling tool {tool_call.function}")

--- a/src/seer/automation/agent/agent.py
+++ b/src/seer/automation/agent/agent.py
@@ -127,7 +127,7 @@ class LlmAgent:
                         f"Agent {self.name} reached maximum iterations without finishing."
                     )
 
-        return self.get_last_message_content()
+        return self.get_last_assistant_message_content()
 
     @contextlib.contextmanager
     def manage_run(self):
@@ -137,7 +137,7 @@ class LlmAgent:
     def add_user_message(self, content: str):
         self.memory.append(Message(role="user", content=content))
 
-    def get_last_message_content(self) -> str | None:
+    def get_last_assistant_message_content(self) -> str | None:
         return (
             self.memory[-1].content if self.memory and self.memory[-1].role == "assistant" else None
         )


### PR DESCRIPTION
When the question asking tool was used, it would end the agent run but the `agent.run` call returns the tool call with `"."` as the content of the last message, causing the root cause and plan/code components to error