### PR TITLE
fix(autofix): Cache repo client objects to avoid re-initialization

### DIFF
--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -140,7 +140,6 @@ class AutofixContext(PipelineContext):
         Gets a repo client for the current single repo or for a given repo name.
         If there are more than 1 repos, a repo name must be provided.
         """
-        # Find the repo definition
         repo: RepoDefinition | None = None
         if len(self.repos) == 1:
             repo = self.repos[0]

--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -69,7 +69,6 @@ class AutofixContext(PipelineContext):
         self.organization_id = request.organization_id
         self.project_id = request.project_id
         self.repos = request.repos
-        self._repo_clients: dict[tuple[str, RepoClientType], RepoClient] = {}
 
         self.sentry_client = sentry_client
 
@@ -153,15 +152,7 @@ class AutofixContext(PipelineContext):
                 "Repo not found. Please provide a valid repo name or external ID."
             )
 
-        # Check cache first
-        cache_key = (repo.external_id, type)
-        if cache_key in self._repo_clients:
-            return self._repo_clients[cache_key]
-
-        # Create new client if not in cache
-        repo_client = RepoClient.from_repo_definition(repo, type)
-        self._repo_clients[cache_key] = repo_client
-        return repo_client
+        return RepoClient.from_repo_definition(repo, type)
 
     def get_file_contents(
         self, path: str, repo_name: str | None = None, ignore_local_changes: bool = False

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -119,7 +119,6 @@ class RepoClient:
     def __init__(
         self, app_id: int | str | None, private_key: str | None, repo_definition: RepoDefinition
     ):
-        print("NEW REPO CLIENT")  # TODO
         if repo_definition.provider != "github":
             # This should never get here, the repo provider should be checked on the Sentry side but this will make debugging
             # easier if it does

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import os
 import shutil
@@ -118,6 +119,7 @@ class RepoClient:
     def __init__(
         self, app_id: int | str | None, private_key: str | None, repo_definition: RepoDefinition
     ):
+        print("NEW REPO CLIENT")  # TODO
         if repo_definition.provider != "github":
             # This should never get here, the repo provider should be checked on the Sentry side but this will make debugging
             # easier if it does
@@ -181,6 +183,7 @@ class RepoClient:
         return False
 
     @classmethod
+    @functools.cache
     def from_repo_definition(cls, repo_def: RepoDefinition, type: RepoClientType):
         if type == RepoClientType.WRITE:
             return cls(*get_write_app_credentials(), repo_def)

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -8,6 +8,13 @@ from seer.automation.codebase.repo_client import RepoClient
 from seer.automation.models import RepoDefinition
 
 
+@pytest.fixture(autouse=True)
+def clear_repo_client_cache():
+    """Clear the RepoClient.from_repo_definition cache before each test"""
+    RepoClient.from_repo_definition.cache_clear()
+    yield
+
+
 @pytest.fixture
 def mock_github():
     with patch("seer.automation.codebase.repo_client.Github") as mock:


### PR DESCRIPTION
See [this profile](https://sentry.sentry.io/profiling/profile/seer/ba56c3e354674bf5bc18c9ca696400e9/flamegraph/?colorCoding=by%20system%20vs%20application%20frame&eventId=acec842a014c44818c8bc5a7263abf65&fov=2984499968,38,7125656064,17&query=&sorting=call%20order&tid=138847897326720&view=top%20down).

We were creating new repo clients over and over again, and each time, it added 1-1.5s.
- before invoking a step, ~1.5s redundant
- pre-filling coding step memory: ~5s (more for more files)
- every expand_document tool call: ~1s

This PR stores created repo clients in memory in the context so that throughout a single step, we only need to initialize one repo client for each repo.