### PR TITLE
fix(autofix): Prevent long wait times for insights threadpool at end of run

### DIFF
--- a/src/seer/automation/autofix/autofix_agent.py
+++ b/src/seer/automation/autofix/autofix_agent.py
@@ -135,14 +135,11 @@ class AutofixAgent(LlmAgent):
 
         # log thoughts to the user
         cur = self.context.state.get()
-        initial_memory_length = cur.steps[-1].initial_memory_length
         if (
             completion.message.content  # only if we have something to summarize
             and self.config.interactive  # only in interactive mode
             and not cur.request.options.disable_interactivity
-            and (
-                completion.message.tool_calls or len(self.memory) <= initial_memory_length + 1
-            )  # only if the run is in progress (and special case for ending in one exception)
+            and completion.message.tool_calls  # only if the run is in progress
         ):
             text_before_tag = completion.message.content.split("<")[0]
             text = text_before_tag

--- a/tests/automation/autofix/cassettes/test_autofix_run_happy_path.yaml
+++ b/tests/automation/autofix/cassettes/test_autofix_run_happy_path.yaml
@@ -21,24 +21,24 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/71SuZajSBD05yv6tb1ScwipGQ+BOAWI+3B4XOIQRSFu2Lf/vjBjjLneGuVkZUZE
-        RuTfPz4+PsM4Trsu6OErrT9/fnwuIUYeQ4TSHQJcCEao4FUHZxz9VujCih5G2vR9thColHeUe5bC
-        4DnDIMnD1YBL2DvNo7EYP6JgS5vhQalZaWBn2nm88RM/S/yB1dGYRsrnXS4QolMLuYUWZSUKG1x7
-        FFrMuI52gLwcA2lVWrQ9tShRRXTGV1y2mgkkb3H6G+G/TGzM0cp2QjrzJOpJGZR+M1iN51xMLt5h
-        zBePWatnRiYIR79I1wVkCHohPv/ad07npmjTLij2jXGCJH9Vuxg26W5B3vdN9/Pra5qmYwZhVqVh
-        U3THGIKvcOjzr7iCQ3JoqrB/whZ8/Fd79666tB2LOD1WMCvqj42mLpL/nBu2qaJ+wmMKwqL6rfxX
-        TEG//BZ6TcM2bX//FMmfDNNFzCMuLtRCNKxVQJVC6ATQNz4tnIXSwhTOrzxHqbx1e0AHnnPD5fU2
-        e2X1UjkLlzEZkctsVjlvUc3bopRacadFJHWpHVOyUa14aseNpolxeS/BhNeneIXjHWNLDyPRqNbX
-        O0jGCEs63yDKCEN2iDytdwgB3yAnlfEmxbydFJPqt0tZFJ7CfPzaKCAfthoW89rJdxo0NrPV516r
-        wrAwcYXBc69TvBB1hJF1xNlojNnLxjkknD0k9B+uxNH+L641cYSda5aZjFDWzdiVIuTSOsmltqpm
-        ttkp7H3wVwS1Um3+LKlBNNGyR2P3nlN1QgmLGJDQc06D5yR5XCd5dLuuvkMgcf0aQud7x6gih20i
-        lsR8V2x8UFU7ZsKLqG9Mhefqz5Bj13DnqcTT3dZ1hcl6z0xePujdEOtrD0sMBbntWI3nbh6Ve/za
-        JK/Cpve16znF27xsxpsP1Lr5t6gucpQMrHAHBVuduZAKLZYMfmKk5JpC028DYoxKQArh+zo8dLfC
-        wDlL7LOdCr778EdBrkf+IYW5Og/Ic9GfHBChTfOJloP2ZIctejhb4y1TxSXr+e6CnXnzkdlxe2a/
-        W8tEAnAHgUIVsz2H6PeJgyd0VG75NPAVzt90VTsggJDeATmfJE2Db4Y2FBJfZj/1MpEqD5ybn4EZ
-        PynTmtg3TTAHnKcuYldRUpI4asYNDSo5D//Q8wkfXNnx0ZIvNAeYBLSQ68t0snJZExXsm5bOSqtJ
-        bT12T/xy10VGHoORWThgNDkGaPpSko0knm20700uNHXoEfOVslqQu5Go0R6KIqR1x8kHfSv7Ofv8
-        8c+/4UPvbokFAAA=
+        H4sIAAAAAAAC/71Rt5ajSBTN5yv6dLzqRhipmQxJWGEEQkCRcKCqcMJJgDBz9t8XeoIJJ9ugklfv
+        mnfvrx9vb+8hhLhtg66+4+r959v7FJLsR0hwlsuUe4bgg4sjh1usXGjDHbabQPAdLiMplPby43In
+        1Q08TJp/4mjeEnAQDu0p2iap+5WG4tTlDLTjBjjgYITkkY4ryh9zR1IJIbUPsD7Pp2k+eo5xz6L9
+        OdK5eCNoZRFpyLEDn5Y6drN/vS7DblJTs5k7VR2Bp2DwyF1UY6Te3HN4TMCZi8CVs/irYEqiR2oZ
+        HT7SwO/3ZWbsC4ekAmvQmoTY7pn3f9ab8dhkT9wG2XoxxbDs97SFdYPXCNKua9qfn5/DMHwkdZ0U
+        OGyy9gPW5WfYd+knLOoebZoi7OL6Wb4tqCpDb39D9S1+ZlVcf+AyzIq/rrePYgG8Mog/ijpZnH57
+        /K4p6KbfRg84fOLn758M/ekQT0oaiTAzMuV6m+WtnsmtXHaNf5R3cn4jddEvgKsXYF5eaZXA5Slt
+        5keQF3dDvFEaqRFanoyGCCbD5ic9NzP1qBDY41bOs7M1s9j8WGQaSGnrqEaSNcC5fqmkkAOS3UaV
+        NaslekUkav0rk0cksVKkuFopZGqhHIwTGHSbp3Wb6/RKmHSJI33q0Ohl2i8zEkom7bvNFtrJ7Iv3
+        WT8JNfLkHniHAU5MFZFsFYnOFpLOtGj2SHR6dPyjhVzz/9KakSuvWqN2Shh9XoKdOUbLb7SWm7Nh
+        J0uc8rpXf1dQ6cWSz4SvTBNNazVOB9yilfM6gyVbA5fugYtSWKE04g+z7zIErO596H6tHEXkCk0k
+        sKTvKY1fFsXKiSRl61+HDHhWHIrCHK4698aIKOUICCY2ybrTHD0PqUIwHSsHDr9yNcBbMsrX+s1J
+        s8Hi31z90HDBazZccpBHw4aDLhEfNjBpeCGOCrpihAix0/Kv9CLEo99GB9LeDZda6ue+8CLtlpzb
+        FlSVdFetQcCWtHviu00HwuVAZ5dE2h2cSkOk1JzdpzKazpHNQztlqq1lqSw7bhAVcRfu3qbEEMeG
+        dxVixZLMXTsf92QkEsgD2Gv8oXzMPJuoY+aBy86B1PYFeY9NUHButPm1uw3S5mGweBpQ+7Iy8o48
+        RXI6/srR5qbgT2H/UlTAVV/qeR5rOjgRjy+Hj/TWYpKS7Zz8FiSO/BhszHQTKJ/XPNc85lyq4yEi
+        KCvRe/V1PPTETqL3usFmvFyy/CwoJdmK1MO7357SOT63Ys9wTStaSSzMCQKktbmaysWKs+tO5cz3
+        H//+B3rG322JBQAA
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -49,7 +49,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 12 Dec 2024 19:47:09 GMT
+      - Sat, 14 Dec 2024 22:41:44 GMT
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -147,7 +147,7 @@ interactions:
       authorization:
       - redacted
       baggage:
-      - sentry-trace_id=1ebd1f01f89147a689812bf9b722cef9,sentry-environment=production,sentry-transaction=seer.automation.autofix.steps.coding_step.autofix_coding_task,sentry-sample_rate=1.0,sentry-sampled=true
+      - sentry-trace_id=277f53f48740406bbc1bccb338b81d2a,sentry-environment=production,sentry-transaction=seer.automation.autofix.steps.coding_step.autofix_coding_task,sentry-sample_rate=1.0,sentry-sampled=true
       connection:
       - keep-alive
       content-length:
@@ -157,7 +157,7 @@ interactions:
       host:
       - us-east5-aiplatform.googleapis.com
       sentry-trace:
-      - 1ebd1f01f89147a689812bf9b722cef9-bb60d26d172c658c-1
+      - 277f53f48740406bbc1bccb338b81d2a-8b49a74c5207921c-1
       user-agent:
       - AnthropicVertex/Python 0.34.2
       x-stainless-arch:
@@ -177,23 +177,22 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/1SOwWrDMBBE7/4Ks2cLbLnJQcdS6KW3QiCUIlRrm4aoK0e7Mg3B/x6lJAEf983s
-        Y3BCElP/IrPboWVxSSrvxJn6DHIaEQwsQmjuN5gz7P01552dkvzZtttsvzY+0+nlG191Wvfvz28/
-        U19+lqoCUgxX4Jj3xUv/3ugxFDYElz2qXq0URyIUNWmlW/3UtVqX3hBJymowH58NsMTRJnSlCYZy
-        CDfEeMxIA95hfkymMYuVeEBiMN267RuIWRZwnuu5qi4AAAD//0qFhE1BZl46WpAoKIEElYBqAAAA
-        AP//gqqBOik+KSc/ORt7KGJRAvRLZl5KaoWSlYEOqjzIoVB9JakVIIVgykpJqVYBDoDWAwAAAP//
-        wmo9MBRLEvFbD1aCYj1EBNVauDKo5T6pJQj7gbYDAAAA//+ir+3ARKpQkpGZl62QmASMMBC7WKG4
-        JLVAIakSOVhgrgMAAAD//6Kz60Au0YvJi8kzhDgG6AIAAAAA//+irwv0FNwyi4pLdBQ8FfJSU1MU
-        SvJRQwXoIAAAAAD//6JzkAD1JpaAIi1VAaKzFuEUAAAAAP//onPYFFQqpGXmpCokJhflFxcrJObk
-        KBSlFuQXZ5bkF2WmFqNlKwAAAAD//6Kv46xi8nQVwlNBsQZzB9ANAAAAAP//oq8bQMlFoTg1sSg5
-        QyEtv0ghBqIfGG4xsDIH6CYAAAAA//+ic/rJzMOIKJAzgWV0aVEqtiwPAAAA//+is/vKU4GJKi8F
-        nMCT84uKUpPB5SPQIQAAAAD//6KzQ0BJW6NYE5SOoGU00A0AAAAA//+irxvUixVKiyF5HeSaeGha
-        KsnPzwElKIyiCAAAAP//onMIgSoLJXCtDgAAAP//wlFj5xcQqrDzC5CsRU95AAAAAP//olI7wBBP
-        OwAYkvHAIAYpToHyS2HtrsBA37y0qBBTi7SogpCwoLCQilLzsmyg0rzEXJBmpCgBWwZs7QCNroVn
-        bAAAAAD//6JSbBhixgakuZUFbJ7BFRcAvZyZmAMWRDRpgK4AAAAA//8aSFdUxyhhpFEAAAAA//8a
-        SPeAYgwUecjFLwAAAP//Gkj3WIGqBEgOAgAAAP//GkhngCslaAEHAAAA//8aSHeA6sValMYwAAAA
-        //+iSrliiJL+AAAAAP//SkXtnGH1GoqkEpJXUDpGyKUHlu5RLVL/CL0vZGSAaJMAAAAA//9KRe8t
-        YvoOWU4Js4YGAAAA//8DAOIrSD5wDgAA
+        H4sIAAAAAAAC/1SOzWrDMBCE734Ks2cLbOUHqicIPZjeAi1BqPZikqgrV7syCcHvXqXUBe9tvpkd
+        BickMeUXMrsBLYuLUvROnCkfIPcRwcDKhGrRYB5w7p8+D3aKcrN1076/Da/tePh08eWyP/IuDEcd
+        88+6KoMY/BM45nPupd/e0KPPrPMu9ag2aqc4EKGoSStd621Ta51zXSDJq8F8nCpgCaON6HISDCXv
+        /xDjd0LqcIHpfzKNSayEKxKDafb1poKQZAXnuVxuLoofAAAA//9KhYRRQWZeOlrQKCiBBJWAagAA
+        AAD//4KqgTotPiknPzkbe2hiUQL0U2ZeSmqFkpWBDqo8yMFQfSWpFSCFYMpKSakW7jwAAAAA///C
+        ajUwJEsS8VsNVoJiNUQE1Uq4MqjFPqklILuB9gIAAAD//6KvvcAkqoSIFZD9AAAAAP//orP9JRmZ
+        edkKiUnAtILsEJhrAAAAAP//or9rihWKS1ILFJIqwbSeEkqaBQAAAP//oq9zYvJi8gz1FNwyi4oh
+        gQN0AQAAAP//oq8LdBQ8FfJSQUkEaDUAAAD//6Kv1SkKJfkKQP2JJalIuRIAAAD//6J7ekhVSIAn
+        AaD9AAAAAP//oq/9YNV6BZVQJwDtBwAAAP//orP/0zJzUhUy88DhUJRakF+cWZJflJlajBQjAAAA
+        AP//oq+LrBD5EWg3AAAA//+id3bUVfCE2g+0HAAAAP//onNUFGfkl+agFJFANwAAAAD//6J3liwt
+        TgWnBVC6ALYFEouSM4DZND8HSKCV3kDHAQAAAP//ontazUtRSMyrBDuuWCEvMRdabgEAAAD//6J3
+        IMXA8y0isQAAAAD//6JzSlWC+BwAAAD//8LRfMovINR6yi9AshOjUgYAAAD//6JSq8wQT6sMmKbi
+        gYkNpDgFyi+FtYYtysssU4p9jUMs0hwzPSLzC8Jd8tLCgErBUW6lhJQ4wZYB26BAo2shzSsAAAAA
+        //+iUkQYYkYEpAWcBWwxwxUXAP2bmZgDFkRqXSKHJQAAAP//Gkj3VMeAwwqaU2AuAgAAAP//GkgX
+        xQAb/7DsA6/zAAAAAP//GkgHFVTGKNWixhvQRQAAAAD//6JKvjJEMhAAAAD//0pF7S9i9RyKpBKS
+        Z1D6ashZB0uPrRapy4bePTMwRe0JAAAAAP//SkXvxGL6D1lOCTWMAAAAAP//AwCmRunMAw8AAA==
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -216,9 +215,9 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Thu, 12 Dec 2024 19:47:10 GMT
+      - Sat, 14 Dec 2024 22:41:45 GMT
       request-id:
-      - req_vrtx_01WcvLF2t7pd15uGecANqHvD
+      - req_vrtx_01QVWFjUimxSrDjCRCxtg5Fd
       server:
       - hypercorn-h11
       x-accel-buffering:
@@ -248,24 +247,24 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/71Ry5aiShDcz1f06fXVBpRWZocIiAoI8io2faAonkUB8lLm3H+/ML2Y5ezuIjeZ
-        GRGZEb9+vL29BxCitv3qqgKR959v76+A4dYBxZsuW+5YuyXRoxksuSAFs33kVYKLA5UIzmRHD+bU
-        u+aX5gTntHtiybtxJDvksVRm4tESnLqs2AKwTYC7lR279lg0SXsUHgldfVbU161W0tNBh7C7bDCt
-        nNt9wwFDKcUj8BvZO1nCZviMokwVUuz30xbkjc3sbxgWRkN3O06Ia3G/D4QEXHho3HlTvEvGSfYY
-        NeOdve97DdX3In8904g805IfKXrHvv+z/IyedfZA7Ve2fLxhOe53t4VVjRYL0q6r258fH+M4rpNq
-        fhkFddauYVV+BH2XfrQNbtFjyCBa4yrJyNuMI1n09jdcP6MyEldrVAYZ/us6xFUfrWocdHH1KL8v
-        /x3TV/f6PvSAggd6fE+y6E+G6HVOQxlmena+25NCa5nSKmVX+4LyqeQ2o8k+Bq6GwTRXaZbAFTfq
-        JD5Bjgtdtjcqo1Jqnjx1Gbx0S3xpuZFdhTOFPH7hvDi0kcXGepap4UZdWlV0Mkc4VcOVkXLAcHRI
-        zOlaRkPIRK1/Z/OQoRaKFJGFQtnMlKN+BKNmiVvN4juNSC/txDP+5lBrZdrPPQaejK3v1jS0ksmX
-        i0k7SlXkKT3wDiN8sSRkOBLKDg0Z5zVr9pHs9JHwRytyjf9La4pcZdF6qseE1abZ2Iln1dzeqrkx
-        6VYy26kse9XvCIiGZ39e6M7W4WuJxumAi1slrzJYchVwtz1woxSSKA3Fw+S7LAVJ0QfufuHAoSvV
-        ocQxvneu/RLjhTM6nWn/PmbAM+NAlqbgW8eNXBMDhyORxAkm7d/MOU7XNg9gAxeuGnizR/kSvzGq
-        k7Kda7lnC2e8asHZB36a/ZtUQq1BIA6PahicxBBUUMnWQYwlP371xcHbN51s2sW017Irm67S9Mbj
-        h9yWWVleMOLA5qwXvYwccARBrT/1g0aYYkJSuGO213KKR/5y27WnJ49VT9+JEbpkd+tKhrOgJteY
-        juWeZ1esoh45JD1VV7+XzV4N3fPT9kiYswWZIqq2j8GOoYjNilT9KVw2K5FNaGjmT2DYtH5r6L2M
-        EY8Lowurm9k5PRrYzgqPqhsNKGFWKDapM7et7VOYVlwEByYEwskAYXbstwfabkpCgDjmVvPklH7L
-        CnxvNpdJccTibtjXHBWgeYzTeNtmNVYMpHp7ydKZetxIUOHv2r1jc+7iMJ7A9YNGBn+AJHn/8e9/
-        PJUPBokFAAA=
+        H4sIAAAAAAAC/71RybaiSBTc11e889atD1JQqR0oIMggs7DxJAkiyJAyyFCn/73h1aKWtetFbm7G
+        jYgb8evHx8cnRChumltbPePy8+fH5wgBs4YEa3p0saNZda8TR+H4tHT10USeRdOV4mCH2qUZBMrp
+        cjkWAfDrgruRJ1l8WysDbrPuEoIBr/h87z99JENVNshdQ/vdHYO9DOSRJ4CKqbylApb2TLE4uJsk
+        K0OFE/jDrRWIDTIf9zO7g+HtHJ41NsZWuH3z1mNHx2NsnAisbrq26qgYHhL/zBqOxZq8JRgn8QrU
+        9CXAfHeyHW2/056IO4Q5lfAsQe7oz3+Wm+MBp3Xc3NLl4g3NMN/TBlU4XiJ4tC1ufn599X2/Tqoq
+        yWOI02aNquILdu3jC+VVF61wDtt7VRcff4M3r7yJ63eK4nVeJWn514VuhqflvVrHBUzzj9lVmUa/
+        nX/XdGvH30a5GNZx/fsnjf50GI/yIxRRqqey5UwSqaVSIxUtDg7SVsocoIlB7nta7k/zK8zC9/iN
+        OvGDn+VPXXQ2KlAJNUsGXfRH3eZHLTNS5SAT8ZVdOM8uaaR3Yz3LYLRRl1EVncweTdVbAULmA4YM
+        S3NSiugdgqgJLDoLAbFQPOJyoZA2M2WvH/1es3lKs9lWK4VRO7Eg2HBYKx7dPAPoZFCBh0lkJ1Mg
+        PiftKFTRVer8K9ejkS5DwJSh6JIIuOOs2UWi20WHP1qRZ/xfWlPkSYvWoB4TWpvmYCeWVjOHUjNj
+        0u1kjlNacNV3BaWWz/mMsUXjcFyqcVvfyxspq1JUMJXvUZ3vRQ9URo+Q56bAowlUPjvo7ReOPPQE
+        HAoMCK4yDoo8Xzijk0wGVp/6V/MORWGC3zpBpm0013LMXHE0RRMNMrCDl/nkaZPkFy7sX+eMsqV+
+        Y1Rtf/b/XPxQaN5XbTTnIA26jXr9SqzDZqfLTt+pdyxrASB9Rmrh1j+8Xg23ihu/ty/WOeeV4ta/
+        HtVLwq/70G2LcWyIFnRblDCZHVhawUKRAylT2u5OHfSIffEu4MSMzOqDGZLCiaVlWlFt3r90ISwB
+        QVRsR7Y6hjRSN+Gw2R5t9pWaSn/ra2M1kNSAY86i9nWIBvhcBey0v6z6a87KF9KVaCgybuB5K+l6
+        5Kebb3I7kSbYVTQyeZ3eb1BXvU7ROrfjq6PBVnpy6i57OqUmnrYVcdtX+FQ6HrrS96l2KOZ6c8/4
+        4IhyHeB77Z+hJRzf4tFaOWfjCNuQuoNxV5+jQleYQ30u3+IrKf2A8zjici6ay54b3DTRwK4xvRFz
+        xuePf/8DejZ8y4kFAAA=
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -276,7 +275,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 12 Dec 2024 19:47:12 GMT
+      - Sat, 14 Dec 2024 22:41:49 GMT
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -322,11 +321,528 @@ interactions:
       (who are much more familiar with the codebase) any specific questions that would
       help you in your analysis.\n- EVERY TIME before you use a tool, think step-by-step
       each time before using the tools provided to you.\n- You also MUST think step-by-step
+      before giving the final answer."}]}], "stream": true, "system": "You are an
+      exceptional principal engineer that is amazing at finding and fixing issues
+      in codebases.\n\nYou have access to tools that allow you to search a codebase
+      to find the relevant code snippets and view relevant files. You can use these
+      tools as many times as you want to find the relevant code snippets.\n\n# Guidelines:\n-
+      EVERY TIME before you use a tool, think step-by-step each time before using
+      the tools provided to you.\n- You also MUST think step-by-step before giving
+      the final answer.", "tools": [{"name": "list_directory", "description": "Given
+      the path for a directory in this codebase, returns the immediate contents of
+      the directory such as files and direct subdirectories. Does not include nested
+      directories.", "input_schema": {"type": "object", "properties": {"path": {"type":
+      "string", "description": "The path to view. For example, \"src/app/components\""},
+      "repo_name": {"type": "string", "description": "Optional name of the repository
+      to search in if you know it."}}, "required": ["path"]}}, {"name": "expand_document",
+      "description": "Given a document path, returns the entire document text.\n-
+      Note: To save time and money, if you''re looking to expand multiple documents,
+      call this tool multiple times in the same message.\n- If a document has already
+      been expanded earlier in the conversation, don''t use this tool again for the
+      same file path.", "input_schema": {"type": "object", "properties": {"file_path":
+      {"type": "string", "description": "The document path to expand."}, "repo_name":
+      {"type": "string", "description": "Optional name of the repository to search
+      in if you know it."}}, "required": ["file_path"]}}, {"name": "keyword_search",
+      "description": "Searches for a keyword in the codebase.", "input_schema": {"type":
+      "object", "properties": {"keyword": {"type": "string", "description": "The keyword
+      to search for."}, "supported_extensions": {"type": "array", "description": "The
+      str[] of supported extensions to search in. Include the dot in the extension.
+      For example, [''.py'', ''.js''].", "items": {"type": "string"}}, "repo_name":
+      {"type": "string", "description": "Optional name of the repository to search
+      in if you know it."}, "in_proximity_to": {"type": "string", "description": "Optional
+      path to search in proximity to, the results will be ranked based on proximity
+      to this path."}}, "required": ["keyword", "supported_extensions"]}}, {"name":
+      "file_search", "description": "Searches for a file in the codebase.", "input_schema":
+      {"type": "object", "properties": {"filename": {"type": "string", "description":
+      "The file to search for."}, "repo_name": {"type": "string", "description": "Optional
+      name of the repository to search in if you know it."}}, "required": ["filename"]}},
+      {"name": "file_search_wildcard", "description": "Searches for files in a folder
+      using a wildcard pattern.", "input_schema": {"type": "object", "properties":
+      {"pattern": {"type": "string", "description": "The wildcard pattern to match
+      files."}, "repo_name": {"type": "string", "description": "Optional name of the
+      repository to search in if you know it."}}, "required": ["pattern"]}}, {"name":
+      "ask_a_question", "description": "Asks your team members a quick question.",
+      "input_schema": {"type": "object", "properties": {"question": {"type": "string",
+      "description": "The question you want to ask your team."}}, "required": ["question"]}}],
+      "anthropic_version": "vertex-2023-10-16"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - redacted
+      baggage:
+      - sentry-trace_id=277f53f48740406bbc1bccb338b81d2a,sentry-environment=production,sentry-transaction=seer.automation.autofix.steps.coding_step.autofix_coding_task,sentry-sample_rate=1.0,sentry-sampled=true
+      connection:
+      - keep-alive
+      content-length:
+      - '5371'
+      content-type:
+      - application/json
+      host:
+      - us-east5-aiplatform.googleapis.com
+      sentry-trace:
+      - 277f53f48740406bbc1bccb338b81d2a-b9c3a8381653a69c-1
+      user-agent:
+      - AnthropicVertex/Python 0.34.2
+      x-stainless-arch:
+      - arm64
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 0.34.2
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.0rc1
+    method: POST
+    uri: https://us-east5-aiplatform.googleapis.com/v1/projects/ml-ai-420606/locations/us-east5/publishers/anthropic/models/claude-3-5-sonnet-v2@20241022:streamRawPredict
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/1SOwU7DMAyG732KyudGarOCphw5IW7TDjsgFEWJNcaCU2qnYkx9d1LEEPXN329/
+        +nFCElO/I7M7omVxo1TBiTP1FeQyIBhYhdDcdjBXOIUl56OdRvm0bff0+rBP/uJ3/Vfot49ud9i6
+        N11+1qoCxhQX4JhPxUs/3hQwFuajywHVRt0pTkQoatJKt7rvWr24fCIprcE8vzTAkgY7oiuXYCjH
+        +IsYPzKSxxvMf5VpyGIlnZEYTHffbhpIWVZwnut/M1fVNwAAAP//SoUEU0FmXjpa6CgogQSVgGoA
+        AAAA//+CqoG6Lj4pJz85G3uAYlEC9FZmXkpqhZKVgQ6qPMjNUH0lqRUghWDKSkkJxZEgVwIAAAD/
+        /8LqAmCYliTidwFYCYoLICKoNsOVQe33SS1BdgLQfgAAAAD//6Kv/cBEq1CSkZmXrVQLtBsAAAD/
+        /6Kz3YlJwDQDsr5YobgktUAhqRIcFkCHAAAAAP//orNDQLbrxeTF5BlqoiUIsGsAAAAA//+is2vc
+        MouKS3QUPBXyUlPRnQN0DQAAAP//oq9rUhRK8hWA+hNLQAklVQGiuxbmGAAAAAD//6KvY/QKKhXS
+        MnNAroAHDNARAAAAAP//onP8gIKhKLUgvzizJL8oM7XYCuIWoEMAAAAA///CUXrlFxAqvPILkJwB
+        MgkAAAD//6JSOWiIpxzMz8+JLy0GVSPgCgjEL4VVQYblKSHhrhF+AcHhWakRYWW5ln75wWFApXmJ
+        uSDNoEgA1g6JRckZYMuABT/Q6FoseQcAAAD//6JS3Bhixg2kDsoC1llwxQVAz2cm5oAFoYU70AkA
+        AAAA//8aSCdUx4DDChhssAQLdBAAAAD//xpIB6XGAKvbGIgRetAAAgAAAP//Gkj3FFTGKNUihQ0A
+        AAD//6JKFjKEmAUAAAD//0pFbZdh9RGKpBKSD1DaRMi5BUvLqBapaYTWDLIwrgU5BQAAAP//SkVv
+        ImJ6CFlOCTUTAQAAAP//AwAhUxxqYQoAAA==
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+      cache-control:
+      - no-cache
+      date:
+      - Sat, 14 Dec 2024 22:41:50 GMT
+      request-id:
+      - req_vrtx_01LAs6SZb8qkPCowMkCB4tam
+      server:
+      - hypercorn-h11
+      x-accel-buffering:
+      - 'no'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: grant_type=refresh_token&client_id=764086051850-6qr4p6gpi6hn506pt8ejuq83di341hur.apps.googleusercontent.com
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '268'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - python-requests/2.32.2
+      x-goog-api-client:
+      - gl-python/3.11.0rc1 auth/2.36.0 cred-type/u
+    method: POST
+    uri: https://oauth2.googleapis.com/token
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/72UO5OjOBSF8/kVXR2v3SBDt5kMY142D/M2JC4QMggjwAabx9T+94WeYMLJNlCp
+        6kr6ztU5Kv368fb2HkOI2vbS1TdUvf98ex9jwK1jircDlnyx++LW0gkJT9OGKgFqNHZPFf45swO4
+        59G+c3PfUWr20fDXyNfEuy9K269q6vfjTtXa0tm+NP1UUJPsIsi6odweTWBtTjYvsunt9NzjFRFw
+        IVlHz3D4L9rJ9jVbC4k7UkIeFS577a5seIz5sXvlW5QEhYhzKKSmoLR2fABYj4UsPPKe6PC26EiW
+        Ip+BjnPPlLfhYAgUKpjYPkGrbrBF0V/s+z/LndHQ4AdqL3i58YbluO9qC+sGLRbMU4XTt7zrmvbn
+        x0ff9+usrrMSxQ1u17AmH/Gzyz/ae9mixwtDtC7rDFd/PQDL+pmumjLurvWD/HX7c6bj6lqvEYlx
+        +bvz75gu3fi70R2KH+jxewWnfzJE4yFPZIhNfHC8SaUNrLYq6ZpIUD/VwgOGHJVhYJThNA9ikzAQ
+        N/okDmFR3kzZ2+hAp/QiG0w5HE1XHI3CwppwoNCZX5hHn7bw1VrPMg3c6EupThW7h1P90oBUhICj
+        k8qeNJK+EpC2kcMWCaAWRI6qBaFuZmRv7sPecEXGcPnOqKTRUHgQbXaNQfLnXANQsZgoaGjoZlMk
+        3yZjL9XpWX2G510PR7ZKAFclsk9D4I+z5jOV/Wcq/NFKA+v/0prSQF20Bn2fscY0GzvxrF54jF5Y
+        k+lms53qsq/+jqAyytmfETlsk4xLNH4XBmWrFjWGhKvDgHmGQZrDKs0TcTdFAUvB6vaMg+3CKJNA
+        ahKJA9H50ESkLBdmqhzoyOlxeLavsSxN8aJDJGCI0uSc+SGa0k/Xy1+pnwtewXfm/DxmVhOeZ4+K
+        JX5r1N1w0N3vfhg4n9ddOPugDqYLB72i1o6WjUdVQxdG27squCteMz3szKsubOc/6VcFmLZRvyQK
+        JUOxAoP5GW4oa5cTrb8Hlt97PYLi9kJnfTZwqawFJfT5+6AfJ2l6TAAo7UG1vPFI3JJbYbPKUt8z
+        4oFA5Qtf2cPBuAloE+Evlfl08IoTiGUGV+EWIRNlus3dW4U5ka18CowTxYwaEMmInuMKmsD3gXv3
+        AL7emfBo18ymK2jIdGOsP1RJ0E7qTqKlQLoL5MVsVwWhW/Fyoz1bDaEUzV+dkNthgdzA7VyRLR/g
+        xEVpEzjAau5J1cu1VYyYI7Gta6FfNKUhdtej1J208yTF0e7QEFuIKFNWZEkVDkq5TWrCUKzYvRq/
+        f//x73+TiqysiQUAAA==
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 14 Dec 2024 22:41:52 GMT
+      Expires:
+      - Mon, 01 Jan 1990 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - scaffolding on HTTPServer2
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"content": "Given the chain of thought below for coming
+      up with a fix for the issue:\nnot started yet\n\nWrite the next under-20-word
+      conclusion in the chain of thought based on the notes below.  The criteria for
+      a good conclusion are that it should be a large, novel jump in insights, not
+      similar to any item in the existing chain of thought, it should be a complete
+      conclusion after some meaty analysis, not a plan of what to analyze next, and
+      it should be valuable for coming up with a fix for the issue. It should also
+      be very concrete, to-the-point, and specific. Every item in the chain of thought
+      should read like a chain that clearly builds off of the previous step.\n\nIf
+      you do write something, write it so that someone else could immediately understand
+      your point in detail.\n\nNOTES TO ANALYZE:\nLet me think about this step by
+      step.\n\n1) First, I need to locate the index.py file in the repositories:",
+      "role": "user"}], "model": "gpt-4o-mini-2024-07-18", "temperature": 0.0}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - redacted
+      baggage:
+      - sentry-trace_id=277f53f48740406bbc1bccb338b81d2a,sentry-environment=production,sentry-transaction=seer.automation.autofix.steps.coding_step.autofix_coding_task,sentry-sample_rate=1.0,sentry-sampled=true
+      connection:
+      - keep-alive
+      content-length:
+      - '1004'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      sentry-trace:
+      - 277f53f48740406bbc1bccb338b81d2a-ac5abec217122bb9-1
+      user-agent:
+      - OpenAI/Python 1.55.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 1.55.0
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.0rc1
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4ySQYvbMBCF7/4Vg85xsN2QlNxKt7Dsoae2UEoxijy2ZyNrVGkMTZf89yInG3vZ
+        LfSiw3zznuaN9JQBKGrUHpTptZjB2/wDftt9P96PI7UPH/8Md92nXw/3bD/Hr0eOapUUfHhEI8+q
+        teHBWxRid8EmoBZMruXu3aYqt2VZTWDgBm2SdV7yDecDOcqrotrkxS4v31/VPZPBqPbwIwMAeJrO
+        NKdr8LfaQ7F6rgwYo+5Q7W9NACqwTRWlY6Qo2olazdCwE3TT6F96hMly7U/QkkWwdER7gtSjyUUw
+        gYSMthB4FHIdWO7IgPRawPBoGzggGD3GxCTZxTjienlfwHaMOmV2o7XX+vkWwHLnAx/ild/qLTmK
+        fR1QR3Zp2Cjs1UTPGcDPaVHji+zKBx681MJHdMmwKsqLn5rfZ6bl9gqFRduFqtyt3vCrGxRNNi5W
+        rYw2PTazdH4XPTbEC5AtUr+e5i3vS3Jy3f/Yz8AY9IJN7QM2ZF4mntsCpu/7r7bblqeBVTxFwaFu
+        yXUYfKDL52l9vW1NWWBZ4EFl5+wvAAAA//8DABko//NKAwAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8f21b42e8a6cfa92-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 14 Dec 2024 22:41:52 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=QDOD9Y8CAtevAvPZIiYqq1ACVtIMy83JYLWKKVNk3vE-1734216112-1.0.1.1-wRKSWuPqVtD7ILrEqEy7dQrE25FMAF1QYWypJZkR2t8OV8h9wS.oO54U5HGnYUbbJTjbwj2oVFiBWsKWnRXMGQ;
+        path=/; expires=Sat, 14-Dec-24 23:11:52 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=EOnTc3hobD_Cew2rOLHh0MHB8UwF5lDUG9oQB6y5brY-1734216112988-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-organization:
+      - functional-software
+      openai-processing-ms:
+      - '442'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-ratelimit-limit-requests:
+      - '30000'
+      x-ratelimit-limit-tokens:
+      - '150000000'
+      x-ratelimit-remaining-requests:
+      - '29999'
+      x-ratelimit-remaining-tokens:
+      - '149999760'
+      x-ratelimit-reset-requests:
+      - 2ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_36bf26028f38a8677eb3ba27568fa531
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"content": "You have the following repositories to work
+      with:\n- red-bob-sandwich/red-samuel-basketball\n- black-mary-sandwich/white-alice-banana\n-
+      magenta-john-table/orange-john-basketball\n\nGiven the issue: \npurple-timothy-football\nExceptions:\n\n----------\nEvent
+      Logs:\n\n----------\n\nThe user has provided the following instruction for the
+      fix: The file index.py is missing variable ''a''.\n\n# Your goal:\nProvide the
+      most actionable and effective steps to fix the issue.\n\nSince you are an exceptional
+      principal engineer, your solution should not just add logs or throw more errors,
+      but should meaningfully fix the issue. Your list of steps to fix the problem
+      should be detailed enough so that following it exactly will lead to a fully
+      complete solution.\n\nWhen ready with your final answer, detail the precise
+      plan to fix the issue.\n\n# Guidelines:\n- No placeholders are allowed, the
+      fix must be clear and detailed.\n- Make sure you use the tools provided to look
+      through the codebase and at the files you are changing before outputting your
+      suggested fix.\n- The fix must be comprehensive. Do not provide temporary examples,
+      placeholders or incomplete steps.\n- If the issue occurs in multiple places
+      or files, make sure to provide a fix for each occurrence, no matter how many
+      there are.\n- In your suggested fixes, whenever you are providing code, provide
+      explicit diffs to show the exact changes that need to be made.\n- You do not
+      need to make changes in test files, someone else will do that.\n- At any point,
+      please feel free to ask your teammates (who are much more familiar with the
+      codebase) any specific questions that would help you in your analysis.\n- EVERY
+      TIME before you use a tool, think step-by-step each time before using the tools
+      provided to you.\n- You also MUST think step-by-step before giving the final
+      answer.", "role": "user"}, {"content": "Let me think about this step by step.\n\n1)
+      First, I need to locate the index.py file in the repositories:", "role": "assistant"},
+      {"content": "Error: Repo not found. Please provide a valid repo name or external
+      ID.", "role": "user"}, {"content": "Return the pieces of context from the issue
+      details or the files in the codebase that are directly relevant to the text
+      below:\nThe index.py file likely contains critical routing logic that could
+      be causing the issue.\n\nThat means choose the most relevant codebase snippets
+      (codebase_context), event logs (breadcrumb_context), or stacktrace/variable
+      data (stacktrace_context), that show specifically what the text mentions. Don''t
+      include any repeated information; just include what''s needed.\n\nAlso provide
+      a one-line explanation of how the pieces of context directly explain the text.\n\nTo
+      know what''s needed, reference these notes:\nLet me think about this step by
+      step.\n\n1) First, I need to locate the index.py file in the repositories:",
+      "role": "user"}], "model": "gpt-4o-mini-2024-07-18", "max_tokens": 4096, "response_format":
+      {"type": "json_schema", "json_schema": {"schema": {"$defs": {"BreadcrumbContext":
+      {"properties": {"type": {"title": "Type", "type": "string"}, "category": {"title":
+      "Category", "type": "string"}, "body": {"title": "Body", "type": "string"},
+      "level": {"title": "Level", "type": "string"}, "data_as_json": {"title": "Data
+      As Json", "type": "string"}}, "required": ["type", "category", "body", "level",
+      "data_as_json"], "title": "BreadcrumbContext", "type": "object", "additionalProperties":
+      false}, "CodeSnippetContext": {"properties": {"repo_name": {"title": "Repo Name",
+      "type": "string"}, "file_path": {"title": "File Path", "type": "string"}, "snippet":
+      {"title": "Snippet", "type": "string"}}, "required": ["repo_name", "file_path",
+      "snippet"], "title": "CodeSnippetContext", "type": "object", "additionalProperties":
+      false}, "StacktraceContext": {"properties": {"file_name": {"title": "File Name",
+      "type": "string"}, "repo_name": {"title": "Repo Name", "type": "string"}, "function":
+      {"title": "Function", "type": "string"}, "line_no": {"title": "Line No", "type":
+      "integer"}, "col_no": {"title": "Col No", "type": "integer"}, "code_snippet":
+      {"title": "Code Snippet", "type": "string"}, "vars_as_json": {"title": "Vars
+      As Json", "type": "string"}}, "required": ["file_name", "repo_name", "function",
+      "line_no", "col_no", "code_snippet", "vars_as_json"], "title": "StacktraceContext",
+      "type": "object", "additionalProperties": false}}, "properties": {"explanation":
+      {"title": "Explanation", "type": "string"}, "codebase_context": {"items": {"$ref":
+      "#/$defs/CodeSnippetContext"}, "title": "Codebase Context", "type": "array"},
+      "stacktrace_context": {"items": {"$ref": "#/$defs/StacktraceContext"}, "title":
+      "Stacktrace Context", "type": "array"}, "event_log_context": {"items": {"$ref":
+      "#/$defs/BreadcrumbContext"}, "title": "Event Log Context", "type": "array"}},
+      "required": ["explanation", "codebase_context", "stacktrace_context", "event_log_context"],
+      "title": "InsightContextOutput", "type": "object", "additionalProperties": false},
+      "name": "InsightContextOutput", "strict": true}}, "stream": false, "temperature":
+      0.0}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - redacted
+      baggage:
+      - sentry-trace_id=277f53f48740406bbc1bccb338b81d2a,sentry-environment=production,sentry-transaction=seer.automation.autofix.steps.coding_step.autofix_coding_task,sentry-sample_rate=1.0,sentry-sampled=true
+      connection:
+      - keep-alive
+      content-length:
+      - '5117'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      sentry-trace:
+      - 277f53f48740406bbc1bccb338b81d2a-ad405464f90702ff-1
+      user-agent:
+      - OpenAI/Python 1.55.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - beta.chat.completions.parse
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 1.55.0
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.0rc1
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//nJRNb9swDIbv+RWCdumAuI3TLOlyK7DTjsNQYKsLg5ZoS40saRLdJgvy
+        3wc5aZygHfZxsWG+5IuHtKjtiDGuJV8yLhSQaL3JbvFu8V3dLn6Kx7pufVBK3X270Z8+rzdfIh+n
+        Clc9oqCXqkvhWm+QtLN7WQQEwuSaL65n03ye59e90DqJJpU1nrKZy1ptdTadTGfZZJHlN4dq5bTA
+        yJfsfsQYY9v+mTitxDVfssn4JdJijNAgXx6TGOPBmRThEKOOBJb4eBCFs4S2R98WHNfegIVEXvBl
+        wb8qZH3GmpgP7klLlExbqQUQRkYKiJFC1pNc+g2rtUGmIxOhExoMq11gwXWkbcOMa7QYs2elhUo5
+        AQ0+gSVGbm8SY4cMiCmw8rLg44ILJ7GCiOUBouDL+23BA3pXWmixhwwos8pVWQQrn7VQVykQoe3Q
+        ZBXEFVIFxvR+Ca/0QKovfKHupWi190i9ILHuqbEM+KPDSBeH9/tlUdg0t3fnXTGFAQ+ShxgLvhu/
+        4qwMiFXWQtgMqM9KE2ZgtMCsAgsW/pUzDcucgZ5A7sUjK1iZfqPAGLVt/sTbQoOWIHt0ymYElcEr
+        F8A2uI/8/2hb0PbihDJ9Hxnrzor+/J3RPSQbArGiAOLsOCQFn9BSaVxzJuxOz3nAuouQds12xhzi
+        u+PiGNf44Kp40I/xWlsdVRkQorNpSSI5z3t1N2LsoV/Q7mznuA+u9VSSW6FNhh/n+d6PD/fCoObz
+        2UElR2BOhHz6YfyGYymRQJt4suRcgFAoh9rhRoBOancijE76fs3zlve+d22bv7EfBCHQE8rSB5Ra
+        nPc8pAVMF+fv0o5z7oF53ETCtqy1bTD4oPfXVu3LeS3yCeYTrPhoN/oFAAD//wMArnwAr8QFAAA=
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8f21b4333f1cebed-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 14 Dec 2024 22:41:55 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=FSe_7TeuZ_2aDw0LRG8XkACWrB6q_7dWbwlU0nZwHtE-1734216115-1.0.1.1-p5aOmjbVh6f_99ZFOCkriUMOVHIEX_jAOTohx0eiCM8fPssiHpJgU.EscKOzmsf7qfWwZlvcG_XPCSkeOvaV6w;
+        path=/; expires=Sat, 14-Dec-24 23:11:55 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=8TyfgfAarbIfpzMfTcqtp9txAEgPLznw6pqFqiuMKvo-1734216115312-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-organization:
+      - functional-software
+      openai-processing-ms:
+      - '2062'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-ratelimit-limit-requests:
+      - '30000'
+      x-ratelimit-limit-tokens:
+      - '150000000'
+      x-ratelimit-remaining-requests:
+      - '29999'
+      x-ratelimit-remaining-tokens:
+      - '149995220'
+      x-ratelimit-reset-requests:
+      - 2ms
+      x-ratelimit-reset-tokens:
+      - 1ms
+      x-request-id:
+      - req_d44bec6608e01bd4d0b17b74ea18b2db
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens": 8192, "messages": [{"role": "user", "content": [{"type":
+      "text", "text": "You have the following repositories to work with:\n- red-bob-sandwich/red-samuel-basketball\n-
+      black-mary-sandwich/white-alice-banana\n- magenta-john-table/orange-john-basketball\n\nGiven
+      the issue: \npurple-timothy-football\nExceptions:\n\n----------\nEvent Logs:\n\n----------\n\nThe
+      user has provided the following instruction for the fix: The file index.py is
+      missing variable ''a''.\n\n# Your goal:\nProvide the most actionable and effective
+      steps to fix the issue.\n\nSince you are an exceptional principal engineer,
+      your solution should not just add logs or throw more errors, but should meaningfully
+      fix the issue. Your list of steps to fix the problem should be detailed enough
+      so that following it exactly will lead to a fully complete solution.\n\nWhen
+      ready with your final answer, detail the precise plan to fix the issue.\n\n#
+      Guidelines:\n- No placeholders are allowed, the fix must be clear and detailed.\n-
+      Make sure you use the tools provided to look through the codebase and at the
+      files you are changing before outputting your suggested fix.\n- The fix must
+      be comprehensive. Do not provide temporary examples, placeholders or incomplete
+      steps.\n- If the issue occurs in multiple places or files, make sure to provide
+      a fix for each occurrence, no matter how many there are.\n- In your suggested
+      fixes, whenever you are providing code, provide explicit diffs to show the exact
+      changes that need to be made.\n- You do not need to make changes in test files,
+      someone else will do that.\n- At any point, please feel free to ask your teammates
+      (who are much more familiar with the codebase) any specific questions that would
+      help you in your analysis.\n- EVERY TIME before you use a tool, think step-by-step
+      each time before using the tools provided to you.\n- You also MUST think step-by-step
       before giving the final answer."}]}, {"role": "assistant", "content": [{"type":
-      "tool_use", "id": "toolu_vrtx_01QQMnfZT58fZpTVRVTxu7vk", "name": "file_search",
+      "tool_use", "id": "toolu_vrtx_011wdTWEXNPSWjeXVvm9NoSV", "name": "file_search",
       "input": {"filename": "index.py"}}]}, {"role": "user", "content": [{"type":
-      "tool_result", "content": "Error: Please provide a repo name because you have
-      multiple repos.", "tool_use_id": "toolu_vrtx_01QQMnfZT58fZpTVRVTxu7vk"}]}],
+      "tool_result", "content": "Error: Repo not found. Please provide a valid repo
+      name or external ID.", "tool_use_id": "toolu_vrtx_011wdTWEXNPSWjeXVvm9NoSV"}]}],
       "stream": true, "system": "You are an exceptional principal engineer that is
       amazing at finding and fixing issues in codebases.\n\nYou have access to tools
       that allow you to search a codebase to find the relevant code snippets and view
@@ -378,17 +894,17 @@ interactions:
       authorization:
       - redacted
       baggage:
-      - sentry-trace_id=1ebd1f01f89147a689812bf9b722cef9,sentry-environment=production,sentry-transaction=seer.automation.autofix.steps.coding_step.autofix_coding_task,sentry-sample_rate=1.0,sentry-sampled=true
+      - sentry-trace_id=277f53f48740406bbc1bccb338b81d2a,sentry-environment=production,sentry-transaction=seer.automation.autofix.steps.coding_step.autofix_coding_task,sentry-sample_rate=1.0,sentry-sampled=true
       connection:
       - keep-alive
       content-length:
-      - '5723'
+      - '5728'
       content-type:
       - application/json
       host:
       - us-east5-aiplatform.googleapis.com
       sentry-trace:
-      - 1ebd1f01f89147a689812bf9b722cef9-927e4045433fbae7-1
+      - 277f53f48740406bbc1bccb338b81d2a-807ef2b7f9a18aae-1
       user-agent:
       - AnthropicVertex/Python 0.34.2
       x-stainless-arch:
@@ -408,28 +924,28 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/1SOQUvDQBCF7/kVy5yzkGxrCHus2F56EloPIsuaDKW4zsbMbKqU/He3YsUe53tv
-        Ph5OSGLVOzL7AzoWP0rRe/FWnUG+BgQLNyGU1xvsGY79JeeDm0b5dFX9uD2ttk+7dkHNZr1/kFfT
-        3K/q/HOrymCM4QI88zF76ccbewyZdcGnHvVC32mORCh6MtpUZllXxuReF0nyarDPLyWwxMGN6HMT
-        LKUQfhHjR0Lq8ArT32QakjiJb0gMtm5aU0JM8h+286yUmoviGwAA//9KhYROQWZeOlqgKCiBBJWA
-        agAAAAD//4KqgToqPiknPzkbezhiUQL0TWZeSmqFkpWBDqo8yKlQfSWpFSCFYMpKSQnkNigAWg8A
-        AAD//8JqPTAcSxLxWw9WgmI9RATVWrgyqOUxeTF5PqklwPSiUJKRmZetkJgEDDsQu1ihuCS1QCGp
-        EuE+oOsAAAAA//+ir+vATrACudFQT8FTIS81NUWhJB/mIKBzAAAAAP//orNz0oDqgWGTqpAA1qhX
-        UJkADx2gawAAAAD//6K7a3JSdRSSgNHlqZCRWJaKnJBgTgIAAAD//6Kzk0oyilJTFYpSC/KLM0vy
-        izJTi4HxpVCcmliUnAGSzC9Nz7BCcSfQjQAAAAD//6J3igfaqgt0Y4puUn6SbnFiXkp5ZnIGauAB
-        XQUAAAD//6Kvq/RB7ilOzC1NzdFNSizOTi1JSszJUaoFOgQAAAD//xqQ4EnKSUzO1s1NLKqEh5A+
-        erwBAAAA//+ir8PKMzJLUnUTczKTU4EhlAeEEKeipXqguwAAAAD//6Jzms8F1kN5JYm6WfkZebol
-        iUk5qfr5RYl5wMoJFHsAAAAA//+ir2MgjkAkIFDRaaSnEJwJqjgRxSYAAAD//6JzCJWnKqTk56mX
-        KGTn5ZcrACMSWBjAy4hKsDMSM/OKwSUrqFBDT2gAAAAA//+ir3N1gMVpcUZ+aU4KrODKzMMoHQAA
-        AAD//6JzCKYmAp2Rn5eqB62vsRX1AAAAAP//oneyB7YYgJEHjLNckMuADQUQZYXuMqDDAAAAAP//
-        wtGgyi8g1J7KL0ByFqaHAQAAAP//olJDzRBPQy0/Pye+tBjUvAU3jEH8UljTOMCozNA3P7+8OD3b
-        sSQpNd3XKCvTxwmoNC8xF6QZlJLjISkIbBmwQQo0uhYzfAAAAAD//6JSxBliRhykaZwFbErDFRcA
-        /Z6ZmAMWRGt8Qp0DAAAA//8aSOdUx2BzEQAAAP//GkgXgWIRHKGgwhwAAAD//xpIh8QA+ygxSpnY
-        cj4AAAD//xpIZ0HawUBXAd0BAAAA//8aSHdUxqB3pAAAAAD//xpI1+gAo6ooFc1BAAAAAP//GkgH
-        FeSjdOMAAAAA//8aSKfEA7MTUlsEAAAA//8aSKekQjIVpC8AScMAAAAA//8aSOfAeyNICQfoJAAA
-        AAD//xpIJ6G2+oGOAQAAAP//GkjHgPtIqGEDAAAA//8aSOdAe2sYbUMAAAAA//8aUDdBW/5K0AEv
-        AAAAAP//Gki35MQo1WKpzQEAAAD//6JKc9AQ1UwAAAAA//9KRR31xOpBFEklJA+hjDgit/mwjDvW
-        Ig08og0yGloaYXRFAQAAAP//QnMXNl8iyylhBBYAAAD//wMA/ac67c8VAAA=
+        H4sIAAAAAAAC/1SOwWrDMBBE7/4Ks2cLbLVxi44hvbTX0ksJQtiLCVZXrnZlEoL/PUpIQrK3eTM7
+        DM5IYso/ZHYDWhYXpeidOFMeQQ4TgoEnE6qbBnOEXX/2ebBzlL2tm88wxO5jTQ1/ja37fhvacfOz
+        yT/PVRnE4M/AMe9yL116Q48+s8671KN6USvFgQhFzVrpWr82tdY51wWSvBrM77YCljDZiC4nwVDy
+        /ooY/xNShzeY7pNpSmIljEgMpmnf2wpCkkeol6V8vKUoTgAAAP//SoWEU0FmXjpa8CgogQSVgGoA
+        AAAA//+CqoE6Lz4pJz85G3uIYlEC9FdmXkpqhZKVgQ6qPMjRUH0lqRUghWDKSkmpFuY6AAAAAP//
+        wmozMDBLEvHbDFaCYjNEBNVGuDKovTF5MXk+qSVKtSghBAAAAP//oq8bgCkW2X6QAwAAAAD//6Kz
+        A0oyMvOyYW4AWg8AAAD//6Kz9cUlqQUKSZVIgQB0AwAAAP//GgA3WIFSgyHEGUAXAAAAAP//oq8L
+        9BTcMouKS3QUPJVqgZYDAAAA//+is/fzUlNTFEryFdKA+hQSc3KAgQB0BAAAAP//orMjMvNAxWdy
+        ajFqSgAAAAD//6KzK/LTFBJQHQAAAAD//6KvA8Cq9QoqE4DhgV4uAAAAAP//onNQABMCsGwoSk1V
+        KEotyC/OLMkvykwtVihPRQ0fAAAAAP//orOrMhLLUhUSk4HppBiYZK2UUCs4kIMAAAAA//+idx0C
+        tFUXGEQglwBtBwAAAP//oq/tKbpJ+Um6xYl5KeWZyRlIhTgAAAD//6KvM/SLUlOArsgtTc1B1OUA
+        AAAA//+irxN0kxKLs1NLkoCpFhwliIQBdAoAAAD//6KzUxSSchKTs3VzE4sq4fUJAAAA//+isxNg
+        SUK/PCOzBC3HAgAAAP//orNTEnMyk1OB0ZMHhHCHAJ0BAAAA//8akHyam5iuhNEmBgAAAP//oq9L
+        gPoTdbPyM/J00QsvkFsAAAAA//+ir1tKEpNyUvXzixLz0lPRnQN0DAAAAP//oq9jwGGCyMbwrAMA
+        AAD//8LRHckvINQbyS9AcgOqzwAAAAD//6JSF8cQTxcnPz8nvrQY1EUEdy5B/FJY99I1MzwgOKPQ
+        xT3Cw8PMMTMwyMUrMSgNqDQvMRekOS0zB9hNTU0sAhbqOpCeHtDoWuQyDQAAAP//olLcGGLGDaRj
+        mQXsiMIVFwB9nZmYAxZEdNhQQhQAAAD//xpI91THgEMMHHiYDQIAAAAA//8aSJfFgPrViGoZAAAA
+        //8aWKdAdIMb9wAAAAD//xpIh+gVgDs5AAAAAP//GkgnVMYoIcUKAAAA//8aSJfoKMQogdrX8NIO
+        AAAA//8aSMfE58GdAQAAAP//GkhnJOZiK2AAAAAA//8aSBelIudjmIMAAAAA//8a2MwManKDG//w
+        KAMAAAD//xrQKIM2N7FFHAAAAP//Gkh3QTomiE4JAAAA//8aSLeAukeg9g1yIxgAAAD//xpI98C6
+        S0q1aCOgAAAAAP//okqDyxDJQAAAAAD//0pFHZzH6j8USSUk/6AMjCM3q7AMj9cijY+jjYUbmhnV
+        oiVMAAAAAP//QnMWNh8iy4GGxgEAAAD//wMA0xdAqmcYAAA=
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -452,9 +968,9 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Thu, 12 Dec 2024 19:47:13 GMT
+      - Sat, 14 Dec 2024 22:41:53 GMT
       request-id:
-      - req_vrtx_01FCmh2avedSRNw9DR1ckkD9
+      - req_vrtx_01NH6PKWJKUFzVfozapYdwc9
       server:
       - hypercorn-h11
       x-accel-buffering:
@@ -498,7 +1014,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 12 Dec 2024 19:47:16 GMT
+      - Sat, 14 Dec 2024 22:41:55 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -516,7 +1032,7 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3; param=machine-man-preview; format=json
       X-GitHub-Request-Id:
-      - F997:368EF6:B8FFDC0:BC1CFF0:675B3DC4
+      - C457:2A4793:9851D51:9B58F37:675E09B3
       X-XSS-Protection:
       - '0'
       x-github-api-version-selected:
@@ -546,24 +1062,24 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/71TuZajSBD05yv6tb1Sc7aa8UAChBBHAeJy9KBAUNwSIETN239f6DHGHG+NcrIy
-        IyIjXv768fb2HkGY9v11aMu0ef/59j5HFLeNCN7y2HrHnDKp6Tw6sidL6+jdJXgofOBOIiItr7iQ
-        BPfFjA4vcGOeD3hCGGU6aWyKMdp4ZLiPSrN2YUPp43VPtzXg7pTHv4CpKh2KeyvnRFhRVfJFnGzB
-        vThDQ5+BLJdnC93nY2OaMgO4c3nK1bYMmwje7aoXvE8ZHF72y+gk21Bv0T4LVP4y2bwl2hI4yj6l
-        oV0KfDkIX52HNuCe3i3l4eQZQe7Y93/WndNXhx5pf0XrxjTLcd/VHrZdulqQD0PX//z4mKZpm7Vt
-        VqVRh/otbOuPaBzyD1i1Y7Lpqmi4tY/67W/tY58+UHNrt2kdoeqv7f29WgaeCKbbqs1Q87aoalDy
-        W/l3TNdh/i1USKNH+vj9g5I/GabzKY9liAx0si9YIXWk9Eo9dOFe+VSKC6XLYRV4ehXg5dVWHXgi
-        rWHxFRRVacgXWqM0QiuylyEHs+GIs14AdN6fiNTnV0zVJQG6ge1C00FaW0ttcrQmiNvnmZKKgOLI
-        uLHwuU6eMZX0oc0WMUWsEHnarBAKvUBOxiGYdEdkdIcf9Eaa9SNPhbTQ6XU+LjUKHgETeh0JnQyH
-        con1g9QmvjIGvjDBmW1iimti2SUh5c4L55jI7pjs/3AlHvi/uHDiKSvXSztkrI4XYzHPasWF0QqA
-        DSdb7FTWvvY7gkavFn/m1Ga7eF6jcYfAq3qlaBGsuTbwmDHwkhw2SR6LAg49loBNOUbe14pRxZ7U
-        xRJHhf6pC+uqWjGT44kM7QkFvnWLZAlH3zyS4dZhYfiuEhKn5V5d36UTO3VCJb2IK1YX+ItHxRo/
-        mDSsMBoOVj0MXOY1By4+8HjxD+sNsbXqJ/9JKc7FCPs75h0ri70cFWbPq16N6GewrH9E/MuZilNf
-        SBUViRJV781L6dE++QxgyXiqwMWq8yxgY0NzzoGv1j7bqqQpyPsSkjCJwCdD3KczJNypxMGj7spN
-        mX8K9K0sktKEht0WBdWHTfB5DP1zeyEe7lHNVYW0avZYWCSYbU1n+1DsoqGPm8NAE7adPkvmTiYm
-        OMTnSPSFuCvPJCgN7XrcdDnNbqRWrS2ajBh2l9zPtYT4neoiwlCPFE+3giftcYlf6lM2zFtBGFwi
-        Cy24BpETpzVfqVEh+iPi1EFOzcbc25sxvunzDVePncD1ugluRnwCTQPond3avUTz4OYVEGcGeP/x
-        73+sdDSriQUAAA==
+        H4sIAAAAAAAC/71RuZKjShD09ysmxn6j4RCSWA/EKYlGHBI0zgQ3Dc0hcQk23r8/mDXWXO8ZFR1R
+        XZWZlfnrx9vbux+Gcdt+dXURV+8/394nn2I3PsGZDlPud7CPxkIgjMlCEO3zlEv9xjzzr+kR7Iy8
+        tqKO5VOjxNl1q1jCzQU5SzdxsQsETu1pxPm2MqNHK1B3HHxc5+GwHfJZK/UGNwYlFwBaLXXAvi88
+        t3VhbROvNSIbu8M4XJ6UDLy9p3haGzan67XQeBAwlSrN9v6Rz46SOoye+McUnjlbtThTtCRDkV1K
+        Q1l225EnrFo9LdFuWilw6sKRIPfM+z/rzfGrQc+4/ULrxTTDst/dNqybeLVgeSoUvWVd17Q/Pz/H
+        cdykdZ3i2G9Quwnr8tPvu+wzxHUffTTY75L6Wf51vG/jJ6qSehOXPsJ/HW8feFkYUBhvcJ0uSr81
+        fsf01U2/hfKx/4yfv39Q9CfDeDplgRwiHZ2s26ySAKmtWnaNd1R3an6jgOxh6AAM56VKs4SOSGuz
+        +II5LnT5RmuURmh5+tJlOOm2OIHcQJfjiYhdbsU830kDJcZmoWlCWltbdaSYYzjXw4WSckixZFCZ
+        86WMhoCKWs9i8oAiVogsrlYIlV4gR12AI7DFLbC5DlTSBBSO8mi+AWXWLz0qVIyt5zRkaKezJxcz
+        EKQ6ctUeuvwYTkwVUGwVyHcypO7TwtlH8r2Pjn+4Isf4v7jmyFFXrpcmpAyYF2NnjtHy21bLjVm3
+        08VOdZ2rvyOoAF78mWKLaYJpjebeQQe3al6jsGRr6Gx76ERZWEVZIPKz5zBEWBW97xxWDBw4UhNI
+        LOW5p8YrMV4xI+VEetaIoGsmvizN/jdPdtTvfHcTRArguwJc+II4u5jlqYxIccVqoLt4lK/xG5Nm
+        w9dSq55tuOxrdrj4oL50O3yBitg0YQXZHfIvrKqnOzZj4sSQ3ESs250vZXxn4ag8nGX7WDPXIJF0
+        xUxufSMzjPwirpPS2wJ6UmYT1VE7MpQ36PRE9mNAu7HsK1yaf6nj5URXfdnuQU96ghoa4KIcXPPK
+        njgwDX5B40gcVegZom+Nz+nCBvdmUIN7YQmFKFhVw4v+rYPD4fGBrmHLq3z+RAxqBUm0TnQQ0Sr7
+        olS/K+z53Le3lhyxSoRtzVySQ06Rztlo9sTlBYg47glaQdWZKSVV2QnoWFy3EJ2bPfsYnkpx9z5M
+        cD58wQjpvXvZocBPWCTEhDXfkEmwLX88wGu2N88YPrq7xyXCVvHTLNcB80yvH8Nsy1juhHQY33/8
+        +x9b4AshiQUAAA==
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -574,7 +1090,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 12 Dec 2024 19:47:16 GMT
+      - Sat, 14 Dec 2024 22:41:56 GMT
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -593,6 +1109,129 @@ interactions:
       - SAMEORIGIN
       X-XSS-Protection:
       - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"content": "Given the chain of thought below for coming
+      up with a fix for the issue:\n1. The index.py file likely contains critical
+      routing logic that could be causing the issue.\n\nWrite the next under-20-word
+      conclusion in the chain of thought based on the notes below. If there is no
+      clear conclusion that adds a ton of new insight and value, return <NO_INSIGHT/>.
+      If it is similar to a previous conclusion, return <NO_INSIGHT/>. The criteria
+      for a good conclusion are that it should be a large, novel jump in insights,
+      not similar to any item in the existing chain of thought, it should be a complete
+      conclusion after some meaty analysis, not a plan of what to analyze next, and
+      it should be valuable for coming up with a fix for the issue. It should also
+      be very concrete, to-the-point, and specific. Every item in the chain of thought
+      should read like a chain that clearly builds off of the previous step.\n\nIf
+      you do write something, write it so that someone else could immediately understand
+      your point in detail.\n\nNOTES TO ANALYZE:\n\n\nLet me think step by step:\n\n1.
+      First, I need to find all instances of `index.py` in all three repositories
+      we have access to:\n   - red-bob-sandwich/red-samuel-basketball\n   - black-mary-sandwich/white-alice-banana\n   -
+      magenta-john-table/orange-john-basketball", "role": "user"}], "model": "gpt-4o-mini-2024-07-18",
+      "temperature": 0.0}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - redacted
+      baggage:
+      - sentry-trace_id=277f53f48740406bbc1bccb338b81d2a,sentry-environment=production,sentry-transaction=seer.automation.autofix.steps.coding_step.autofix_coding_task,sentry-sample_rate=1.0,sentry-sampled=true
+      connection:
+      - keep-alive
+      content-length:
+      - '1404'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      sentry-trace:
+      - 277f53f48740406bbc1bccb338b81d2a-b631ac88c3b65c82-1
+      user-agent:
+      - OpenAI/Python 1.55.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 1.55.0
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.0rc1
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//jJJdS8MwFIbv+ytCrldtu0+HCBPEDdx2MfEDkZKmp200TUKSiiL775J2
+        Wzuc4E0uznPeN+85ybeHEGYpniJMC2Jpqbg/g4dxMrubPGXXQbWZfyye1zO+zG+KZfS4xD2nkMkb
+        ULtXnVFZKg6WSdFgqoFYcK7huD+IwlEYDmtQyhS4k+XK+gPpl0wwPwqigR+M/XCyUxeSUTB4il48
+        hBD6rk+XU6Twiaco6O0rJRhDcsDTQxNCWEvuKpgYw4wlwuJeC6kUFkQd/XK1jherzeJ2fn9+1e3R
+        kFWGuJyi4nxX3x4u5TJXWiZmxw/1jAlmilgDMVK4C4yVCtd06yH0Wg9XHeXFSstS2djKdxDOsB8M
+        Gj/c7rSlwx2z0hLeFV30TtjFKVjCuOlsB1NCC0hbabtKUqVMdoDXGfp3mFPezeBM5P+xbwGloCyk
+        sdKQMno8cNumwf24v9oOS64DY/NlLJRxxkQOWmnWvHem4lFGwwDCABLsbb0fAAAA//8DAHZgvjv9
+        AgAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8f21b442e8d5f947-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 14 Dec 2024 22:41:56 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=aXYTHY9cgzLeMOaHnCXAqnsgUftw5XOETFOgMKcTAtI-1734216116-1.0.1.1-xDPZEAxs1.IRaT838hJAcvfVo_xSYyIBDHjB5po8e3ghUyJtK0dI_G0GYs1VLo_86LX2bb.FLbZon39vqLtUEg;
+        path=/; expires=Sat, 14-Dec-24 23:11:56 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=PDbotwwBojOGePpCpiv0cCyl84rm6G6AwTuFt2FYbUE-1734216116566-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-organization:
+      - functional-software
+      openai-processing-ms:
+      - '789'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-ratelimit-limit-requests:
+      - '30000'
+      x-ratelimit-limit-tokens:
+      - '150000000'
+      x-ratelimit-remaining-requests:
+      - '29999'
+      x-ratelimit-remaining-tokens:
+      - '149999660'
+      x-ratelimit-reset-requests:
+      - 2ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_ce8ad6525c851887e32448c4bfffe094
     status:
       code: 200
       message: OK
@@ -621,15 +1260,15 @@ interactions:
       help you in your analysis.\n- EVERY TIME before you use a tool, think step-by-step
       each time before using the tools provided to you.\n- You also MUST think step-by-step
       before giving the final answer."}]}, {"role": "assistant", "content": [{"type":
-      "tool_use", "id": "toolu_vrtx_01QQMnfZT58fZpTVRVTxu7vk", "name": "file_search",
+      "tool_use", "id": "toolu_vrtx_011wdTWEXNPSWjeXVvm9NoSV", "name": "file_search",
       "input": {"filename": "index.py"}}]}, {"role": "user", "content": [{"type":
-      "tool_result", "content": "Error: Please provide a repo name because you have
-      multiple repos.", "tool_use_id": "toolu_vrtx_01QQMnfZT58fZpTVRVTxu7vk"}]}, {"role":
-      "assistant", "content": [{"type": "tool_use", "id": "toolu_vrtx_01P2v1MoowsgkAtbegM2jiLB",
+      "tool_result", "content": "Error: Repo not found. Please provide a valid repo
+      name or external ID.", "tool_use_id": "toolu_vrtx_011wdTWEXNPSWjeXVvm9NoSV"}]},
+      {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_vrtx_01EiWPShqDGXHH6AiQRDJaRf",
       "name": "file_search", "input": {"filename": "index.py", "repo_name": "red-bob-sandwich/red-samuel-basketball"}}]},
       {"role": "user", "content": [{"type": "tool_result", "content": "Error: 404
       {\"message\": \"Not Found\", \"documentation_url\": \"https://docs.github.com/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app\",
-      \"status\": \"404\"}", "tool_use_id": "toolu_vrtx_01P2v1MoowsgkAtbegM2jiLB"}]}],
+      \"status\": \"404\"}", "tool_use_id": "toolu_vrtx_01EiWPShqDGXHH6AiQRDJaRf"}]}],
       "stream": true, "system": "You are an exceptional principal engineer that is
       amazing at finding and fixing issues in codebases.\n\nYou have access to tools
       that allow you to search a codebase to find the relevant code snippets and view
@@ -681,17 +1320,17 @@ interactions:
       authorization:
       - redacted
       baggage:
-      - sentry-trace_id=1ebd1f01f89147a689812bf9b722cef9,sentry-environment=production,sentry-transaction=seer.automation.autofix.steps.coding_step.autofix_coding_task,sentry-sample_rate=1.0,sentry-sampled=true
+      - sentry-trace_id=277f53f48740406bbc1bccb338b81d2a,sentry-environment=production,sentry-transaction=seer.automation.autofix.steps.coding_step.autofix_coding_task,sentry-sample_rate=1.0,sentry-sampled=true
       connection:
       - keep-alive
       content-length:
-      - '6247'
+      - '6252'
       content-type:
       - application/json
       host:
       - us-east5-aiplatform.googleapis.com
       sentry-trace:
-      - 1ebd1f01f89147a689812bf9b722cef9-94690e691d172c0f-1
+      - 277f53f48740406bbc1bccb338b81d2a-92cce4dfe5b828dc-1
       user-agent:
       - AnthropicVertex/Python 0.34.2
       x-stainless-arch:
@@ -711,19 +1350,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/1SOwWrDMBBE7/4Ks2cLbLmBRPfQEsght0IpQpGWYKquHO/KtAT/e5WSlOa4b2aH
-        hzOSmPoTmd0JLYubpApOnKkvIN8jgoGHEJr7DeYCQ7jmfLLzJF+27Z6HLaZ1r/3h1e/WvduE1ctx
-        X34epwqYUrwCxzyUXfrdTQFjYT66HFD1aqU4EaGoWSvd6qeu1br0fCIp1mDe3htgSaOd0JUmGMox
-        3hDjOSN5vMP8p0xjFivpA4nBdEW2gZTlP+z1stRLVf0AAAD//0qFBE5BZl46WpgoKIEElYBqAAAA
-        AP//gqqBuik+KSc/ORt7MGJRAvRMZl5KaoWSlYEOqjzIpVB9Jfn5OfGlxaBAAwc3iF8KD3Bv30Tn
-        qsxIs6iq5JTC9NxEP1+/jDyg0rzEXJDmtMwcYMSlJhYlZ4AtA3oTaDTQeygA6A8AAAAA///C6g9g
-        fJQk4vcHWAmKPyAiCPdDAjwLGEFwxQVAv2cm5oAFgSqUwKENAAAA//8aSBdUx4BDSqkWESAAAAAA
-        //8aSOeAI68W4g4AAAAA//8aSHfEAFN6DNgEpVqU1AIAAAD//xpIR1XoFVTGKClhJmEAAAAA//8a
-        SEfpAMOpKLUgPz4vEcllQEcBAAAA//8aSEflpsLDCegSAAAAAP//GkiXgJJRUk5icrZubmIRxElA
-        FwEAAAD//xpIF1XqFidiSUMAAAAA//8a0FyfUp4JLKZr4Y4BAAAA//8aSMfol6NleQAAAAD//xpI
-        x2RklqTqJuZkJqfqIgUPAAAA//8aSBclJSIyFgAAAP//GtiaIi8xRqkW4RgAAAAA///C0R7JLyDU
-        HMkvQHIKcsQDAAAA//9KRW0iYvUYiqQSkkdQmmfITRksjbRapFYaWovMwhQ1MQIAAAD//0pFb7Zi
-        +g9ZTgmmDwAAAP//AwDFrfH37woAAA==
+        H4sIAAAAAAAC/1SOQWvCQBCF7/kVYc5ZSFarsscWbemh9OJJyrIko6jrbJqZDVXJf3ctWupxvvfm
+        42GPJCY/ILPboGVxnWSNE2fyM8ixRTDwEEJxv8GcYdtcc97YvpMfW1aTuDu9T99C//z68Tl9WS4W
+        7jRfp59HVQJd8FfgmLfJS7/e0KBPrPYuNqhG6klxIEJRvVa61OOq1Dr16kCSVoNZfRXAElrboUtN
+        MBS9vyHG74hU4x3Gv8nURrES9kgMppqNJgWEKP+hHg9DPmTZBQAA//9KhQROQWZeOlqYKCiBBJWA
+        agAAAAD//4KqgbopPiknPzkbezBiUQL0TGZeSmqFkpWBDqo8yKVQfSX5+TnxpcWgQAMHN4hfCg/w
+        wjxH8xCT3MDs8OKkioI8i5CK4ioXoNK8xFyQ5rTMHGDEpSYWJWeALQN6E2g00HswAPQCAAAA///C
+        6gVgVJQk4vcCWAmKFyAiCKdDwjoLGDdwxQVAb2cm5oAFgSqUaiFuAAAAAP//Gkg3VMdAnIEUJAAA
+        AAD//xpI54CiDBx70KABAAAA//8aSLfEAJN6DMQEvQKUQAI7DQAAAP//GkinVUJiDegKAAAAAP//
+        GkhX6ACDpyi1ID8+LxE5eICuAgAAAP//GkhX5aZCIi4pJzE5Wxcz3gAAAAD//xpQtyUWQRwEdAcA
+        AAD//xrQ9KNbnJgHDRqgUwAAAAD//xpIp6SUZyZn6JdnKKEUywAAAAD//xpIF2WWpOom5mQmw10E
+        dA8AAAD//xpI96TqouUuAAAAAP//GkjHJCXmAWGMUi08HQMAAAD//8LRCMgvINQGyC9AcgvUMAAA
+        AAD//0pFbZJh9RSKpBKSJ1CaQ8hNByyNolqkVhFaC8jCFNwAAgAAAP//SkVvHWL6CFkO1B4CAAAA
+        //8DAJxabBJRCgAA
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -746,9 +1385,9 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Thu, 12 Dec 2024 19:47:18 GMT
+      - Sat, 14 Dec 2024 22:41:57 GMT
       request-id:
-      - req_vrtx_01Sqfy46stLrbiVp4UgKTDwC
+      - req_vrtx_01TRTenqZgpQi2AJSP3Rg4rv
       server:
       - hypercorn-h11
       x-accel-buffering:
@@ -792,7 +1431,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 12 Dec 2024 19:47:19 GMT
+      - Sat, 14 Dec 2024 22:41:58 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -810,7 +1449,7 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3; param=machine-man-preview; format=json
       X-GitHub-Request-Id:
-      - 28B9:146D55:9F4C1BD:A20345D:675B3DC7
+      - C45B:3AEDF4:9BBA988:9EC1C10:675E09B6
       X-XSS-Protection:
       - '0'
       x-github-api-version-selected:
@@ -840,24 +1479,24 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/72UN5OjShSF8/0VUxOvNFiZzUAgBBqQ8CZRQeMa0yCMMFvvvz+YCTbcbINObt/+
-        zr3nVPXvH29v7z4AUds+uiqP0Puvt/fJJ45bH2M0my73NJdvtFNp6Uqj8dd9TEsB9BzeUxQ71HGe
-        H8eEOPpuPc6P0JaJSLkIWLu7H/npdGuQLhQASWbWaUHKWtTLtfn6czdmdnU9+9W9LHfPwKOjvoT+
-        SUR6EOk4gdoNuXGgGQodh1GOaMu5FWD+SfbEnVyjF9ggJFNlUebWLt3dXf+UuFfGZ3RG4/WzehEc
-        QoYCVxi1g1veK7aoaQ/uUx6OA4bv6fef687RWMMmah9w3Zikj8evaguqOlotSLuubn99fAzDsE2q
-        Kikiv4btFlTlh9936UffRg1EcbWNSh8Wb39rB0XVh5u68Lu4asq/trfPYuG/IIi2RZVA9LZMhWD4
-        PflXTI9u+h6Ujfwmar5vYPgnw2iS0kAA8AYl3ZxFXIFiK5Zd7Z3EnZiZhCJ4hWsrhTsvp9TKJRhS
-        nvnRzYr8JpikTMiYnCXjTXCnm8FPSqbCz5OERQ6zMq8WrsJY3S4yNSDltVSFF20Ac/X6JM6ZSxzx
-        AGnzZxm+AiJsPZ3OAgJbEWmEVoRILsjhxrmDYvCUYjCdgs6TcmEIj2RrpUz7pUaAi0p5do0DI5k9
-        IZ8V7lyFjti7DjuAiUYBcUSBYOGAsKZFsw8Fqw9Pf7RCW/1XWnNoi6vWKHMJrcyLsTNDy5lJyZk6
-        34xksVNc+6qvCJBSLP5MkU7XwbRGY3WuXbRiVkFQHivXpnrXDlOAwjTg2dmzaQygvPftw8ooAvtc
-        B+cj4TlS7ZVFsTLDi4R7+gBdR4t94Tz7X1EDwjhLuJGbg2zVpm16mmKePbV0SRPjV1btOotH2Rq/
-        OsizSMlzvs5DgeW9bIDFB2ZW1h0cbBt1bWMxAcKCjZ6l/fGJlQ4lP+GlV4rD3djYHAwThqSXzwBR
-        HHRM/VBrggn0YLzT0a3zqfYx7zP5pdEPNet0pjDSc5AZNu9W1kF+HYKdZe5xZ3CbXODbfXkxqb6x
-        jxxb4Fdn7HSFviQpRk1lcSUf6HE1Hieq3Rw2uyrmJkjpkRhM16YatYvVQPXRbRR0k9gYhnxvkaFt
-        XFO8vrN+mKStKqY+T4siPEgNXnvsQarD/X14mmBGrM2xfRp0BSNLtxy7ii4pveLmgsMC414x3HnD
-        Th0eIB4dXDnEMdNZr6BucyrmJLOrDElKgpfUCX0aU2eg9+InFGKcbk5sfLhkRtcyT3gA6CmKx6um
-        vv/473+H5foBiQUAAA==
+        H4sIAAAAAAAC/72RuZajSBBF/f6KOmWPVKySaA9JrGIRi0Dg6EAmYiezBIhlzvz7QLfR5nhjpBMZ
+        cV/Ee3//+Pj4jABI2vbRoTJpPn9+fE4RxW0jgrd9tt7vIkKWz3eaSYyKhC7OUl6nisdTaT2FPhG8
+        JJe0qtg4C+7mpB6Gg2jEjPhUUXvY8S+mUx7S03ldN1qw4SIT81H4HKX3GL7ybwXNIulKY2kkb6v0
+        TOaJfNICWq2K+yu6AMEhdSzTRxw/Q4Y4BpMHy/jRm3l9jVDd2uawiU7xEJ3S4MIHwOFtwREtWbpT
+        ek59h00ZOAAyN/NaTGp0lB1gEeSe/fxrvTkZcf5K2ke+XkyzHPer2gKEk9WCrOtw+/PraxiGbYpQ
+        WiURztstQPVX1HfZF6hQDze4ironetUf/9Xefldt8nrnINlWKM2bj0WmyeF/zvXLVN480Tapo7z6
+        vfmvmB7d9HvRYxK9ktfvnxz+yTCZ1CyWQG7mqnObFdLIlVapOxyelJ1S3ChDCqvAN6pgXl5t14Ev
+        0PosjEFRlaZ0o3VKJ/QiHU0pmExXmIzCyrWTSiR3fmVePNLKn9Z2kcGA1tcSgrI9gBm9NUosAooj
+        48aetRq+Ywq2ocMWMUWsiCxpVoRCL8jBPAeD4QqM4fKd0YiTIfNUuCRu1Fm/1CggW0zoYxK46RxK
+        5WycRQTvSh/cjwOY2CamuCaWPBJQ3rRo9lDyenj6owV96//SmqGvrFqjfk5ZY16MnXlWL26MXliz
+        6aaLncrah35F0BjV4s+UOCyOpzUarwv8qlUKlIOaQ4HP9IEPM9DALBaOc+izBGjKPvIPK6OKfRHH
+        IkeFdxWHdVWtTCirZOgMeXC3n5EkztGqU3OE5h0Fzydtg+IEtwFDUKdU7GEnKoWVhYP74lGxxm9N
+        uhuMupuu+zBgmdddsPigjKYLRlMmtiivqZbGVx66rw0zCiYHQQj1bkLBOBt89z60+e6csBkuLRpL
+        bJyK+15MIKCqTeRxWgktBlMMPBaWlRXRSZtD5zCrKBZBCesx0B10KqipTRg1uzBEL17L957JHOvI
+        nPVyNI64uJ0tWD4vt8Nlsq5xfadx0bEyp561aaOIQEPaIFy6m5Rqjwh0NJU/HPsGGu/xvGl64Wo2
+        R58eoQ1HJdmAUo6F+UKyKtx70jWj0sH4lgWu1QbG7EcMbVuwuHyP90/FSVSh+RZMTGRFnJJHJk3v
+        ZNnMhL657NBFyUOkqm1x1IVSgUMwDoYdthx87d6AYL/3NsC34rSXd5sl5jTlsheSLt3uiK699fnj
+        n38BQ4sJYokFAAA=
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -868,7 +1507,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 12 Dec 2024 19:47:19 GMT
+      - Sat, 14 Dec 2024 22:41:58 GMT
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -915,20 +1554,20 @@ interactions:
       help you in your analysis.\n- EVERY TIME before you use a tool, think step-by-step
       each time before using the tools provided to you.\n- You also MUST think step-by-step
       before giving the final answer."}]}, {"role": "assistant", "content": [{"type":
-      "tool_use", "id": "toolu_vrtx_01QQMnfZT58fZpTVRVTxu7vk", "name": "file_search",
+      "tool_use", "id": "toolu_vrtx_011wdTWEXNPSWjeXVvm9NoSV", "name": "file_search",
       "input": {"filename": "index.py"}}]}, {"role": "user", "content": [{"type":
-      "tool_result", "content": "Error: Please provide a repo name because you have
-      multiple repos.", "tool_use_id": "toolu_vrtx_01QQMnfZT58fZpTVRVTxu7vk"}]}, {"role":
-      "assistant", "content": [{"type": "tool_use", "id": "toolu_vrtx_01P2v1MoowsgkAtbegM2jiLB",
+      "tool_result", "content": "Error: Repo not found. Please provide a valid repo
+      name or external ID.", "tool_use_id": "toolu_vrtx_011wdTWEXNPSWjeXVvm9NoSV"}]},
+      {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_vrtx_01EiWPShqDGXHH6AiQRDJaRf",
       "name": "file_search", "input": {"filename": "index.py", "repo_name": "red-bob-sandwich/red-samuel-basketball"}}]},
       {"role": "user", "content": [{"type": "tool_result", "content": "Error: 404
       {\"message\": \"Not Found\", \"documentation_url\": \"https://docs.github.com/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app\",
-      \"status\": \"404\"}", "tool_use_id": "toolu_vrtx_01P2v1MoowsgkAtbegM2jiLB"}]},
-      {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_vrtx_01GKMaCziY6ZzcdqgmaNMNhn",
+      \"status\": \"404\"}", "tool_use_id": "toolu_vrtx_01EiWPShqDGXHH6AiQRDJaRf"}]},
+      {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_vrtx_016qnA7T4mQkWsbxpn8TxszD",
       "name": "file_search", "input": {"filename": "index.py", "repo_name": "black-mary-sandwich/white-alice-banana"}}]},
       {"role": "user", "content": [{"type": "tool_result", "content": "Error: 404
       {\"message\": \"Not Found\", \"documentation_url\": \"https://docs.github.com/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app\",
-      \"status\": \"404\"}", "tool_use_id": "toolu_vrtx_01GKMaCziY6ZzcdqgmaNMNhn"}]}],
+      \"status\": \"404\"}", "tool_use_id": "toolu_vrtx_016qnA7T4mQkWsbxpn8TxszD"}]}],
       "stream": true, "system": "You are an exceptional principal engineer that is
       amazing at finding and fixing issues in codebases.\n\nYou have access to tools
       that allow you to search a codebase to find the relevant code snippets and view
@@ -980,17 +1619,17 @@ interactions:
       authorization:
       - redacted
       baggage:
-      - sentry-trace_id=1ebd1f01f89147a689812bf9b722cef9,sentry-environment=production,sentry-transaction=seer.automation.autofix.steps.coding_step.autofix_coding_task,sentry-sample_rate=1.0,sentry-sampled=true
+      - sentry-trace_id=277f53f48740406bbc1bccb338b81d2a,sentry-environment=production,sentry-transaction=seer.automation.autofix.steps.coding_step.autofix_coding_task,sentry-sample_rate=1.0,sentry-sampled=true
       connection:
       - keep-alive
       content-length:
-      - '6771'
+      - '6776'
       content-type:
       - application/json
       host:
       - us-east5-aiplatform.googleapis.com
       sentry-trace:
-      - 1ebd1f01f89147a689812bf9b722cef9-a0cd264576ee5b03-1
+      - 277f53f48740406bbc1bccb338b81d2a-ab74621791202064-1
       user-agent:
       - AnthropicVertex/Python 0.34.2
       x-stainless-arch:
@@ -1010,19 +1649,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/1SOwU7DMBBE7/mKaM+xlLhFav0FHCjXSqDKcuNVMBg7ZNdWS5V/r4sIonubN7Oj
-        wYyBVf2JRGZATWwmrqxho+oL8HlEUHBnQrNoUBdw9ubToPPEJ91263dn3dvu8Tl/9/uXoxuedvm0
-        LT/3VQVM0d+AIXKlN/z0Rou+sN6bZFGsxIOgGAKyyFLIVq67VsqS62PgshrU66EB4jjqCU1JggrJ
-        +19E+JUw9LjA9Dc5jIk1xw8MBKrbbmQDMfF/KDfzXC83V9UVAAD//0qFBFJBZl46WtgoKIEElYBq
-        AAAAAP//gqqBui0+KSc/ORt7cGJRAvRUZl5KaoWSlYEOqjzIxVB9Jfn5OfGlxaDAAwc7iF8KC3jX
-        dMe0MEOXxJSstJQ8j+BM99w0szIPoNK8xFyQ5rTMHGAEpiYWJWeALQN6F2g0qjcBAAAA///C6gVg
-        lJQk4vcCWAmKFyAiCKdDwjwLGEdwxQVAb2cm5oAFgSqUEC4BuwUAAAD//xpIt1THAIML6iCgUwAA
-        AAD//xpIp+Sk5iXCgwboFgAAAAD//xpIt+SmxgATfAzIDJCTgK4BAAAA//8aSNekVugVVMZA0w3Q
-        LQAAAAD//xpIt+gAQ6UotSA/HjkVA90EAAAA//8aSDeB8j0kvoCOAroFAAAA//8a0JQDLHrzShJ1
-        UTI5OIQAAAAA//8aSFdl5WfkoRc7AAAAAP//Gkj36JYkJuWk6udD4gsAAAD//xpIlxQl5qWnoscW
-        OHwAAAAA//8a6PjSTQK7CugSAAAAAP//GkiXJBZnp5YkwQtmoGsAAAAA//8a0DoiJ0apFhFZQNcA
-        AAAA///C0RbJLyDUFMkvQHILyCQAAAAA//9KRW0eYvURiqQSkg9QmmbIzRcsDbRapBYaWmvMwqwW
-        6BIAAAAA//9KRW+oYvoGWU4JI+kCAAAA//8DAPZ8pPPqCgAA
+        H4sIAAAAAAAC/1SOwWrDMBBE7/4Ks2cLbMUtra7pqeRQQg+FUoSwlxCsrBztytQJ/vcqbVOavc2b
+        2WFwQhJTHpDZ7dCyuChF78SZ8gwyjwgGbkyorhrMGfb9xeednaJ82rp5O241H15f2ufTMKd5vYnb
+        0/CUf26rMojBX4Bj3ude+u4NPfrMOu9Sj2ql7hQHIhQ1aaVr3Ta11jnXBZK8Gsz7RwUsYbQRXU6C
+        oeT9L2I8JqQOrzD9TaYxiZUwIDGY5vHhvoKQ5D/U7bKUP7cUxRcAAAD//0qFBFFBZl46WsgoKIEE
+        lYBqAAAAAP//gqqBuiw+KSc/ORt7YGJRAvRSZl5KaoWSlYEOqjzIvVB9Jfn5OfGlxaCgAwc6iF8K
+        C3bzJB+TFJPIUPOUtCBvo+zKdPMsD+9CoNK8xFyQ5rTMHGD0pSYWJWeALQN6Fmg02JNAxwMAAAD/
+        /8LqeGBUlCTidzxYCYrjISIIR0PCOgsYN3DFBUAPZybmgAWBKpRgAQ0NbAAAAAD//xpIt1THgAMK
+        FGYxEIcBHQQAAAD//xpIB1kpxABVoQcRAAAA//8aSBcBdeoVVMYgog3oHgAAAAD//xpI9+gAQ6go
+        tSAfEUZABwEAAAD//xpIB8VDUg8o5nIT0yHOAjoJAAAA//8aSCcBTUvUzcrPQE1IIFcBAAAA//8a
+        SFfpliQm5aTq5xcl5iEnJgAAAAD//xpIJ6WngoNJNymxGDWoQA4DAAAA//8aSIdlp5agOQjkIgAA
+        AAD//xpIFyUl5uTEKNUiuQroIAAAAAD//8JRCeYXEKoD8wuQnIPiRwAAAAD//0pFbZ5g9R2KpBKS
+        b1CaBsgVKJYGQi1SCwGtNWBhVgtzDgAAAP//SkVvLWH6DVlOCaYPAAAA//8DABEX215mCQAA
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -1045,9 +1683,9 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Thu, 12 Dec 2024 19:47:20 GMT
+      - Sat, 14 Dec 2024 22:42:00 GMT
       request-id:
-      - req_vrtx_017BSiv5wifdgL7cp3v2uuX8
+      - req_vrtx_01PmqrgdhcwkCKPuqqX6hLwh
       server:
       - hypercorn-h11
       x-accel-buffering:
@@ -1091,7 +1729,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 12 Dec 2024 19:47:21 GMT
+      - Sat, 14 Dec 2024 22:42:01 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -1109,7 +1747,7 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3; param=machine-man-preview; format=json
       X-GitHub-Request-Id:
-      - 86DE:368EF6:B9011AD:BC1E43A:675B3DC9
+      - C45E:93DB7:57AAAA5:5981461:675E09B9
       X-XSS-Protection:
       - '0'
       x-github-api-version-selected:
@@ -1139,24 +1777,24 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/72ROZejOBSF8/4VdSoeu1gL0xlggwEjF2ADIvFhtQViMYtZ+sx/H6gOOuxsAiVP
-        T9+9uvfXj7e39yCKkra9dVWelO8/396ngOK3ASFYLltwTK0NB5fV52rjq+YnmDuFS7I45WqojEAT
-        PVktjzZKrjdGBoHRSKW6SbspS3rJcSs2DA6VeHiVju2fZoyBleFelnXtqLK1KJCnFjY39yxo4xjU
-        jkk3uS48SZ6jA4jqh1OGNnURSvC0QNroJZ97oTfFe1l3i/HEVtmzlNUokO5QFxzTFqyDLZtHxaMM
-        9MJ7MRostVK4k+BwFnD61BIIkmPf/1n/nIw1apL2htYf0yzPf0/bqKqTNYJH19Xtz4+PYRi296q6
-        4ySoUbuNquIj6LvHR98mDSrTapsUAcJvf1uPcNXHmxoHXVo1xV/X2yde+C8UJVtc3VH5trgqUfzb
-        +XdNt276bVRMgiZpft+g+E+HyaQ9QiVCZ6TZ11klAVJbtehqX1I/1exKAcXH0AUYzssprAK6B9qY
-        DyPMcH5WrrRBGYSR3cezAqfz5TCBzEQnSSMST1iZukOaKDW3i0wd0cY6quKjNURz9TpRcgYpngxL
-        az4V8Suk4ta32SykiBXxSMoVodILcjjv4QAuBwZchA6U8gSOAuXTYg2KR7/MqOhoMr5bk9HlPvtK
-        PoO9XMWe2kNPHKKJLUOKL0PFISPKmRbNPlacPpb+aMWu+X9pzbGrrlqjsb+zYF6CnQXWyK6MkZnz
-        +XJf4lTXveq7ghLgJZ8psdk6nNZqnA66uFWzCkUFX0GX6aEbP6IyfoQHcfZdlojKvA/c3crAoSvX
-        ocxTvqfVfoHxyoyPGunbA4KelQaKPAerDuZz6FqtXdZZTFgSLMVX4j0oS9Ec6EUrq4beklG21m8O
-        xqwyYH9Y/TDR8t64REsOwrzkRxgesS1SlhXPtyjWsc8Lz8TXW/CCwHtGe3RjNp3IDWQKqniDXfsu
-        mak+aRwbjrNuR9an0qs7T3m16TGz6D1vt57CxGdvxwhwDOWv05WZey0hyk5v3Ea43d2WluB8ylF0
-        llU64ATvknHpEHi91vY2UygKeJINnRw7E8mapT0/EVnq42HkBsE250061YCTs/11w4iq6tOBHGe8
-        0SNZ0E12uGpkg+ZhA5h4jrX2mRTUrp6mDFQEO6lP335IWOwIKcG5QUOyPdM6fcNEIGH1sAm+dnoe
-        XkdD5jeVBuDrc58Hmfkwn7keMydfmXiJk4WS0uq9nz3V4jgON3ibrfaLIaydl92FnObOjkMVn9zw
-        /uPf/wAQXOOoiQUAAA==
+        H4sIAAAAAAAC/72RO5eiShSF8/kVvTq+2shLmQwREbFAAeWRuKBAKOSlxbNm3f9+oSeYcLIbVHLq
+        1Ld37f3rx8fHZwBhjPG9qZ5x+fnz43MMaGEZUKLpcMWapUyTGTAEhYF3C93ukmsYKVJxB9b2nSV2
+        KnXkauvoZF/X2rOp7bGnEAAvl6I2L15TQ5fTQnjpJVVBFQCxFcQL4ZYwqsQqorg+FPw+IniMwC6S
+        uccwrXMyvV/Ii4pXE5Z1jd0iYYI+tLNj4GmjGAwsQNJt+/JbnJPN1RUCKfE08fq0RFO29peD4tIA
+        OSN96jlmvTZDPRrNqjsWfJ5QqzX3+c/853io0TvGdzT/mOEE4XuKYVXHcwRp09T459dX3/fLpKqS
+        PA5qhJewKr6Ctkm/Why/UfmolnERoPzjb+swr9poUedB86jexV/X8Suf+B2C8TKvElR+TK5KFP12
+        /l3TvRl/G93GwTt+/75B0Z8O4/GYhgpEBjpaV6KudKRitWhqX1J5NbvSuuLnnqPnHplOYRaeIzOA
+        yIOX5U9DuTKABhTIksFQvNGw5VHPLugkHanYFWemdltd0OOynGRqyIB5VEUHs4ek6k70PvNoYRWW
+        JjkVURfSEfYtLgtpakakcTkjVGZC9sbO63VbZnVbbPRyP+oHkfaZba0XaTvNaHi4sL5Tr6CdEF95
+        En23ryJXbT1328ORK0NaKEPltoL0bZw020i5tZH0RytyLv+XFokcddYawC7hdDIFS0QOZFcWZBdi
+        2MkUpzrvVd8VlHo+5TPGFleH41zNrfGcHKtZhWAhVJ7Dtp4TpbCM0lDeEt/hKFg+28DZzIw8dPZ1
+        uBdo3z3WfpHnMzM6HFe+1SPPNR+BsifBrFPUN9vdP006QrHjP4Bbm075JD4tTDpwZtWeO2WUzfVf
+        RmB7A8jk2Q8Lp/fAhlMO6mDYcAQutTwJsdYBj0Db1tQTJLJj0RVKMJ8xWntusVZyKOJfUd1Yx835
+        rBNtXZ5NnG0Ljjqki8SPV4Rpzat5WqXdlVjMute5h1smvVpLrsy81ILZCdXJEVS+RkcjvVMgtPUK
+        Jm532t7cMyxZWoT4CZJLaI2GKqdbBsjx2i/TdN2V3fm0etauu0eF5PN5OCjG2NR6SJFAuXXdjifl
+        jvJWL4oxFq/wiXGROtRIC5jRpoBhFQ60c2VukaBBqct0sN2cjpnAby3luBG35OwNUiFmHjIrkxol
+        Dr1eqBduaHzoK9OTFtz7yLOyx0rii0oBWCe83eOh1N3Apfs7oM5nXLcMxTRtzznrB7ZFwl6y5PPH
+        v/8B9R3l64kFAAA=
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -1167,7 +1805,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 12 Dec 2024 19:47:21 GMT
+      - Sat, 14 Dec 2024 22:42:01 GMT
       Expires:
       - Mon, 01 Jan 1990 00:00:00 GMT
       Pragma:
@@ -1214,25 +1852,25 @@ interactions:
       help you in your analysis.\n- EVERY TIME before you use a tool, think step-by-step
       each time before using the tools provided to you.\n- You also MUST think step-by-step
       before giving the final answer."}]}, {"role": "assistant", "content": [{"type":
-      "tool_use", "id": "toolu_vrtx_01QQMnfZT58fZpTVRVTxu7vk", "name": "file_search",
+      "tool_use", "id": "toolu_vrtx_011wdTWEXNPSWjeXVvm9NoSV", "name": "file_search",
       "input": {"filename": "index.py"}}]}, {"role": "user", "content": [{"type":
-      "tool_result", "content": "Error: Please provide a repo name because you have
-      multiple repos.", "tool_use_id": "toolu_vrtx_01QQMnfZT58fZpTVRVTxu7vk"}]}, {"role":
-      "assistant", "content": [{"type": "tool_use", "id": "toolu_vrtx_01P2v1MoowsgkAtbegM2jiLB",
+      "tool_result", "content": "Error: Repo not found. Please provide a valid repo
+      name or external ID.", "tool_use_id": "toolu_vrtx_011wdTWEXNPSWjeXVvm9NoSV"}]},
+      {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_vrtx_01EiWPShqDGXHH6AiQRDJaRf",
       "name": "file_search", "input": {"filename": "index.py", "repo_name": "red-bob-sandwich/red-samuel-basketball"}}]},
       {"role": "user", "content": [{"type": "tool_result", "content": "Error: 404
       {\"message\": \"Not Found\", \"documentation_url\": \"https://docs.github.com/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app\",
-      \"status\": \"404\"}", "tool_use_id": "toolu_vrtx_01P2v1MoowsgkAtbegM2jiLB"}]},
-      {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_vrtx_01GKMaCziY6ZzcdqgmaNMNhn",
+      \"status\": \"404\"}", "tool_use_id": "toolu_vrtx_01EiWPShqDGXHH6AiQRDJaRf"}]},
+      {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_vrtx_016qnA7T4mQkWsbxpn8TxszD",
       "name": "file_search", "input": {"filename": "index.py", "repo_name": "black-mary-sandwich/white-alice-banana"}}]},
       {"role": "user", "content": [{"type": "tool_result", "content": "Error: 404
       {\"message\": \"Not Found\", \"documentation_url\": \"https://docs.github.com/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app\",
-      \"status\": \"404\"}", "tool_use_id": "toolu_vrtx_01GKMaCziY6ZzcdqgmaNMNhn"}]},
-      {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_vrtx_01EgAfV1DadjfdnHSiGmf6vH",
+      \"status\": \"404\"}", "tool_use_id": "toolu_vrtx_016qnA7T4mQkWsbxpn8TxszD"}]},
+      {"role": "assistant", "content": [{"type": "tool_use", "id": "toolu_vrtx_017bL4d4YU7dfRK2kyg7jHKq",
       "name": "file_search", "input": {"filename": "index.py", "repo_name": "magenta-john-table/orange-john-basketball"}}]},
       {"role": "user", "content": [{"type": "tool_result", "content": "Error: 404
       {\"message\": \"Not Found\", \"documentation_url\": \"https://docs.github.com/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app\",
-      \"status\": \"404\"}", "tool_use_id": "toolu_vrtx_01EgAfV1DadjfdnHSiGmf6vH"}]}],
+      \"status\": \"404\"}", "tool_use_id": "toolu_vrtx_017bL4d4YU7dfRK2kyg7jHKq"}]}],
       "stream": true, "system": "You are an exceptional principal engineer that is
       amazing at finding and fixing issues in codebases.\n\nYou have access to tools
       that allow you to search a codebase to find the relevant code snippets and view
@@ -1284,17 +1922,17 @@ interactions:
       authorization:
       - redacted
       baggage:
-      - sentry-trace_id=1ebd1f01f89147a689812bf9b722cef9,sentry-environment=production,sentry-transaction=seer.automation.autofix.steps.coding_step.autofix_coding_task,sentry-sample_rate=1.0,sentry-sampled=true
+      - sentry-trace_id=277f53f48740406bbc1bccb338b81d2a,sentry-environment=production,sentry-transaction=seer.automation.autofix.steps.coding_step.autofix_coding_task,sentry-sample_rate=1.0,sentry-sampled=true
       connection:
       - keep-alive
       content-length:
-      - '7298'
+      - '7303'
       content-type:
       - application/json
       host:
       - us-east5-aiplatform.googleapis.com
       sentry-trace:
-      - 1ebd1f01f89147a689812bf9b722cef9-b3b1f23daf1fc8a9-1
+      - 277f53f48740406bbc1bccb338b81d2a-a27c325d22b44613-1
       user-agent:
       - AnthropicVertex/Python 0.34.2
       x-stainless-arch:
@@ -1314,36 +1952,32 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/1SOwWrDMBBE7/4Ks2cLbNmFVvdAaE+FkEspQtjbJERZudqVmzT436uUpuDjvpl9
-        DE5IYsoTMrsdWhYXpRicOFNeQS4jgoFFCNX9BnOFw3DLeWenKGdbN6/fXfzYbMPTav/18nxsu7R2
-        /WP+WaoyiMHfgGM+ZC/9esOAPrPeuzSgatWD4kCEoiatdK27ptY69/pAkleDeXuvgCWMNqLLTTCU
-        vP9DjJ8Jqcc7TP+TaUxiJRyRGIxu2raCkGQB57ks56L4AQAA//9KhQROQWZeOlqYKCiBBJWAagAA
-        AAD//4KqgbopPiknPzkbezBiUQL0TGZeSmqFkpWBDqo8yKVQfSWpFSCFYMpKSQnoNBQAdAMAAAD/
-        /8LqBmBYliTidwNYCYobICKodsOVQV0QkxeT55NaguQQoBMAAAAA//+irxOA6VWhJCMzLxtIFuWX
-        pmeAeMUKxSWpBQpJlShBBHQbAAAA//+is9tArrACBZIhahABAAAA//+irzP0FDzVy4ChVJSZmqJQ
-        nJpYlAwMr3SFtPwiBYhBqOkI6D4AAAAA//+is/sKKoEOUUjMyQHFYWqqQlFqQX5xZkk+0MHFCkml
-        JegJHehCAAAAAP//onNEFqUmp2aWAYPPxMBEIbWoKL+oWEehPCMzOUMJUj4AAAAA//+id8IqTU9P
-        LS4pVijIBxmWmZijkJicDCxRFTKLi0uBoQaM25KMxBKo6wAAAAD//6Kz60oy0OIwNzM9o0QhL79E
-        ISkVEZlAhwEAAAD//6KzwwqK8gtSi3IqQRamZaaXFqWm6IGypxF6OQEAAAD//6J3BnUHJq48cLgl
-        5iYBHZZZUqmQmIfuKgAAAAD//6Kvq1JwJS4dBU+F4oz80hylWqCjAAAAAP//orejEouzFYrzgaU+
-        sG1QlJlWCSrKgPV7cUlmfl6xQkk+NNCALgMAAAD//6J3RVSpUJKamJubWJIKcocCsP0ATGDAsAKm
-        urLMlFT02AQAAAD//xqATJmbX1wCisvSIqAjgaGYUwoKNT2Yy4COAgAAAP//wtGGyS8g1ITJL0By
-        EnppDQAAAP//olLLyBBPyyg/Pye+tBjUnAQ3REH8UlhT1M3UsiysOCwsyTQ3JMk0NNcsIMg8MASo
-        NC8xF9LyzI5PjIclIrB9wDYg0PTaWoQfAAAAAP//olJ0GWJGF6QZmgVstsIVFwD9Dcx3YEHMlh7Q
-        NQAAAAD//xpI11THKAHDClq1AAAAAP//GkiHgKMrBsioRQkbAAAAAP//GkgnKcQoOedDgwYAAAD/
-        /xpId4AKZ0hoAAAAAP//GkhXpChU5qNFDgAAAP//GtBAUSjIAXYPUxUysLQoAQAAAP//GkiHpeYU
-        KGBxEgAAAP//GkgnASvYHNROCwAAAP//GkjX5CeDKqySDFiiBgAAAP//GtDIAlpbBOwQlADbuNi6
-        4AAAAAD//xpIt0Ha3NDyBwAAAP//GkiHFIHarykKKI19AAAAAP//GtCASSzJAPZ4ge4BOgQAAAD/
-        /xrQgAE3xIAmoDcHAQAAAP//GtAkXQHsgyshNXYAAAAA//8a0Co0DZbLAQAAAP//GkhXZOak2mOU
-        ySBHAQAAAP//GkhHeaojNdUBAAAA//8a0NpBoTQvMSknVQG1igAAAAD//xpIJ5XkY4stAAAAAP//
-        GtiEDNStkFmikAlxGdA5AAAAAP//Gkjn5KGMKAAdAwAAAP//GkjHVCpAimIAAAAA//8a0EZFGrgs
-        xja8CAAAAP//GkhngYZAkctiAAAAAP//GtAkDB3Gw+yAAgAAAP//GtCIAw0q6ik4QgagAAAAAP//
-        GtAeaL4O0OJSSFoGAAAA//8aSIfkgLpapWh9LQAAAAD//xrQlAMd9VLIRe8BAgAAAP//GtDWVyrE
-        3gpYEwMAAAD//xrQGkshMQnmDgAAAAD//xrQ7FSKmb0BAAAA//8a2HApz0ApAQEAAAD//xrYFIMY
-        UAYAAAD//xrQ/ATqTmXkl4OqLNRGFwAAAP//GlBXlSUWZYIbgurgshgAAAD//xpItySqK4AmfksL
-        sLUDAQAAAP//GuBOeWoKaEYA1WFAVwEAAAD//xpIVyWlKoDGyyFDBQAAAAD//xrYQcLMPOQOMdA5
-        AAAAAP//GvC+sD2WNiEAAAD//xpIR8Uo1cL7EAAAAAD//6LKFI0hitcAAAAA//9KRV36g9VTKJJK
-        SJ5AWXaDPBGDZfFNLdLqG7SVNoaWRqASBAAAAP//QnMKNn8hyymhRRIAAAD//wMACr/pEcUkAAA=
+        H4sIAAAAAAAC/1SOzU7DMBCE73mKaM+xlDj8SH4AThxQhegBIWuJV6WqWYfsOhRVeXdcRBHZ23wz
+        OxqaidXV7ySCO/KiOGkVUNHVJ9CvkcDByoTmosGdYB/Ovuz8POnRt93DI36Gt3DXj1vc3B/T9mlz
+        Q6/lZ11VwJTiGaDIvvTyT28KFAsbIuZApjfXRhIzqZmtsa296lprS25IrGU1uOeXBkTT6CfCkgTH
+        OcZfJPSRiQe6wPw3mcesXtOBWMDZrr9tIGVdwWWp/91SVd8AAAD//0qFBFNBZl46WugoKIEElYBq
+        AAAAAP//gqqBui4+KSc/ORt7gGJRAvRWZl5KaoWSlYEOqjzIzVB9JakVIIVgykpJqRbuPAAAAAD/
+        /8JqNTAwSxLxWw1WgmI1RATVSrgyqMUxeTF5PqklSrUoQQQAAAD//6KvG4ApVqEkIzMvG0gW5Zem
+        Z4B4xQrFJakFCkmVEKcBHQUAAAD//6Kzo0DWW4GCx1AJJQWB3QIAAAD//6KvW/QU3DKLikuQEgkA
+        AAD//6Kv/ToKngolRZmpSrVAqwEAAAD//6Kv1SkKJfkKxamJRckZCmn5RQoQ3bXo8QEAAAD//6Jz
+        fBRUKiQmF+UXFysk5uQoFKUW5BdnluQDQ6hYRyGpFDk3Ad0GAAAA//+ic7r1VMhLTQW7AGg3AAAA
+        //8aiMgqSE3OTKtUKM/ITM7AjCkAAAAA//+ic2jA46ZSD+EWoDMAAAAA//+idylrpAfKQxmpeXBX
+        AB0BAAAA//+ic1iAsnAKNDOB6zn0uAEAAAD//6KzezLzFFIT0dMI0BkAAAAA//8asCQCKl0yyzJT
+        SoG5uhI9J8OdBwAAAP//orPzgA2f/FKgOUXAuDMxMFFILSrKLypGqgsAAAAA//+ic9kXk2esp+CU
+        CiyMU1FyFAAAAP//onOwFBTlJ6empgDTsUJaaREwZxUBaymkUAEAAAD//6J3ayEjvzQnRSGxOFsh
+        t1KhJDUxNzexJBVYPyTlY6YioPMAAAAA//+id9bPSAXaVVSUmoxWOQEAAAD//xq4vJaYnAzsQMBb
+        dwAAAAD//6KzQxLzUhSA+hNLMvPzFPLToIECdAcAAAD//xqAiAFrAbYpEI4AAAAA//+isyPSMnNS
+        9TCKYQAAAAD//8LRB8ovINQFyi9AcgKSgQAAAAD//6JSp8oQT6cqPz8nvrQY1CcF92ZB/FJYfzY0
+        M7y0wiI0Iz8zwjEl1bzI1yUszNcNqDQvMRfSfc2OT4wH9jSLQYkCbB+wIwk0vRaWRgEAAAD//6JS
+        tBhiRgukI5sF7PjCFRcAPZ2ZmAMWROohwkMTAAAA//8aSMdUxyght2MAAAAA//8aSKcA4wvkFKAr
+        AAAAAP//GkhXgJNMjJKVQoySc34pSlwBXQYAAAD//xpIlwErpcr8UoWM1BwstRAAAAD//xpIhxWA
+        uv2ZKYgWMdA9AAAAAP//Gkj3lGSmwXpNAAAAAP//GkhnQDtOCkVYogsAAAD//xpIdyEq7mRofgMA
+        AAD//xpI1wANhLoCAAAA//8aSFckZuYVQ2tweDsGAAAA//8aSPdAmhEKaahNPAAAAAD//xpIFwEb
+        FgrlqaARiRQFLAkaAAAA//8a0Pyer5CbD3QT0BkAAAAA//8a0DjLTKu0V3DMKc7XgTgGAAAA//8a
+        SMcolKMNBAMAAAD//xpIx2QkotejAAAAAP//GtDkopBZDO1G5aIFEgAAAP//GtBaNCe1JFWhADXH
+        AwAAAP//GtAysSQDNApYkgEtnwEAAAD//xrQ0qcY1LWBOgQAAAD//xrQytM+RqkWc7wNAAAA//+i
+        Sg/LEGIWAAAA//9KRZ38w+oxFEklJI+gTLwh96KwTL/VIs2/oc21GZqZwqpBAAAAAP//QnMONk8h
+        yylBdAEAAAD//wMA/0WT9MIcAAA=
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -1366,13 +2000,333 @@ interactions:
       cache-control:
       - no-cache
       date:
-      - Thu, 12 Dec 2024 19:47:22 GMT
+      - Sat, 14 Dec 2024 22:42:02 GMT
       request-id:
-      - req_vrtx_018qXsvUMaqfmB7xzWEgUuMp
+      - req_vrtx_01SJphhHsL1ygR6m8zpZXyBA
       server:
       - hypercorn-h11
       x-accel-buffering:
       - 'no'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"content": "Given the chain of thought below for coming
+      up with a fix for the issue:\n1. The index.py file likely contains critical
+      routing logic that could be causing the issue.\n\nWrite the next under-20-word
+      conclusion in the chain of thought based on the notes below. If there is no
+      clear conclusion that adds a ton of new insight and value, return <NO_INSIGHT/>.
+      If it is similar to a previous conclusion, return <NO_INSIGHT/>. The criteria
+      for a good conclusion are that it should be a large, novel jump in insights,
+      not similar to any item in the existing chain of thought, it should be a complete
+      conclusion after some meaty analysis, not a plan of what to analyze next, and
+      it should be valuable for coming up with a fix for the issue. It should also
+      be very concrete, to-the-point, and specific. Every item in the chain of thought
+      should read like a chain that clearly builds off of the previous step.\n\nIf
+      you do write something, write it so that someone else could immediately understand
+      your point in detail.\n\nNOTES TO ANALYZE:\n\n\nLet me think through this step
+      by step:\n\n1. First, I tried to search for index.py across all repositories,
+      but I need to specify which repository.\n2. I then tried searching in each repository
+      individually, but encountered 404 errors.\n3. Before proceeding further, I should
+      ask my teammates about the correct repository access and location of the index.py
+      file.", "role": "user"}], "model": "gpt-4o-mini-2024-07-18", "temperature":
+      0.0}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - redacted
+      baggage:
+      - sentry-trace_id=277f53f48740406bbc1bccb338b81d2a,sentry-environment=production,sentry-transaction=seer.automation.autofix.steps.coding_step.autofix_coding_task,sentry-sample_rate=1.0,sentry-sampled=true
+      connection:
+      - keep-alive
+      content-length:
+      - '1503'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      sentry-trace:
+      - 277f53f48740406bbc1bccb338b81d2a-b6636a19d1430a27-1
+      user-agent:
+      - OpenAI/Python 1.55.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 1.55.0
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.0rc1
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//jFLBbtNAEL37K0Z7jiM7CU3JDQmEygFaCfWCkLVZj+2B9c6yMwHSKv+O
+        7KRxKorEZQ/z5j2992YfMwBDtdmAcZ1V10efv8H7tf/xzra/kn6i+/X75dsb/Pjw4ebu9u7WzAYG
+        b7+h0yfW3HEfPSpxOMIuoVUcVMv1crUor8rFqxHouUY/0Nqo+YrzngLli2Kxyot1Xl6f2B2TQzEb
+        +JIBADyO7+Az1PjbbKCYPU16FLEtms15CcAk9sPEWBEStUHNbAIdB8UwWv/cIThOCZ1CwshCymkP
+        NtRgnUMRiJh6EiEOAjYhoAgGJetBGTw7q3hcD9bvHxC0QxhNzuMeGvII2DTolH6i388vbSRsdmKH
+        KsLO+9P8cM7luY2Jt3LCz/OGAklXJbTCYcggytGM6CED+Dr2t3tWiYmJ+6iV8ncMg+CyKI96Zjrb
+        hJbXJ1BZrb9gla9nL+hVNaolLxcXMM66DuuJOp3L7mriCyC7SP23m5e0j8kptP8jPwHOYVSsq5iw
+        Jvc88bSWcPjV/1o7tzwaNrIXxb5qKLSYYqLjn2piddW4ssCywK3JDtkfAAAA//8DAAff+YZhAwAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8f21b47feae39676-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 14 Dec 2024 22:42:05 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=Zw10iUv79rjoU3UKrubfVX74jlR3bh.cgsF_7goaFAw-1734216125-1.0.1.1-9Xdw5ifkv4G7d9sm.Rj.w8B.gkXLtphCW24o.AkPEWMLn.BvbTWXYDYU3RpdW8R25wlt_mMm_2edyUCzwO1yLw;
+        path=/; expires=Sat, 14-Dec-24 23:12:05 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=sfncSAB4PMa.3sMnJ0ViFSfjunKZv.dSscp287wG4ws-1734216125761-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-organization:
+      - functional-software
+      openai-processing-ms:
+      - '242'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-ratelimit-limit-requests:
+      - '30000'
+      x-ratelimit-limit-tokens:
+      - '150000000'
+      x-ratelimit-remaining-requests:
+      - '29999'
+      x-ratelimit-remaining-tokens:
+      - '149999636'
+      x-ratelimit-reset-requests:
+      - 2ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_43a2b8fb726d72a14c17478560fcc87b
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages": [{"content": "You have the following repositories to work
+      with:\n- red-bob-sandwich/red-samuel-basketball\n- black-mary-sandwich/white-alice-banana\n-
+      magenta-john-table/orange-john-basketball\n\nGiven the issue: \npurple-timothy-football\nExceptions:\n\n----------\nEvent
+      Logs:\n\n----------\n\nThe user has provided the following instruction for the
+      fix: The file index.py is missing variable ''a''.\n\n# Your goal:\nProvide the
+      most actionable and effective steps to fix the issue.\n\nSince you are an exceptional
+      principal engineer, your solution should not just add logs or throw more errors,
+      but should meaningfully fix the issue. Your list of steps to fix the problem
+      should be detailed enough so that following it exactly will lead to a fully
+      complete solution.\n\nWhen ready with your final answer, detail the precise
+      plan to fix the issue.\n\n# Guidelines:\n- No placeholders are allowed, the
+      fix must be clear and detailed.\n- Make sure you use the tools provided to look
+      through the codebase and at the files you are changing before outputting your
+      suggested fix.\n- The fix must be comprehensive. Do not provide temporary examples,
+      placeholders or incomplete steps.\n- If the issue occurs in multiple places
+      or files, make sure to provide a fix for each occurrence, no matter how many
+      there are.\n- In your suggested fixes, whenever you are providing code, provide
+      explicit diffs to show the exact changes that need to be made.\n- You do not
+      need to make changes in test files, someone else will do that.\n- At any point,
+      please feel free to ask your teammates (who are much more familiar with the
+      codebase) any specific questions that would help you in your analysis.\n- EVERY
+      TIME before you use a tool, think step-by-step each time before using the tools
+      provided to you.\n- You also MUST think step-by-step before giving the final
+      answer.", "role": "user"}, {"content": "Let me think about this step by step.\n\n1)
+      First, I need to locate the index.py file in the repositories:", "role": "assistant"},
+      {"content": "Error: Repo not found. Please provide a valid repo name or external
+      ID.", "role": "user"}, {"content": "\n\nLet me think step by step:\n\n1. First,
+      I need to find all instances of `index.py` in all three repositories we have
+      access to:\n   - red-bob-sandwich/red-samuel-basketball\n   - black-mary-sandwich/white-alice-banana\n   -
+      magenta-john-table/orange-john-basketball", "role": "assistant"}, {"content":
+      "Error: 404 {\"message\": \"Not Found\", \"documentation_url\": \"https://docs.github.com/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app\",
+      \"status\": \"404\"}", "role": "user"}, {"content": ".", "role": "assistant"},
+      {"content": "Error: 404 {\"message\": \"Not Found\", \"documentation_url\":
+      \"https://docs.github.com/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app\",
+      \"status\": \"404\"}", "role": "user"}, {"content": ".", "role": "assistant"},
+      {"content": "Error: 404 {\"message\": \"Not Found\", \"documentation_url\":
+      \"https://docs.github.com/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app\",
+      \"status\": \"404\"}", "role": "user"}, {"content": "\n\nLet me think through
+      this step by step:\n\n1. First, I tried to search for index.py across all repositories,
+      but I need to specify which repository.\n2. I then tried searching in each repository
+      individually, but encountered 404 errors.\n3. Before proceeding further, I should
+      ask my teammates about the correct repository access and location of the index.py
+      file.", "role": "assistant"}, {"content": ".", "role": "user"}, {"content":
+      "Return the pieces of context from the issue details or the files in the codebase
+      that are directly relevant to the text below:\nThe correct repository and access
+      permissions are essential to locate and analyze the index.py file effectively.\n\nThat
+      means choose the most relevant codebase snippets (codebase_context), event logs
+      (breadcrumb_context), or stacktrace/variable data (stacktrace_context), that
+      show specifically what the text mentions. Don''t include any repeated information;
+      just include what''s needed.\n\nAlso provide a one-line explanation of how the
+      pieces of context directly explain the text.\n\nTo know what''s needed, reference
+      these notes:\n\n\nLet me think through this step by step:\n\n1. First, I tried
+      to search for index.py across all repositories, but I need to specify which
+      repository.\n2. I then tried searching in each repository individually, but
+      encountered 404 errors.\n3. Before proceeding further, I should ask my teammates
+      about the correct repository access and location of the index.py file.", "role":
+      "user"}], "model": "gpt-4o-mini-2024-07-18", "max_tokens": 4096, "response_format":
+      {"type": "json_schema", "json_schema": {"schema": {"$defs": {"BreadcrumbContext":
+      {"properties": {"type": {"title": "Type", "type": "string"}, "category": {"title":
+      "Category", "type": "string"}, "body": {"title": "Body", "type": "string"},
+      "level": {"title": "Level", "type": "string"}, "data_as_json": {"title": "Data
+      As Json", "type": "string"}}, "required": ["type", "category", "body", "level",
+      "data_as_json"], "title": "BreadcrumbContext", "type": "object", "additionalProperties":
+      false}, "CodeSnippetContext": {"properties": {"repo_name": {"title": "Repo Name",
+      "type": "string"}, "file_path": {"title": "File Path", "type": "string"}, "snippet":
+      {"title": "Snippet", "type": "string"}}, "required": ["repo_name", "file_path",
+      "snippet"], "title": "CodeSnippetContext", "type": "object", "additionalProperties":
+      false}, "StacktraceContext": {"properties": {"file_name": {"title": "File Name",
+      "type": "string"}, "repo_name": {"title": "Repo Name", "type": "string"}, "function":
+      {"title": "Function", "type": "string"}, "line_no": {"title": "Line No", "type":
+      "integer"}, "col_no": {"title": "Col No", "type": "integer"}, "code_snippet":
+      {"title": "Code Snippet", "type": "string"}, "vars_as_json": {"title": "Vars
+      As Json", "type": "string"}}, "required": ["file_name", "repo_name", "function",
+      "line_no", "col_no", "code_snippet", "vars_as_json"], "title": "StacktraceContext",
+      "type": "object", "additionalProperties": false}}, "properties": {"explanation":
+      {"title": "Explanation", "type": "string"}, "codebase_context": {"items": {"$ref":
+      "#/$defs/CodeSnippetContext"}, "title": "Codebase Context", "type": "array"},
+      "stacktrace_context": {"items": {"$ref": "#/$defs/StacktraceContext"}, "title":
+      "Stacktrace Context", "type": "array"}, "event_log_context": {"items": {"$ref":
+      "#/$defs/BreadcrumbContext"}, "title": "Event Log Context", "type": "array"}},
+      "required": ["explanation", "codebase_context", "stacktrace_context", "event_log_context"],
+      "title": "InsightContextOutput", "type": "object", "additionalProperties": false},
+      "name": "InsightContextOutput", "strict": true}}, "stream": false, "temperature":
+      0.0}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - redacted
+      baggage:
+      - sentry-trace_id=277f53f48740406bbc1bccb338b81d2a,sentry-environment=production,sentry-transaction=seer.automation.autofix.steps.coding_step.autofix_coding_task,sentry-sample_rate=1.0,sentry-sampled=true
+      connection:
+      - keep-alive
+      content-length:
+      - '6875'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      sentry-trace:
+      - 277f53f48740406bbc1bccb338b81d2a-a93029973b78d1fd-1
+      user-agent:
+      - OpenAI/Python 1.55.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - beta.chat.completions.parse
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - Linux
+      x-stainless-package-version:
+      - 1.55.0
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.11.0rc1
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//jFTRbpswFH3PV1z5OakgYemat1XapGlaNWnVXkqFHHMBt8bXsi9dsyj/
+        PhlISLRW2guGe849nAPX3s8AhC7FBoRqJKvWmcUn/HXdfr351tzfydvP/k9a/Uhuf35/ul1mZiXm
+        sYO2T6j42HWlqHUGWZMdYOVRMkbV9HqVLdN1ulz3QEslmthWO15ktGi11YtlsswWyfUi/Th2N6QV
+        BrGBhxkAwL6/Rp+2xFexgWR+rLQYgqxRbE4kAOHJxIqQIejA0rKYT6Aiy2h76/vcAuQCX52RVkb3
+        udhALu4bhJ72ytDoujG6bjgANwgWsYSKPCjyHhWDR0dBM/kdSKUwBGACQ0oy9g295Su3g0obnIMM
+        IJmxddwTxxYddUJnGEvQFtB78uEqF/PBoKIStzJgMZqKLh8eRzCwVM/spXobxhe0XBiqL9CIAeyH
+        JdJ453AI3798fPWAxSw1+d2AT4GLwf0Fd0vlyMuSbAgCaBV1ltFjCb8bbRDY77Stzz7ASVTjKfcg
+        aPAFzXvOSsmykKF4Csdft8/z/DgU8XYD8XpHDF+os2V8mPelwJK7MFGyJIvLIReD/CEuj7k9nM+O
+        x6oLMs6v7YwZ64fTMBqqnadtGPFTvdJWh6bwKAPZOHiByYkePcwAHvuh7y7mWDhPreOC6RltFExX
+        2WoQFNNmO4PT9YgysTRnQPbhZv6GZFEiS23C2c4RSqoGy6l32mayKzWdAbOz4P/6eUt7CK9t/T/y
+        E6AUOsaycB5LrS4zTzSP8TR6j3b60L1hEXaBsS0qbWv0zuvhLKhcsa5UmmCa4FbMDrO/AAAA//8D
+        ALqAMXwZBQAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 8f21b483488606a9-SJC
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 14 Dec 2024 22:42:07 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=zevYr8rlB7wxdM8ZMnwjuDw5UOe3v_VTUewoIlBU5sU-1734216127-1.0.1.1-hd7PZH9JBxwctneJ1c7zn4aEpzmFzeOgQR5haFXvBU2mxwAycyYWXwanMXaJB1SBSIEfKz1Xb2UfyVwMNijEhg;
+        path=/; expires=Sat, 14-Dec-24 23:12:07 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=RY8mRbQDxXPAN7g287aHGTTohwuy0IpVAEt4Zn_1QQM-1734216127567-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      openai-organization:
+      - functional-software
+      openai-processing-ms:
+      - '1461'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-ratelimit-limit-requests:
+      - '30000'
+      x-ratelimit-limit-tokens:
+      - '150000000'
+      x-ratelimit-remaining-requests:
+      - '29999'
+      x-ratelimit-remaining-tokens:
+      - '149994857'
+      x-ratelimit-reset-requests:
+      - 2ms
+      x-ratelimit-reset-tokens:
+      - 2ms
+      x-request-id:
+      - req_12cb5a7b8513b4b7ff9ff8da733db471
     status:
       code: 200
       message: OK

--- a/tests/automation/autofix/cassettes/test_run_iteration_with_insight_sharing.yaml
+++ b/tests/automation/autofix/cassettes/test_run_iteration_with_insight_sharing.yaml
@@ -1,8 +1,13 @@
 interactions:
 - request:
     body: '{"messages": [{"content": "You are a helpful assistant for fixing code.",
-      "role": "system"}], "model": "gpt-4o-mini-2024-07-18", "stream": true, "stream_options":
-      {"include_usage": true}, "temperature": 0.0}'
+      "role": "system"}, {"content": "My code has a capitalization error, first write
+      an explanation of the error and then use the tools provided to fix it: ```python\nprint(''hello
+      World!'')\n```", "role": "user"}], "model": "gpt-4o-mini-2024-07-18", "stream":
+      true, "stream_options": {"include_usage": true}, "temperature": 0.0, "tools":
+      [{"type": "function", "function": {"name": "fix_capitalization", "description":
+      "Fix the capitalization of the code", "parameters": {"type": "object", "properties":
+      {}, "required": []}}}]}'
     headers:
       accept:
       - application/json
@@ -13,7 +18,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '207'
+      - '594'
       content-type:
       - application/json
       host:
@@ -40,117 +45,335 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
+      string: 'data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"Of"},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"The"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
-        course"},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        capitalization"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"!"},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        error"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
-        Please"},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        in"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
-        provide"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
         the"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
         code"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
-        you"},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        is"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
-        need"},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        that"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
-        help"},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        the"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
-        with"},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        word"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"World"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"\""},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        is"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        incorrectly"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        capital"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"ized"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        In"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        Python"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        string"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        literals"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        are"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        case"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"-sensitive"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
         and"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
-        let"},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        if"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
-        me"},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        the"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
-        know"},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        intention"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
-        what"},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        is"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
-        issues"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
-        you''re"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
-        facing"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
-        or"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
-        what"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
-        you''d"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
-        like"},"logprobs":null,"finish_reason":null}],"usage":null}
-
-
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
         to"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"
-        achieve"},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        print"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"usage":null}
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"Hello"},"logprobs":null,"finish_reason":null}],"usage":null}
 
 
-        data: {"id":"chatcmpl-AdjQkAJGFohzdGbnHDMBNaXmnwZv9","object":"chat.completion.chunk","created":1734032790,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_bba3c8e70b","choices":[],"usage":{"prompt_tokens":16,"completion_tokens":27,"total_tokens":43,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        World"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"!\""},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        with"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        the"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        first"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        letter"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        of"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        each"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        word"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        capital"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"ized"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        then"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"Hello"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"\""},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        should"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        also"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        be"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        capital"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"ized"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        The"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        correct"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        string"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        should"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        be"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"Hello"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        World"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"!\""},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        instead"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        of"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"hello"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        World"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"!"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"\".\n\n"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"Now"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        I"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        will"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        fix"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        the"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        capitalization"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        of"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        the"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"
+        code"},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_9fy3G6SqTY1zM9h6jeFHQkkQ","type":"function","function":{"name":"fix_capitalization","arguments":""}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}"}}]},"logprobs":null,"finish_reason":null}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"usage":null}
+
+
+        data: {"id":"chatcmpl-AeVxcCaY4ykQXzRHe8Z3uoqHq8QXo","object":"chat.completion.chunk","created":1734219340,"model":"gpt-4o-mini-2024-07-18","system_fingerprint":"fp_6fc10e10eb","choices":[],"usage":{"prompt_tokens":82,"completion_tokens":98,"total_tokens":180,"prompt_tokens_details":{"cached_tokens":0,"audio_tokens":0},"completion_tokens_details":{"reasoning_tokens":0,"audio_tokens":0,"accepted_prediction_tokens":0,"rejected_prediction_tokens":0}}}
 
 
         data: [DONE]
@@ -161,20 +384,20 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 8f10388b7fbafa56-SJC
+      - 8f2202ff9b2b15f1-SJC
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Thu, 12 Dec 2024 19:46:30 GMT
+      - Sat, 14 Dec 2024 23:35:40 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=w1nB2Dksstku9oXJ9oWYHym16W1ZzburiNihqZHuyNs-1734032790-1.0.1.1-El.rBsWjOODZlGgXXH6p2i67ZRog0gkaj8ESnq3ZINww8jhtmO5fquf8rEAukKtR0w9YAGdHvsIrKSKNPyh6zg;
-        path=/; expires=Thu, 12-Dec-24 20:16:30 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=K6aMnZzrstVJcfVZgHQgQlOfVjmepVOhSRY7.JYF2TY-1734219340-1.0.1.1-h_EpHrAMelhsNnisy.UdA07JNQc44XDPslF4RRy0gjG4mOr6skL_g2nW.DY31u3Fv_N43lO.yQG0mEsCxy6O4w;
+        path=/; expires=Sun, 15-Dec-24 00:05:40 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=CMyjwHbXXVhqdbIk6cwHkBE36a22G.yDo3CAhqlevVY-1734032790598-0.0.1.1-604800000;
+      - _cfuvid=2Yk.4vkyvm2zYE2MFNsqEC2TRZl9U5bQSKkVzHVl_v4-1734219340981-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -187,7 +410,7 @@ interactions:
       openai-organization:
       - functional-software
       openai-processing-ms:
-      - '172'
+      - '142'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -199,13 +422,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '29999'
       x-ratelimit-remaining-tokens:
-      - '149999971'
+      - '149999932'
       x-ratelimit-reset-requests:
       - 2ms
       x-ratelimit-reset-tokens:
       - 0s
       x-request-id:
-      - req_a8f0d1c5791418e26386fae86d983e68
+      - req_146c295a81ce307f056585bf2df28c73
     status:
       code: 200
       message: OK
@@ -219,10 +442,13 @@ interactions:
       also be very concrete, to-the-point, and specific. Every item in the chain of
       thought should read like a chain that clearly builds off of the previous step.\n\nIf
       you do write something, write it so that someone else could immediately understand
-      your point in detail.\n\nNOTES TO ANALYZE:\nOf course! Please provide the code
-      you need help with, and let me know what issues you''re facing or what you''d
-      like to achieve.", "role": "user"}], "model": "gpt-4o-mini-2024-07-18", "temperature":
-      0.0}'
+      your point in detail.\n\nNOTES TO ANALYZE:\nThe capitalization error in the
+      code is that the word \"World\" is incorrectly capitalized. In Python, string
+      literals are case-sensitive, and if the intention is to print \"Hello World!\"
+      with the first letter of each word capitalized, then \"Hello\" should also be
+      capitalized. The correct string should be \"Hello World!\" instead of \"hello
+      World!\".\n\nNow, I will fix the capitalization of the code.", "role": "user"}],
+      "model": "gpt-4o-mini-2024-07-18", "temperature": 0.0}'
     headers:
       accept:
       - application/json
@@ -233,7 +459,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '957'
+      - '1235'
       content-type:
       - application/json
       host:
@@ -261,20 +487,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFNNi9swEL37Vww6x4udDZs0t7IttL2V0ktKMYo0srWVNEIaZ7ss+e9F
-        TjbO0i304sP74s2M/FwBCKvFFoQaJCsfXf1eP3x1X8zne/+tPaiw3n2Iu8d78+n7eGd2YlEctH9A
-        xS+uG0U+OmRL4USrhJKxpLbr21Vzu1y/ayfCk0ZXbH3kekW1t8HWy2a5qpt13W7O7oGswiy28KMC
-        AHievqVn0PhbbKFZvCAec5Y9iu1FBCASuYIImbPNLAOLxUwqCoxhqv7RGFRsDwiKvB+DVbKMAGRA
-        kUawOY+YwVBmTBkUOSf3lCbRAhxKbUMPTGBDoIOckjK5sfAZZNCAYZBBoS7iFIqaYqTEY7BsMcOj
-        5cEG4AEhJuqT9L6IznX46ea6eUIzZlm2F0bnzvjxsgpHfUy0z2f+ghsbbB66hDJTKGNnpigm9lgB
-        /JxWPr7aooiJfOSO6ReGEthu1qc8MV96ZpftmWRi6a7wZrN4I6/TyNK6fHU0oaQaUM/W+cJy1Jau
-        iOpq6r/bvJV9mtyG/n/iZ0IpjIy6iwm1Va8nnmUJy4/wL9lly1NhkZ8yo++MDT2mmOzpGZrY3RnV
-        Ntg2uBfVsfoDAAD//wMA9+aLMpQDAAA=
+        H4sIAAAAAAAAAwAAAP//jJJPb9QwEMXv+RQjnzdVkoaW7q1wQz2AkEACoWjWniQGx2PZE9E/2u+O
+        nN1utqJIXHKY37yXeTN+KgCUNWoLSo8oegquvKUv99S8c/5jhZ/Nh9CgfPt69/sOPz3eOrXJCt79
+        JC3PqgvNU3Aklv0B60golF3r68u2qW8u22YBExtyWTYEKVsuJ+tt2VRNW1bXZf32qB7ZakpqC98L
+        AICn5Zvn9Ibu1RaqzXNlopRwILU9NQGoyC5XFKZkk6AXtVmhZi/kl9Hfc4ykxfoBZCTQGKygs4+Y
+        gwD5NEdKC+JZwiwwoeiREmRTg9FAz3FCyQ4bID+i19ksEhrcWWflAdAbCJF7SsmyR2fTBNYf/seG
+        Ls5Hi9TPCfN6/Ozcsb4/ZXU8hMi7dOSnem+9TWMXCRP7nCsJB7XQfQHwY9np/GJNKkSegnTCv8hn
+        w6Z9c/BT6ylXWt8cobCgO1NdtZtX/DpDgtals6sojXoks0rXE+JsLJ+B4iz139O85n1Ibv3wP/Yr
+        0JqCkOlCJGP1y8RrW6T80v/VdtryMrBKD0lo6nrrB4oh2sM760N31eu6orqinSr2xR8AAAD//wMA
+        gbcdPXUDAAA=
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 8f10388fe8482712-SJC
+      - 8f22030c3b82f97b-SJC
       Connection:
       - keep-alive
       Content-Encoding:
@@ -282,14 +508,14 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 19:46:31 GMT
+      - Sat, 14 Dec 2024 23:35:43 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=svo2FeQ64g.ltiATvn71a85MG26AnKisw1EM90vOAbQ-1734032791-1.0.1.1-t6rtOeeAqfcn3x1Km2zeI5ujPPBEjscuF8U1XF54lKSS.O6ZDp7CV_.bQibyCsmkxfkQYv_VV99tENbmd.OFgQ;
-        path=/; expires=Thu, 12-Dec-24 20:16:31 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=COSP3.C3GnHhS7.1bI8rLiXP_XvbCWUkwLsaLJlY03Q-1734219343-1.0.1.1-6i5iRSDrXvOwHwgh41..gb3y9o9kWm8bsrpEDn4jA1N5OQEPZfBB1Fz2mjwLiQUyhmLO7w0yalNm_eoohfm.0A;
+        path=/; expires=Sun, 15-Dec-24 00:05:43 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=Ob0dFxrAH.K.rrmcq23labwgAX7yqN20ZVxfHKNJFT8-1734032791526-0.0.1.1-604800000;
+      - _cfuvid=gbnfU5jKUCJlkXrXsWbIcrVpgeNsNl7pi2vS3KbC4Vw-1734219343210-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -302,7 +528,7 @@ interactions:
       openai-organization:
       - functional-software
       openai-processing-ms:
-      - '376'
+      - '342'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -314,42 +540,51 @@ interactions:
       x-ratelimit-remaining-requests:
       - '29999'
       x-ratelimit-remaining-tokens:
-      - '149999771'
+      - '149999703'
       x-ratelimit-reset-requests:
       - 2ms
       x-ratelimit-reset-tokens:
       - 0s
       x-request-id:
-      - req_406346dfd999c6b5948c0571c8685e38
+      - req_efb92780dc6e01eb7f99379828afc118
     status:
       code: 200
       message: OK
 - request:
-    body: '{"messages": [{"content": "Of course! Please provide the code you need
-      help with, and let me know what issues you''re facing or what you''d like to
-      achieve.", "role": "assistant"}, {"content": "Return the pieces of context from
-      the issue details or the files in the codebase that are directly relevant to
-      the text below:\nEffective communication of code issues fosters collaboration,
-      leading to innovative solutions and enhanced learning opportunities within the
-      programming community.\n\nThat means choose the most relevant codebase snippets
-      (codebase_context), event logs (breadcrumb_context), or stacktrace/variable
-      data (stacktrace_context), that show specifically what the text mentions. Don''t
-      include any repeated information; just include what''s needed.\n\nAlso provide
-      a one-line explanation of how the pieces of context directly explain the text.\n\nTo
-      know what''s needed, reference these notes:\nOf course! Please provide the code
-      you need help with, and let me know what issues you''re facing or what you''d
-      like to achieve.", "role": "user"}], "model": "gpt-4o-mini-2024-07-18", "max_tokens":
-      4096, "response_format": {"type": "json_schema", "json_schema": {"schema": {"$defs":
-      {"BreadcrumbContext": {"properties": {"type": {"title": "Type", "type": "string"},
-      "category": {"title": "Category", "type": "string"}, "body": {"title": "Body",
-      "type": "string"}, "level": {"title": "Level", "type": "string"}, "data_as_json":
-      {"title": "Data As Json", "type": "string"}}, "required": ["type", "category",
-      "body", "level", "data_as_json"], "title": "BreadcrumbContext", "type": "object",
-      "additionalProperties": false}, "CodeSnippetContext": {"properties": {"repo_name":
-      {"title": "Repo Name", "type": "string"}, "file_path": {"title": "File Path",
-      "type": "string"}, "snippet": {"title": "Snippet", "type": "string"}}, "required":
-      ["repo_name", "file_path", "snippet"], "title": "CodeSnippetContext", "type":
-      "object", "additionalProperties": false}, "StacktraceContext": {"properties":
+    body: '{"messages": [{"content": "My code has a capitalization error, first write
+      an explanation of the error and then use the tools provided to fix it: ```python\nprint(''hello
+      World!'')\n```", "role": "user"}, {"content": "The capitalization error in the
+      code is that the word \"World\" is incorrectly capitalized. In Python, string
+      literals are case-sensitive, and if the intention is to print \"Hello World!\"
+      with the first letter of each word capitalized, then \"Hello\" should also be
+      capitalized. The correct string should be \"Hello World!\" instead of \"hello
+      World!\".\n\nNow, I will fix the capitalization of the code.", "role": "assistant"},
+      {"content": ".", "role": "user"}, {"content": "Return the pieces of context
+      from the issue details or the files in the codebase that are directly relevant
+      to the text below:\nCorrecting the capitalization ensures the output matches
+      standard formatting, enhancing readability and professionalism in the code.\n\nThat
+      means choose the most relevant codebase snippets (codebase_context), event logs
+      (breadcrumb_context), or stacktrace/variable data (stacktrace_context), that
+      show specifically what the text mentions. Don''t include any repeated information;
+      just include what''s needed.\n\nAlso provide a one-line explanation of how the
+      pieces of context directly explain the text.\n\nTo know what''s needed, reference
+      these notes:\nThe capitalization error in the code is that the word \"World\"
+      is incorrectly capitalized. In Python, string literals are case-sensitive, and
+      if the intention is to print \"Hello World!\" with the first letter of each
+      word capitalized, then \"Hello\" should also be capitalized. The correct string
+      should be \"Hello World!\" instead of \"hello World!\".\n\nNow, I will fix the
+      capitalization of the code.", "role": "user"}], "model": "gpt-4o-mini-2024-07-18",
+      "max_tokens": 4096, "response_format": {"type": "json_schema", "json_schema":
+      {"schema": {"$defs": {"BreadcrumbContext": {"properties": {"type": {"title":
+      "Type", "type": "string"}, "category": {"title": "Category", "type": "string"},
+      "body": {"title": "Body", "type": "string"}, "level": {"title": "Level", "type":
+      "string"}, "data_as_json": {"title": "Data As Json", "type": "string"}}, "required":
+      ["type", "category", "body", "level", "data_as_json"], "title": "BreadcrumbContext",
+      "type": "object", "additionalProperties": false}, "CodeSnippetContext": {"properties":
+      {"repo_name": {"title": "Repo Name", "type": "string"}, "file_path": {"title":
+      "File Path", "type": "string"}, "snippet": {"title": "Snippet", "type": "string"}},
+      "required": ["repo_name", "file_path", "snippet"], "title": "CodeSnippetContext",
+      "type": "object", "additionalProperties": false}, "StacktraceContext": {"properties":
       {"file_name": {"title": "File Name", "type": "string"}, "repo_name": {"title":
       "Repo Name", "type": "string"}, "function": {"title": "Function", "type": "string"},
       "line_no": {"title": "Line No", "type": "integer"}, "col_no": {"title": "Col
@@ -376,7 +611,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '3257'
+      - '4005'
       content-type:
       - application/json
       host:
@@ -406,25 +641,23 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//lFRNj9s2EL37Vwx42QSwHdvxrjfOKUF6CNAe+oEARVQINDmS6FAclhx5
-        d2P4vxeUtJbVum1yoex5j8P3nqg5TgCE0WILQlWSVe3t7J3e/1z//h5/+fH+w0/qE339uL6rqj8/
-        rJfBfBLTtIN2e1T8vGuuqPYW2ZDrYBVQMqauy83r9eL1avNm1QI1abRpW+l5tqZZbZyZrRar9Wyx
-        mS3v+90VGYVRbOHzBADg2K5Jp9P4KLawmD5XaoxRlii2ZxKACGRTRcgYTWTpWEwHUJFjdK30Y+YA
-        MoGP3konk/pMbCETv1UIES0qRg0t/5EjGGubyEEyQkUPgEWBis0BQVFdN86otgNQAYo0gomxwQhK
-        OrAoNTCBImvljoJst/lAO4v1LJI9GFeCdDoxgzOunGdi2olLvXYyYt7rSAo/Jwjg2D0SK6Cn3Mka
-        OwPdQTMfKL2lvlfHLIzF3EuuOmYM6lXDxsZXFVqPIc73ccSPzniP3LGLxqnWZCWdtvhDCBReYFpf
-        wjElFcnivC28uGlRIKWaEFBvb6bQMd/CKRPdAaf0+KN3GlmqLxyk+h+vrYPBq/T+75q/I43eUEc0
-        zvA770cMaxzmjhJhvbqoK7J9+XZU1ZiPIuMq0AM4fIAurZuPzrCR1nztrkshjUV98/Lt6NSDDDGX
-        Md/HZ23HLGu9/sqSMf3epsU8NzOuTP+vJ4sHdJxbKv87WH7yfWLtixoJUpKxpPB0ztz2933E2pHu
-        GVddgm4wfQe1iTHdeEWuMGUTWs58HDse0P6bGC1ZXkmna3fOpj/lSiyZO11OhIBFE2WaSq6xtq+f
-        ziPGUpk+1djj53phnIlVHlBGcmmcRCYvWvQ0SeGnUdaMppPwgWrPOdMXdKnh7d2q6yeGCTqgq9Vt
-        jzKxtAOwud9MrzTMNbI0Nl5MQ6GkqlAPW4fRKRtt6AKYXNj+p5xrvTvrxpXf0n4AlELPqHMfUBs1
-        tjzQAu7bAXyddo65FSziU2Ss88K4EoMPppvvhc/vCrVc4HKBOzE5Tf4CAAD//wMAkpvLCO0GAAA=
+        H4sIAAAAAAAAAwAAAP//jFTBbtswDL3nKzRdugFJkXRBm+bWw4Dt1MPWbUBdGIxE22xlSZOYNFmQ
+        fx+kuHHSdcAusv0eH/VIUd4OhJCk5VxI1QCr1pvRDX5f13c8pduv6+e72Y1b/gqr29Xs56enRyeH
+        SeEWj6j4RXWuXOsNMjm7p1VAYExZJ1cfpxeT64/TaSZap9EkWe15NHWjliyNLsYX09H4ajSZderG
+        kcIo5+J+IIQQ27wmn1bjWs7FePiCtBgj1CjnhyAhZHAmIRJipMhgWQ57UjnLaLP1bSFx7Q1YSM4L
+        OS/ktwZFjliz8IQKoyBjlpEDMApuUESPiipSQoEnBkO/s1pgCC4IsjlIOY0CrM4flDbUqIVyIaDK
+        0ZULwgfnMaTXFpjJ1ueFHBYyaRcQsex8FHJ+vy1kQO9KCy1mn7iG1PEyoVlVkcHSAzeZboHsud9k
+        JlryHjnjPpDl92ef0Rgnfrhg9LuzD4XcPaQ4BvXEAdTJzonBFVoujatfWeKN79yk2vfmgbF2YZPh
+        0w5lfuH0nvtiu2687iNZETmQrYUhxgBm3xWDKzRZ+QzBkq0zqoGhhFg+xu78tkVRSEMW03Oelq7k
+        5rTkopC7VPfueDQCVssIaTzt0pgO3x1mzbjaB7eIHX/AK7IUmzIgRGfTXEV2XmZ2NxDiIc/08mRM
+        pQ+u9Vyye0KbEl5NZvt8sr9KPXv9QrJjMD0+m1wO38hXamQgE49uhVSgGtS9tL9CsNTkjojBUdV/
+        u3kr975ysvX/pO8JpdAz6tIH1KROK+7DAqY/zb/CDl3OhmXcRMa2rMjWGPLJp/OofHlZqckYJ2Nc
+        yMFu8AcAAP//AwBNNDCX9QQAAA==
     headers:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 8f103893cc6396b1-SJC
+      - 8f220310bf93faba-SJC
       Connection:
       - keep-alive
       Content-Encoding:
@@ -432,14 +665,14 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 12 Dec 2024 19:46:38 GMT
+      - Sat, 14 Dec 2024 23:35:44 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=Z37pJ5WcCaq8sk7t5VGIBExIiVyfDsmzpirQbSrZISA-1734032798-1.0.1.1-Hc8XFnv9eCtF4gjI0SP_3pP2kchTqSszwT3xyTgzEBITgN6W4OacCjmC.9jn9qglDEqabTMNA4h6C3qFYeV3nA;
-        path=/; expires=Thu, 12-Dec-24 20:16:38 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=pKZ5s_pEfUfBA4hAVwmkypui7W6Q1K1N0M_xYwk9.Gs-1734219344-1.0.1.1-dkxkZ6ePmfq0UT7YZDy_HSQVR.yNLaJSEhv6QpWwVXibu149CB3hpICZ0gHd9kleBCCP1dYWLtRQvU.n3rqWYA;
+        path=/; expires=Sun, 15-Dec-24 00:05:44 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=lu9.HBhkz1EBauTBgT25cRkUgIsf1Kte3cmQacDsvoA-1734032798593-0.0.1.1-604800000;
+      - _cfuvid=u1mocBFDihX25ld4TKr0MeeFbTDK.XaImp7WE01biTY-1734219344962-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -452,7 +685,7 @@ interactions:
       openai-organization:
       - functional-software
       openai-processing-ms:
-      - '6808'
+      - '1385'
       openai-version:
       - '2020-10-01'
       strict-transport-security:
@@ -464,13 +697,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '29999'
       x-ratelimit-remaining-tokens:
-      - '149995662'
+      - '149995495'
       x-ratelimit-reset-requests:
       - 2ms
       x-ratelimit-reset-tokens:
       - 1ms
       x-request-id:
-      - req_879b38e8fc0f1df66aedf43bfef461d2
+      - req_7d3019006184fc75aee6eebe6595bccf
     status:
       code: 200
       message: OK

--- a/tests/automation/autofix/test_autofix_agent.py
+++ b/tests/automation/autofix/test_autofix_agent.py
@@ -6,6 +6,7 @@ from johen import generate
 from seer.automation.agent.agent import AgentConfig, RunConfig
 from seer.automation.agent.client import OpenAiProvider
 from seer.automation.agent.models import Message
+from seer.automation.agent.tools import FunctionTool
 from seer.automation.autofix.autofix_agent import AutofixAgent
 from seer.automation.autofix.autofix_context import AutofixContext
 from seer.automation.autofix.components.insight_sharing.models import InsightSharingOutput
@@ -121,6 +122,20 @@ def test_run_iteration_with_queued_user_messages(
 @pytest.mark.vcr()
 def test_run_iteration_with_insight_sharing(autofix_agent, run_config):
     autofix_agent.config.interactive = True
+    autofix_agent.memory = [
+        Message(
+            role="user",
+            content="My code has a capitalization error, first write an explanation of the error and then use the tools provided to fix it: ```python\nprint('hello World!')\n```",
+        )
+    ]
+    autofix_agent.tools = [
+        FunctionTool(
+            name="fix_capitalization",
+            description="Fix the capitalization of the code",
+            parameters=[],
+            fn=lambda: None,
+        )
+    ]
     with autofix_agent.context.state.update() as state:
         state.request.options.disable_interactivity = False
         state.steps = [


### PR DESCRIPTION
Issue #1630 

I discovered in profiling that when the root cause step completed, there was sometimes a huge wait (the case I saw was 6 seconds) for the thread pool to finish it's last insight card generation, before moving onto the root cause formatter. (similar for the coding step)

Why? Because we started a new insight sharing thread after every LLM call, including the final call of the agent run. Due to Zach's changes that make us wait for threads to complete before ending the run, this caused big delays.

Solutions in this PR:
1. Don't generate an insight card on the final output of the run. That was somewhat redundant anyway if we're about to show the final output card, plus this avoids starting a new thread from scratch that blocks everything else.
2. Adds a second thread worker. That way while running in parallel with the main agent, one insight doesn't have to wait for the previous to complete, and it's unlikely that insights will "fall behind" the main agent.

We could completely eliminate this delay if we didn't wait for the threads to be completed, and I'm not sure that's a bad idea, but I'm still assuming we don't want to sacrifice that safety. This PR mitigates most of the issue while maintaining thread safety.