### PR TITLE
feat(celery): Set celery worker queue via CELERY_WORKER_QUEUE

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,12 @@ VCRs are a way to record and replay HTTP requests.  They are useful for recordin
 To use VCRs, add the `@pytest.mark.vcr()` decorator to your test.
 
 To record new VCRs, delete the existing cassettes and run the test.  Subsequent test runs will use the cassette instead of making requests.
+
+
+# Production
+
+## Celery Worker Queue
+
+You can set the queue that the celery worker listens on via the `CELERY_WORKER_QUEUE` environment variable.
+
+If not set, the default queue name is `"seer"`.

--- a/celeryworker.sh
+++ b/celeryworker.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
-# TODO: Remove debug log level once celery debugging is done
-WORKER_CMD="celery -A src.celery_app.tasks worker --loglevel=info $CELERY_WORKER_OPTIONS"
+# You can set the celery queue name via the CELERY_WORKER_QUEUE environment variable.
+# If not set, the default queue name is "seer".
+QUEUE="seer"
+if [ "$CELERY_WORKER_QUEUE" != "" ]; then
+    QUEUE="$CELERY_WORKER_QUEUE"
+fi
+
+WORKER_CMD="celery -A src.celery_app.tasks worker --loglevel=info -Q $QUEUE $CELERY_WORKER_OPTIONS"
 
 if [ "$CELERY_WORKER_ENABLE" = "true" ]; then
     if [ "$DEV" = "true" ] || [ "$DEV" = "1" ]; then

--- a/src/celery_app/config.py
+++ b/src/celery_app/config.py
@@ -1,4 +1,3 @@
-from enum import StrEnum
 from typing import Any
 
 from seer.bootup import module
@@ -10,11 +9,6 @@ class CeleryConfig(dict[str, Any]):
     pass
 
 
-class CeleryQueues(StrEnum):
-    DEFAULT = "seer"
-    CUDA = "seer-cuda"
-
-
 @module.provider
 def celery_config(app_config: AppConfig = injected) -> CeleryConfig:
     return CeleryConfig(
@@ -23,11 +17,11 @@ def celery_config(app_config: AppConfig = injected) -> CeleryConfig:
         result_serializer="json",
         accept_content=["json"],
         enable_utc=True,
-        task_default_queue=CeleryQueues.DEFAULT,
+        task_default_queue=app_config.CELERY_WORKER_QUEUE,
         task_queues={
-            CeleryQueues.DEFAULT: {
-                "exchange": CeleryQueues.DEFAULT,
-                "routing_key": CeleryQueues.DEFAULT,
+            app_config.CELERY_WORKER_QUEUE: {
+                "exchange": app_config.CELERY_WORKER_QUEUE,
+                "routing_key": app_config.CELERY_WORKER_QUEUE,
             }
         },
         result_backend="rpc://",

--- a/src/seer/automation/steps.py
+++ b/src/seer/automation/steps.py
@@ -88,8 +88,11 @@ class ParallelizedChainStep(PipelineChain, PipelineStep):
     def _get_conditional_step_class() -> Type[ParallelizedChainConditionalStep]:
         pass
 
+    def _invoke(self, **kwargs):
+        self._send_signatures()
+
     @inject
-    def _invoke(self, app_config: AppConfig = injected):
+    def _send_signatures(self, app_config: AppConfig = injected):
         signatures = [self.instantiate_signature(step) for step in self.request.steps]
 
         expected_signals = [

--- a/src/seer/configuration.py
+++ b/src/seer/configuration.py
@@ -87,6 +87,8 @@ class AppConfig(BaseModel):
     GRPC_SERVER_ENABLE: ParseBool = False
     HOSTNAME: str = Field(default_factory=gethostname)
 
+    CELERY_WORKER_QUEUE: str = "seer"
+
     # Test utility that disables deployment conditional behavior.
     # Update this to reflect new kinds of conditional behavior by adding
     # more test coverage and locking them in.
@@ -150,6 +152,11 @@ class AppConfig(BaseModel):
                 logger.warning("GITHUB_SENTRY_APP_ID is missing in production!")
             if not self.DEV and not self.GITHUB_SENTRY_PRIVATE_KEY:
                 logger.warning("GITHUB_SENTRY_PRIVATE_KEY is missing in production!")
+
+            if not self.CELERY_WORKER_QUEUE:
+                logger.warning(
+                    'CELERY_WORKER_QUEUE is not set in production! Will default to "seer"'
+                )
 
 
 @configuration_module.provider

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -31,7 +31,7 @@ stderr_logfile_maxbytes=0
 
 ; The celery worker program is disabled by default. Set CELERY_WORKER_ENABLE=true in the environment to enable it.
 [program:celeryworker-default]
-command=env CELERY_WORKER_OPTIONS="-c 16 -Q seer -n seer@%%h" /app/celeryworker.sh
+command=env CELERY_WORKER_OPTIONS="-c 16 -n seer@%%h" /app/celeryworker.sh
 directory=/app
 startsecs=0
 autostart=true

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -77,6 +77,8 @@ def test_celery_app_configuration():
 
         app.finalize()
         celery_app.finalize()
+
+        assert app.conf.task_default_queue == resolve(CeleryConfig)["task_default_queue"]
         assert app.conf.task_queues == resolve(CeleryConfig)["task_queues"]
         assert celery_app.conf.task_queues == app.conf.task_queues
 


### PR DESCRIPTION
Setting `CELERY_WORKER_QUEUE` env var will make that instance of seer both publish tasks to and the celery worker consume from the queue with that name.

Will follow up w/ SRE to set this value.