### PR TITLE
fix(autofix): Add line to prompt to clarify to agent that it can't use tools

### DIFF
--- a/src/seer/automation/autofix/components/coding/prompts.py
+++ b/src/seer/automation/autofix/components/coding/prompts.py
@@ -267,7 +267,8 @@ class CodingPrompts:
             - No placeholders are allowed, the changes must be clear and detailed.
             - The plan must be comprehensive. Do not provide temporary examples, placeholders or incomplete changes.
             - Think step-by-step before giving the final answer.
-            - Provide both the high-level plan and the exact code changes needed."""
+            - Provide both the high-level plan and the exact code changes needed.
+            - You may not search the codebase or use any tools at this time."""
         )
 
     @staticmethod


### PR DESCRIPTION
In the case where we switch to a simple fixer after the full fixer is in memory, we already added a special instruction. Just appending a line to that to clarify that the agent can't use any tools. Should help with #1637 but hard to verify. FWIW I could never reproduce it locally.