### PR TITLE
[feat] Add functionality for AI PR review

### DIFF
--- a/src/seer/automation/autofix/steps/steps.py
+++ b/src/seer/automation/autofix/steps/steps.py
@@ -15,6 +15,7 @@ from seer.automation.pipeline import (
     PipelineStep,
     PipelineStepTaskRequest,
 )
+from seer.automation.state import DbStateRunTypes
 from seer.automation.steps import (
     ParallelizedChainConditionalStep,
     ParallelizedChainStep,
@@ -45,7 +46,9 @@ class AutofixPipelineStep(PipelineChain, PipelineStep):
         )
 
     @staticmethod
-    def _instantiate_context(request: PipelineStepTaskRequest) -> PipelineContext:
+    def _instantiate_context(
+        request: PipelineStepTaskRequest, _: DbStateRunTypes | None = None
+    ) -> PipelineContext:
         return AutofixContext.from_run_id(request.run_id)
 
     def _invoke(self, **kwargs: Any) -> Any:

--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -1,3 +1,4 @@
+from typing import Literal, NotRequired, TypedDict
 from pydantic import BaseModel
 from pydantic_xml import attr
 
@@ -44,3 +45,14 @@ class SearchResult(BaseModel):
     relative_path: str
     matches: list[Match]
     score: float
+
+
+class GithubPrReviewComment(TypedDict):
+    commit_id: str
+    body: str
+    path: str
+    side: NotRequired[Literal["LEFT", "RIGHT"]]
+    line: NotRequired[int]
+    start_line: NotRequired[int]
+    start_side: NotRequired[Literal["LEFT", "RIGHT"]]
+    in_reply_to: NotRequired[str]

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -5,13 +5,15 @@ import shutil
 import tarfile
 import tempfile
 from enum import Enum
-from typing import Literal
+from typing import List, Literal, Optional
+from typing_extensions import TypedDict
 
 import requests
 import sentry_sdk
 from github import (
     Auth,
     Github,
+    GithubObject,
     GithubException,
     GithubIntegration,
     InputGitTreeElement,
@@ -22,6 +24,7 @@ from github.Repository import Repository
 
 from seer.automation.autofix.utils import generate_random_string, sanitize_branch_name
 from seer.automation.codebase.utils import get_language_from_path
+from seer.automation.codebase.models import GithubPrReviewComment
 from seer.automation.models import FileChange, FilePatch, InitializationError, RepoDefinition
 from seer.automation.utils import detect_encoding
 from seer.configuration import AppConfig
@@ -102,6 +105,7 @@ class RepoClientType(str, Enum):
     READ = "read"
     WRITE = "write"
     CODECOV_UNIT_TEST = "codecov_unit_test"
+    CODECOV_PR_REVIEW = "codecov_pr_review"
 
 
 class RepoClient:
@@ -181,12 +185,20 @@ class RepoClient:
 
         return False
 
+    @staticmethod
+    def _extract_id_from_pr_url(pr_url: str):
+        """
+        Extracts the repository path and PR/issue ID from the provided URL.
+        """
+        pr_id = int(pr_url.split("/")[-1])
+        return pr_id
+
     @classmethod
     @functools.cache
     def from_repo_definition(cls, repo_def: RepoDefinition, type: RepoClientType):
         if type == RepoClientType.WRITE:
             return cls(*get_write_app_credentials(), repo_def)
-        elif type == RepoClientType.CODECOV_UNIT_TEST:
+        elif type == RepoClientType.CODECOV_UNIT_TEST or type == RepoClientType.CODECOV_PR_REVIEW:
             return cls(*get_codecov_unit_test_app_credentials(), repo_def)
 
         return cls(*get_read_app_credentials(), repo_def)
@@ -273,7 +285,6 @@ class RepoClient:
                 shutil.rmtree(root_folder_path)  # remove the root folder
 
         return tmp_dir, tmp_repo_dir
-
 
     def get_file_content(self, path: str, sha: str | None = None) -> tuple[str | None, str]:
         logger.debug(f"Getting file contents for {path} in {self.repo.full_name} on sha {sha}")
@@ -569,3 +580,35 @@ class RepoClient:
         response = requests.post(url, headers=headers, json=params)
         response.raise_for_status()
         return response.json()["html_url"]
+
+    def post_issue_comment(self, pr_url: str, comment: str):
+        """
+        Create an issue comment on a GitHub issue (all pull requests are issues).
+        This can be used to create an overall PR comment instead of associated with a specific line.
+        See https://docs.github.com/en/rest/issues/comments?apiVersion=2022-11-28#create-an-issue-comment
+        Note that expected input is pr_url NOT pr_html_url
+        """
+        pr_id = self._extract_id_from_pr_url(pr_url)
+        issue = self.repo.get_issue(number=pr_id)
+        comment_obj = issue.create_comment(body=comment)
+        return comment_obj.html_url
+
+    def post_pr_review_comment(self, pr_url: str, comment: GithubPrReviewComment):
+        """
+        Create a review comment on a GitHub pull request.
+        See https://docs.github.com/en/rest/pulls/comments?apiVersion=2022-11-28#create-a-review-comment-for-a-pull-request
+        Note that expected input is pr_url NOT pr_html_url
+        """
+        pr_id = self._extract_id_from_pr_url(pr_url)
+        pr = self.repo.get_pull(number=pr_id)
+        commit = self.repo.get_commit(comment["commit_id"])
+
+        review_comment = pr.create_review_comment(
+            body=comment["body"],
+            commit=commit,
+            path=comment["path"],
+            line=comment.get("line", GithubObject.NotSet),
+            side=comment.get("side", GithubObject.NotSet),
+            start_line=comment.get("start_line", GithubObject.NotSet),
+        )
+        return review_comment.html_url

--- a/src/seer/automation/codegen/codegen_context.py
+++ b/src/seer/automation/codegen/codegen_context.py
@@ -2,9 +2,11 @@ import logging
 
 from seer.automation.codebase.repo_client import RepoClient, RepoClientType
 from seer.automation.codegen.codegen_event_manager import CodegenEventManager
+from seer.automation.codegen.models import CodegenContinuation
 from seer.automation.codegen.state import CodegenContinuationState
 from seer.automation.models import RepoDefinition
 from seer.automation.pipeline import PipelineContext
+from seer.automation.state import DbStateRunTypes
 
 logger = logging.getLogger(__name__)
 
@@ -32,8 +34,8 @@ class CodegenContext(PipelineContext):
         logger.info(f"CodegenContext initialized with run_id {self.run_id}")
 
     @classmethod
-    def from_run_id(cls, run_id: int):
-        state = CodegenContinuationState(run_id)
+    def from_run_id(cls, run_id: int, type: DbStateRunTypes = DbStateRunTypes.UNIT_TEST):
+        state = CodegenContinuationState(run_id, model=CodegenContinuation, type=type)
         with state.update() as cur:
             cur.mark_triggered()
 

--- a/src/seer/automation/codegen/models.py
+++ b/src/seer/automation/codegen/models.py
@@ -1,5 +1,6 @@
 import datetime
 from enum import Enum
+from typing import List, Union
 
 from pydantic import BaseModel, Field
 
@@ -39,7 +40,7 @@ class CodegenPrReviewRequest(BaseModel):
 
 
 class CodegenContinuation(CodegenState):
-    request: CodegenUnitTestsRequest
+    request: Union[CodegenUnitTestsRequest, CodegenPrReviewRequest]
 
     def mark_triggered(self):
         self.last_triggered_at = datetime.datetime.now()
@@ -85,3 +86,17 @@ class CodegenPrReviewStateResponse(BaseModel):
     triggered_at: datetime.datetime
     updated_at: datetime.datetime
     completed_at: datetime.datetime | None = None
+
+
+class CodePrReviewRequest(BaseComponentRequest):
+    diff: str
+
+
+class CodePrReviewOutput(BaseComponentOutput):
+    class Comment(BaseModel):
+        path: str
+        line: int
+        body: str
+        start_line: int
+
+    comments: List[Comment]

--- a/src/seer/automation/codegen/pr_review_coding_component.py
+++ b/src/seer/automation/codegen/pr_review_coding_component.py
@@ -1,0 +1,99 @@
+import json
+import logging
+from typing import List
+
+from langfuse.decorators import observe
+from sentry_sdk.ai.monitoring import ai_track
+
+from seer.automation.agent.agent import AgentConfig, LlmAgent, RunConfig
+from seer.automation.agent.client import AnthropicProvider, LlmClient
+from seer.automation.autofix.components.coding.models import PlanStepsPromptXml
+from seer.automation.autofix.components.coding.utils import (
+    task_to_file_change,
+    task_to_file_create,
+    task_to_file_delete,
+)
+from seer.automation.autofix.tools import BaseTools
+from seer.automation.codebase.repo_client import RepoClientType
+from seer.automation.codegen.codegen_context import CodegenContext
+from seer.automation.codegen.models import (
+    CodePrReviewOutput,
+    CodePrReviewRequest,
+    CodegenPrReviewRequest,
+    CodegenPrReviewResponse,
+)
+from seer.automation.codegen.prompts import CodingCodeReviewPrompts, CodingUnitTestPrompts
+from seer.automation.component import BaseComponent
+from seer.automation.models import FileChange
+from seer.automation.utils import escape_multi_xml, extract_text_inside_tags
+from seer.dependency_injection import inject, injected
+
+logger = logging.getLogger(__name__)
+
+
+class PrReviewCodingComponent(BaseComponent[CodePrReviewRequest, CodePrReviewOutput]):
+    context: CodegenContext
+
+    @observe(name="Review PR")
+    @ai_track(description="Review PR")
+    @inject
+    def invoke(
+        self, request: CodePrReviewRequest, llm_client: LlmClient = injected
+    ) -> CodePrReviewOutput | None:
+        with BaseTools(self.context, repo_client_type=RepoClientType.CODECOV_PR_REVIEW) as tools:
+            agent = LlmAgent(
+                tools=tools.get_tools(),
+                config=AgentConfig(interactive=False),
+            )
+
+            final_response = agent.run(
+                run_config=RunConfig(
+                    prompt=CodingCodeReviewPrompts.format_pr_review_plan_step(
+                        diff_str=request.diff,
+                    ),
+                    system_prompt=CodingUnitTestPrompts.format_system_msg(),
+                    model=AnthropicProvider.model("claude-3-5-sonnet@20240620"),
+                    run_name="Generate PR review",
+                ),
+            )
+
+            if not final_response:
+                return None
+
+            return self._format_output(final_response)
+
+    @staticmethod
+    def _format_output(llm_output: str) -> CodePrReviewOutput | None:
+        comments_json = extract_text_inside_tags(llm_output, "comments")
+        if len(comments_json) == 0:
+            raise ValueError("Failed to extract pr review comments from LLM response")
+
+        try:
+            comments_data = json.loads(comments_json)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON format inside <comments>: {e}")
+
+        if not isinstance(comments_data, list):
+            raise ValueError("Expected a list of JSON objects inside <comments>")
+
+        results = []
+        for comment_data in comments_data:
+            # skip any llm output item if missing required keys
+            expected_keys = list(CodePrReviewOutput.Comment.model_fields.keys())
+            if not all(key in comment_data for key in expected_keys):
+                continue
+
+            body = comment_data["body"]
+            if "code_suggestion" in comment_data:
+                code_suggestion = comment_data["code_suggestion"]
+                body += f"\n```suggestion\n{code_suggestion}\n```"
+            results.append(
+                CodePrReviewOutput.Comment(
+                    path=comment_data["path"],
+                    line=comment_data["line"],
+                    body=body,
+                    start_line=comment_data["start_line"],
+                )
+            )
+
+        return CodePrReviewOutput(comments=results)

--- a/src/seer/automation/codegen/pr_review_publisher.py
+++ b/src/seer/automation/codegen/pr_review_publisher.py
@@ -1,0 +1,73 @@
+import logging
+from typing import List
+
+from github.PullRequest import PullRequest
+
+from seer.automation.codebase.models import GithubPrReviewComment
+from seer.automation.codebase.repo_client import RepoClient
+from seer.automation.codegen.models import (
+    CodePrReviewOutput,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PrReviewPublisher:
+    """
+    The PrReviewPublisher class publishes review comments to a pull request (PR)
+    """
+
+    def __init__(self, repo_client: RepoClient, pr: PullRequest):
+        self.repo_client = repo_client
+        self.pr = pr
+
+    def publish_generated_pr_review(self, pr_review: CodePrReviewOutput) -> None:
+        repo_client = self.repo_client
+        pr_url = self.pr.url
+
+        # handle if no comments
+        if pr_review is None or not pr_review.comments:
+            self.publish_no_changes_required()
+            return
+
+        # handle send review comments one by one
+        comments = self._format_comments(self.pr.head.sha, pr_review)
+        for comment in comments:
+            try:
+                repo_client.post_pr_review_comment(pr_url, comment)
+            except ValueError as e:
+                logger.warning(
+                    f"Failed to post comment on PR {pr_url} for SHA {self.pr.head.sha}: {comment}. Error: {e}"
+                )
+                continue
+
+    def publish_no_changes_required(self) -> None:
+        self.repo_client.post_issue_comment(
+            self.pr.url, "No changes requiring review at this time."
+        )
+        return
+
+    def publish_ack(self) -> None:
+        self.repo_client.post_issue_comment(
+            self.pr.url, "On it! We are reviewing the PR and will provide feedback shortly."
+        )
+        return
+
+    @staticmethod
+    def _format_comments(
+        commit_id: str, pr_review: CodePrReviewOutput
+    ) -> List[GithubPrReviewComment]:
+        comments = []
+        for comment in pr_review.comments:
+            comments.append(
+                GithubPrReviewComment(
+                    commit_id=commit_id,
+                    side="RIGHT",
+                    path=comment.path,
+                    line=comment.line,
+                    body=comment.body,
+                    start_line=comment.start_line,
+                )
+            )
+
+        return comments

--- a/src/seer/automation/codegen/pr_review_step.py
+++ b/src/seer/automation/codegen/pr_review_step.py
@@ -1,0 +1,89 @@
+from typing import Any, List
+
+from langfuse.decorators import observe
+from sentry_sdk.ai.monitoring import ai_track
+
+from celery_app.app import celery_app
+from seer.automation.autofix.config import (
+    AUTOFIX_EXECUTION_HARD_TIME_LIMIT_SECS,
+    AUTOFIX_EXECUTION_SOFT_TIME_LIMIT_SECS,
+)
+from seer.automation.codebase.repo_client import RepoClientType
+from seer.automation.codegen.models import CodePrReviewOutput, CodePrReviewRequest
+from seer.automation.codegen.pr_review_coding_component import PrReviewCodingComponent
+from seer.automation.codegen.pr_review_publisher import PrReviewPublisher
+from seer.automation.codegen.step import CodegenStep
+from seer.automation.models import FileChange, RepoDefinition
+from seer.automation.pipeline import PipelineStepTaskRequest
+
+
+class PrReviewStepRequest(PipelineStepTaskRequest):
+    pr_id: int
+    repo_definition: RepoDefinition
+
+
+@celery_app.task(
+    time_limit=AUTOFIX_EXECUTION_HARD_TIME_LIMIT_SECS,
+    soft_time_limit=AUTOFIX_EXECUTION_SOFT_TIME_LIMIT_SECS,
+)
+def pr_review_task(*args, request: dict[str, Any]):
+    PrReviewStep(request).invoke()
+
+
+class PrReviewStep(CodegenStep):
+    """
+    This class represents the PR Review step in the codegen pipeline. It is responsible for
+    generating pull request comments for provided code changes in a pull request.
+    """
+
+    name = "PrReviewStep"
+    max_retries = 2
+
+    @staticmethod
+    def _instantiate_request(request: dict[str, Any]) -> PrReviewStepRequest:
+        return PrReviewStepRequest.model_validate(request)
+
+    @staticmethod
+    def get_task():
+        return pr_review_task
+
+    @observe(name="Codegen - PR Review")
+    @ai_track(description="Codegen - PR Review Step")
+    def _invoke(self, **kwargs):
+        self.logger.info("Executing Codegen - PR Review Step")
+        self.context.event_manager.mark_running()
+
+        repo_client = self.context.get_repo_client(type=RepoClientType.CODECOV_PR_REVIEW)
+        pr = repo_client.repo.get_pull(self.request.pr_id)
+        diff_content = repo_client.get_pr_diff_content(pr.url)
+
+        generator = PrReviewCodingComponent(self.context)
+        publisher = PrReviewPublisher(repo_client=repo_client, pr=pr)
+
+        try:
+            publisher.publish_ack()
+        except Exception as e:
+            self.logger.warning(f"Error publishing ack for {pr.url}: {e}")
+            # proceed even if ack fails
+            pass
+
+        try:
+            generated_pr_review = generator.invoke(
+                CodePrReviewRequest(
+                    diff=diff_content,
+                ),
+            )
+        except ValueError as e:
+            self.logger.error(f"Error generating pr review for {pr.url}: {e}")
+            # send "no changes required" upon generation error including if output
+            # does not conform to expected format
+            publisher.publish_no_changes_required()
+            return
+
+        try:
+            publisher.publish_generated_pr_review(pr_review=generated_pr_review),
+        except ValueError as e:
+            self.logger.error(f"Error publishing pr review for {pr.url}: {e}")
+            return
+
+        self.context.event_manager.mark_completed()

--- a/src/seer/automation/codegen/prompts.py
+++ b/src/seer/automation/codegen/prompts.py
@@ -158,3 +158,57 @@ class CodingUnitTestPrompts:
             test_design_hint=test_design_hint,
             steps_example_str=prompt_obj.to_prompt_str(),
         )
+
+
+class CodingCodeReviewPrompts:
+    @staticmethod
+    def format_system_msg():
+        return textwrap.dedent(
+            """\
+            You are an exceptional principal engineer that provides robust and meaningful pull request comments given a change request against codebases.
+
+            You have access to tools that allow you to search a codebase to find the relevant code snippets and view relevant files. You can use these tools as many times as you want to find the relevant code snippets.
+
+            # Guidelines:
+            - EVERY TIME before you use a tool, think step-by-step each time before using the tools provided to you.
+            - You also MUST think step-by-step before giving the final answer."""
+        )
+
+    @staticmethod
+    def format_pr_review_plan_step(diff_str: str):
+        return textwrap.dedent(
+            """\
+            You are given the below code changes as a diff:
+            {diff_str}
+
+            # Your goal:
+            Review the code changes in the diff and provide constructive feedback and suggestions for improvement.
+
+            As an exceptional principal engineer, your feedback should be insightful and actionable, focusing on code quality, performance, security, and adherence to best practices.
+
+            # Guidelines:
+            - Carefully analyze the code changes and understand the context.
+            - Provide specific comments on lines or sections where improvements can be made.
+            - Highlight any potential bugs, performance issues, or security vulnerabilities.
+            - Suggest best practices and coding standards that should be followed.
+            - Be respectful and professional in your feedback.
+            - Do not include any placeholders; your feedback should be clear and detailed.
+            - Before giving your final answer, think step-by-step to ensure your review is thorough.
+            - Use the following JSON format for each comment:
+                {{
+                    "path": "{{file_name}}",
+                    "line": The end line line of the code block where you are suggesting changes,
+                    "body": "Your comment text here",
+                    "start_line": The starting line of the code block where you are suggesting changes,
+                    "code_suggestion": "If you have a code suggestion, provide it here. Ensure you are properly escaping special characters"
+                }}
+            - Ensure each comment includes:
+                - The correct file name ("{{file_name}}").
+                - The specific line number requiring the comment.
+                - Clear, professional, and actionable feedback.
+            - Return all comments as a list of JSON objects, ready to be used in a GitHub pull request review.
+            - Wrap the comments in a <comments> and </comments> block.
+            """
+        ).format(
+            diff_str=diff_str,
+        )

--- a/src/seer/automation/codegen/step.py
+++ b/src/seer/automation/codegen/step.py
@@ -1,10 +1,11 @@
-from typing import Any
+from typing import Any, Optional
 
 import sentry_sdk
 
 from seer.automation.codegen.codegen_context import CodegenContext
 from seer.automation.codegen.models import CodegenStatus
 from seer.automation.pipeline import PipelineContext, PipelineStep, PipelineStepTaskRequest
+from seer.automation.state import DbStateRunTypes
 from seer.automation.utils import make_done_signal
 
 
@@ -12,8 +13,12 @@ class CodegenStep(PipelineStep):
     context: CodegenContext
 
     @staticmethod
-    def _instantiate_context(request: PipelineStepTaskRequest) -> PipelineContext:
-        return CodegenContext.from_run_id(request.run_id)
+    def _instantiate_context(
+        request: PipelineStepTaskRequest, type: DbStateRunTypes | None = None
+    ) -> PipelineContext:
+        if type is None:
+            type = DbStateRunTypes.UNIT_TEST
+        return CodegenContext.from_run_id(request.run_id, type=type)
 
     def _invoke(self, **kwargs: Any) -> Any:
         sentry_sdk.set_tag("run_id", self.context.run_id)

--- a/src/seer/automation/codegen/tasks.py
+++ b/src/seer/automation/codegen/tasks.py
@@ -1,13 +1,18 @@
 from seer.automation.codegen.models import (
     CodegenContinuation,
     CodegenPrReviewRequest,
+    CodegenPrReviewResponse,
     CodegenStatus,
     CodegenUnitTestsRequest,
     CodegenUnitTestsResponse,
     CodegenUnitTestsStateRequest,
 )
+from seer.automation.codegen.pr_review_step import PrReviewStep, PrReviewStepRequest
 from seer.automation.codegen.state import CodegenContinuationState
-from seer.automation.codegen.unittest_step import UnittestStep, UnittestStepRequest
+from seer.automation.codegen.unittest_step import (
+    UnittestStep,
+    UnittestStepRequest,
+)
 from seer.automation.state import DbState, DbStateRunTypes
 from seer.configuration import AppConfig
 from seer.dependency_injection import inject, injected
@@ -16,6 +21,19 @@ from seer.dependency_injection import inject, injected
 def create_initial_unittest_run(request: CodegenUnitTestsRequest) -> DbState[CodegenContinuation]:
     state = CodegenContinuationState.new(
         CodegenContinuation(request=request), group_id=request.pr_id, t=DbStateRunTypes.UNIT_TEST
+    )
+
+    with state.update() as cur:
+        cur.status = CodegenStatus.PENDING
+        cur.signals = []
+        cur.mark_triggered()
+
+    return state
+
+
+def create_initial_pr_review_run(request: CodegenPrReviewRequest) -> DbState[CodegenContinuation]:
+    state = CodegenContinuationState.new(
+        CodegenContinuation(request=request), group_id=request.pr_id, t=DbStateRunTypes.PR_REVIEW
     )
 
     with state.update() as cur:
@@ -51,5 +69,20 @@ def get_unittest_state(request: CodegenUnitTestsStateRequest):
     return state.get()
 
 
-def codegen_pr_review(request: CodegenPrReviewRequest):
-    raise NotImplementedError("PR Review is not implemented yet.")
+@inject
+def codegen_pr_review(request: CodegenPrReviewRequest, app_config: AppConfig = injected):
+    state = create_initial_pr_review_run(request)
+
+    cur_state = state.get()
+
+    pr_review_request = PrReviewStepRequest(
+        run_id=cur_state.run_id,
+        pr_id=request.pr_id,
+        repo_definition=request.repo,
+    )
+
+    PrReviewStep.get_signature(
+        pr_review_request, queue=app_config.CELERY_WORKER_QUEUE
+    ).apply_async()
+
+    return CodegenPrReviewResponse(run_id=cur_state.run_id)

--- a/src/seer/automation/pipeline.py
+++ b/src/seer/automation/pipeline.py
@@ -1,13 +1,13 @@
 import abc
 import logging
 import uuid
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Optional, TypeVar
 
 import sentry_sdk
 from celery import Task, signature
 from pydantic import BaseModel, Field
 
-from seer.automation.state import State
+from seer.automation.state import DbStateRunTypes, State
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +68,7 @@ class PipelineStep(abc.ABC, Generic[_RequestType, _ContextType]):
 
     def __init__(self, request: dict[str, Any]):
         self.request = self._instantiate_request(request)
-        self.context = self._instantiate_context(self.request)
+        self.context = self._instantiate_context(self.request, type=DbStateRunTypes.PR_REVIEW)
 
     def invoke(self) -> Any:
         try:
@@ -128,7 +128,9 @@ class PipelineStep(abc.ABC, Generic[_RequestType, _ContextType]):
 
     @staticmethod
     @abc.abstractmethod
-    def _instantiate_context(request: PipelineStepTaskRequest) -> _ContextType:
+    def _instantiate_context(
+        request: PipelineStepTaskRequest, type: DbStateRunTypes | None = None
+    ) -> _ContextType:
         pass
 
     @abc.abstractmethod

--- a/src/seer/automation/pipeline.py
+++ b/src/seer/automation/pipeline.py
@@ -68,7 +68,7 @@ class PipelineStep(abc.ABC, Generic[_RequestType, _ContextType]):
 
     def __init__(self, request: dict[str, Any]):
         self.request = self._instantiate_request(request)
-        self.context = self._instantiate_context(self.request, type=DbStateRunTypes.PR_REVIEW)
+        self.context = self._instantiate_context(self.request, DbStateRunTypes.PR_REVIEW)
 
     def invoke(self) -> Any:
         try:

--- a/src/seer/automation/state.py
+++ b/src/seer/automation/state.py
@@ -18,6 +18,7 @@ _StateB = TypeVar("_StateB", bound=BaseModel)
 class DbStateRunTypes(str, Enum):
     AUTOFIX = "autofix"
     UNIT_TEST = "unit-test"
+    PR_REVIEW = "pr-review"
 
 
 class State(abc.ABC, Generic[_State]):
@@ -95,8 +96,10 @@ class DbState(State[_State]):
     def validate(self, db_state: DbRunState | None):
         if db_state is None:
             raise ValueError(f"No state found for id {self.id}")
-        if db_state.type != self.type:
-            raise ValueError(f"Invalid state type: '{db_state.type}', expected: '{self.type}'")
+        if db_state.type not in self.type:
+            raise ValueError(
+                f"Invalid state type: '{db_state.type}', expected one of: '{self.type}'"
+            )
 
     def apply_to_run_state(self, value: _State, run_state: DbRunState):
         """

--- a/tests/automation/autofix/steps/test_autofix_steps.py
+++ b/tests/automation/autofix/steps/test_autofix_steps.py
@@ -1,10 +1,12 @@
 import threading
 import time
+from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from seer.automation.autofix.steps.steps import AutofixPipelineStep
+from seer.automation.state import DbStateRunTypes
 from seer.automation.utils import make_kill_signal
 
 
@@ -18,7 +20,7 @@ class ConcreteAutofixPipelineStep(AutofixPipelineStep):
         return MagicMock()
 
     @staticmethod
-    def _instantiate_context(request):
+    def _instantiate_context(request, type: Optional["DbStateRunTypes"] = None):
         return MagicMock()
 
     def _invoke(self, **kwargs):
@@ -60,10 +62,10 @@ class TestAutofixPipelineStep:
             def get_task(cls):
                 return MagicMock()
 
-            def _instantiate_request(self, request):
+            def _instantiate_request(self, request, type: Optional["DbStateRunTypes"] = None):
                 return MagicMock(**request)
 
-            def _instantiate_context(self, request):
+            def _instantiate_context(self, request, type: Optional["DbStateRunTypes"] = None):
                 return MagicMock()
 
             def _invoke(self, **kwargs):

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -4,6 +4,7 @@ import pytest
 from github import UnknownObjectException
 from pydantic import ValidationError
 
+from seer.automation.codebase.models import GithubPrReviewComment
 from seer.automation.codebase.repo_client import RepoClient
 from seer.automation.models import RepoDefinition
 
@@ -114,8 +115,7 @@ class TestRepoClient:
         mock_content = MagicMock()
         mock_content.decoded_content = b"test content"
         # this is a list of contents, so the content returned should be None
-        mock_github.get_repo.return_value.get_contents\
-            .return_value = [mock_content, mock_content]
+        mock_github.get_repo.return_value.get_contents.return_value = [mock_content, mock_content]
 
         content, encoding = repo_client.get_file_content("test_file.py")
 
@@ -499,6 +499,54 @@ class TestRepoClient:
     def test_get_one_file_autofix_change_invalid_input(self, repo_client, patch):
         with pytest.raises(ValueError):
             repo_client.process_one_file_for_git_commit(branch_ref="main", patch=patch)
+
+    def test_post_issue_comment(self, repo_client, mock_github):
+        pr_url = "https://github.com/repos/sentry/sentry/pulls/12345"
+        expected_comment = "No changes requiring review at this time."
+
+        mock_issue = MagicMock()
+        mock_issue.create_comment.return_value.html_url = (
+            "https://github.com/sentry/sentry/pull/12345#issuecomment-1"
+        )
+        repo_client.repo.get_issue.return_value = mock_issue
+
+        result = repo_client.post_issue_comment(pr_url, expected_comment)
+
+        mock_issue.create_comment.assert_called_once_with(body=expected_comment)
+        assert result == "https://github.com/sentry/sentry/pull/12345#issuecomment-1"
+
+    def test_post_pr_review_comment(self, repo_client, mock_github):
+        pr_url = "https://github.com/repos/sentry/sentry/pulls/12345"
+        comment = {
+            "path": "file.py",
+            "line": 10,
+            "body": "Please fix this",
+            "start_line": None,
+            "commit_id": "commitsha123",
+        }
+
+        # Mock the pull request and its create_review_comment method
+        mock_pull = MagicMock()
+        mock_commit = MagicMock()
+        mock_commit.sha = comment["commit_id"]
+        repo_client.repo.get_pull.return_value = mock_pull
+        repo_client.repo.get_commit.return_value = mock_commit
+        mock_pull.create_review_comment.return_value.html_url = (
+            "https://github.com/sentry/sentry/pull/12345#issuecomment-1"
+        )
+
+        # Call the method under test
+        result = repo_client.post_pr_review_comment(pr_url, comment)
+
+        mock_pull.create_review_comment.assert_called_once_with(
+            body=comment["body"],
+            commit=mock_commit,
+            path=comment["path"],
+            line=comment.get("line", ANY),
+            side=comment.get("side", ANY),
+            start_line=comment.get("start_line", ANY),
+        )
+        assert result == "https://github.com/sentry/sentry/pull/12345#issuecomment-1"
 
 
 class TestRepoClientIndexFileSet:

--- a/tests/automation/codegen/test_pr_review.py
+++ b/tests/automation/codegen/test_pr_review.py
@@ -1,0 +1,98 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from seer.automation.codegen.models import CodePrReviewOutput, CodePrReviewRequest
+from seer.automation.codegen.pr_review_coding_component import PrReviewCodingComponent
+from seer.automation.codegen.pr_review_step import PrReviewStep, PrReviewStepRequest
+from seer.automation.models import RepoDefinition
+
+
+class TestPrReview(unittest.TestCase):
+    @patch("seer.automation.codegen.pr_review_coding_component.PrReviewCodingComponent.invoke")
+    @patch("seer.automation.pipeline.PipelineStep", new_callable=MagicMock)
+    @patch("seer.automation.codegen.step.CodegenStep._instantiate_context", new_callable=MagicMock)
+    def test_invoke_happy_path(self, mock_instantiate_context, _, mock_invoke_unit_test_component):
+        mock_repo_client = MagicMock()
+        mock_pr = MagicMock()
+        mock_diff_content = "diff content"
+        mock_latest_commit_sha = "latest_commit_sha"
+        mock_context = MagicMock()
+        mock_context.get_repo_client.return_value = mock_repo_client
+        mock_repo_client.repo.get_pull.return_value = mock_pr
+        mock_repo_client.get_pr_diff_content.return_value = mock_diff_content
+
+        request_data = {
+            "run_id": 1,
+            "pr_id": 123,
+            "repo_definition": RepoDefinition(
+                name="repo1", owner="owner1", provider="github", external_id="123123"
+            ),
+        }
+        request = PrReviewStepRequest(**request_data)
+        step = PrReviewStep(request=request)
+        step.context = mock_context
+
+        step.invoke()
+
+        mock_context.get_repo_client.assert_called_once()
+        mock_repo_client.repo.get_pull.assert_called_once_with(request.pr_id)
+        mock_repo_client.get_pr_diff_content.assert_called_once_with(mock_pr.url)
+
+        actual_request = mock_invoke_unit_test_component.call_args[0][0]
+
+        assert isinstance(actual_request, CodePrReviewRequest)
+        assert actual_request.diff == mock_diff_content
+
+
+    def test_format_response_valid_input(self):
+        mock_output = """<comments>
+        [
+            {
+                "path": "src/file1.py",
+                "line": 42,
+                "body": "Consider refactoring this function to reduce its complexity. It currently exceeds 20 lines, making it harder to read and maintain. Extracting the repeated logic into a helper function could improve clarity and reusability.",
+                "start_line": 40
+            },
+            {
+                "path": "src/utils/helper.py",
+                "line": 18,
+                "body": "This regular expression could benefit from a comment explaining its purpose. Complex regex patterns are often difficult to understand and maintain.",
+                "start_line": 15
+            }
+        ]
+        </comments>"""
+        output = PrReviewCodingComponent._format_output(mock_output)
+        expected_output = CodePrReviewOutput(
+            comments=[
+                {
+                    "path": "src/file1.py",
+                    "line": 42,
+                    "body": "Consider refactoring this function to reduce its complexity. It currently exceeds 20 lines, making it harder to read and maintain. Extracting the repeated logic into a helper function could improve clarity and reusability.",
+                    "start_line": 40,
+                },
+                {
+                    "path": "src/utils/helper.py",
+                    "line": 18,
+                    "body": "This regular expression could benefit from a comment explaining its purpose. Complex regex patterns are often difficult to understand and maintain.",
+                    "start_line": 15,
+                },
+            ]
+        )
+        self.assertEqual(len(output.comments), len(expected_output.comments))
+        for actual, expected in zip(output.comments, expected_output.comments):
+            self.assertEqual(actual.path, expected.path)
+            self.assertEqual(actual.line, expected.line)
+            self.assertEqual(actual.body, expected.body)
+            self.assertEqual(actual.start_line, expected.start_line)
+
+    def test_format_response_invalid_inputs(self):
+        invalid_outputs = [
+            "Missing <> wrapper",  # Missing wrapper
+            "<comments>{\"path\": \"src/file.py\", \"line\": 10}</comments>",  # Not a list
+            "<comments>[{</comments>",  # Malformed JSON
+            "<comments>Not JSON at all</comments>",  # Not JSON
+        ]
+
+        for invalid_output in invalid_outputs:
+            with self.assertRaises(ValueError, msg=f"Failed for input: {invalid_output}"):
+                PrReviewCodingComponent._format_output(invalid_output)

--- a/tests/automation/codegen/test_pr_review_publisher.py
+++ b/tests/automation/codegen/test_pr_review_publisher.py
@@ -1,0 +1,97 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from typing import List
+
+from github.PullRequest import PullRequest
+
+from seer.automation.codebase.models import GithubPrReviewComment
+from seer.automation.codebase.repo_client import RepoClient
+from seer.automation.codegen.models import CodePrReviewOutput
+from seer.automation.codegen.pr_review_publisher import PrReviewPublisher
+
+class TestPrReviewPublisher(unittest.TestCase):
+    def setUp(self):
+        self.mock_repo_client = MagicMock(spec=RepoClient)
+        self.mock_pr = MagicMock(spec=PullRequest)
+        self.mock_pr.url = "https://api.github.com/repos/owner-name/repo-name/pulls/1"
+        self.mock_pr.head.sha = "abcdef1234567890"
+
+        self.publisher = PrReviewPublisher(
+            repo_client=self.mock_repo_client,
+            pr=self.mock_pr
+        )
+
+    def test_publish_no_changes_required(self):
+        self.publisher.publish_no_changes_required()
+        self.mock_repo_client.post_issue_comment.assert_called_once_with(
+            self.mock_pr.url,
+            "No changes requiring review at this time."
+        )
+
+    def test_publish_ack(self):
+        self.publisher.publish_ack()
+        self.mock_repo_client.post_issue_comment.assert_called_once_with(
+            self.mock_pr.url,
+            "On it! We are reviewing the PR and will provide feedback shortly."
+        )
+
+    def test_publish_generated_pr_review_no_comments(self):
+        mock_pr_review_output = MagicMock(spec=CodePrReviewOutput)
+        mock_pr_review_output.comments = []
+
+        self.publisher.publish_generated_pr_review(mock_pr_review_output)
+        self.mock_repo_client.post_issue_comment.assert_called_once_with(
+            self.mock_pr.url,
+            "No changes requiring review at this time."
+        )
+
+    def test_publish_generated_pr_review_with_comments(self):
+        mock_comment = MagicMock(spec=GithubPrReviewComment)
+        mock_comment.path = "file.py"
+        mock_comment.line = 10
+        mock_comment.body = "This is a review comment."
+
+        mock_pr_review_output = MagicMock(spec=CodePrReviewOutput)
+        mock_pr_review_output.comments = [mock_comment]
+
+        with patch.object(
+            PrReviewPublisher,
+            '_format_comments',
+            return_value=[mock_comment]
+        ) as mock_format_comments:
+            self.publisher.publish_generated_pr_review(mock_pr_review_output)
+
+            self.mock_repo_client.post_pr_review_comment.assert_called_once_with(
+                self.mock_pr.url,
+                mock_comment
+            )
+
+            mock_format_comments.assert_called_once_with(
+                self.mock_pr.head.sha,
+                mock_pr_review_output
+            )
+
+    def test_publish_generated_pr_review_handles_exception(self): 
+        mock_comment = MagicMock(spec=GithubPrReviewComment)
+        mock_comment.path = "file.py"
+        mock_comment.line = 10
+        mock_comment.body = "This is a review comment."
+
+        mock_pr_review_output = MagicMock(spec=CodePrReviewOutput)
+        mock_pr_review_output.comments = [mock_comment]
+
+        self.mock_repo_client.post_pr_review_comment.side_effect = ValueError("Invalid comment")
+
+        with patch.object(
+            PrReviewPublisher,
+            '_format_comments',
+            return_value=[mock_comment]
+        ):
+            self.publisher.publish_generated_pr_review(mock_pr_review_output)
+
+            self.mock_repo_client.post_pr_review_comment.assert_called_once_with(
+                self.mock_pr.url,
+                mock_comment
+            )
+
+            self.mock_repo_client.post_issue_comment.assert_not_called()

--- a/tests/automation/test_steps.py
+++ b/tests/automation/test_steps.py
@@ -1,6 +1,8 @@
+from typing import Optional
 import unittest
 from unittest.mock import MagicMock
 
+from seer.automation.state import DbStateRunTypes
 from src.seer.automation.steps import (
     ConditionalStep,
     ConditionalStepRequest,
@@ -20,7 +22,7 @@ class ConcreteConditionalStep(ConditionalStep):
         return ConditionalStepRequest(**request)
 
     @staticmethod
-    def _instantiate_context(request):
+    def _instantiate_context(request, type: Optional["DbStateRunTypes"] = None):
         return MagicMock()
 
     def condition(self):
@@ -73,7 +75,7 @@ class ConcreteParallelizedChainStep(ParallelizedChainStep):
         return ParallelizedChainStepRequest(**request)
 
     @staticmethod
-    def _instantiate_context(request):
+    def _instantiate_context(request, type: Optional["DbStateRunTypes"] = None):
         return MagicMock()
 
     @staticmethod

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -22,6 +22,7 @@ def test_detected_celery_jobs():
                 "seer.automation.autofix.tasks.run_autofix_evaluation_on_item",
                 "seer.automation.autofix.tasks.check_and_mark_recent_autofix_runs",
                 "seer.automation.codegen.unittest_step.unittest_task",
+                'seer.automation.codegen.pr_review_step.pr_review_task',
                 "seer.automation.tasks.delete_data_for_ttl",
                 "seer.smoke_test.smoke_test",
             ]


### PR DESCRIPTION
This PR adds functionality for 2 endpoints to review a PR using Vertex
AI. It leverages similar functionality as the unit test endpoint.

`/codegen/pr-review` kicks off a PR review 
`/codegen/pr-review/state` fetches the stats of a given review

`pr_review_step.py` is responsible for fetching a list of json comments
for a given PR, and `pr_review_publisher` is responsible for posting
comments to that PR.
