### PR TITLE
chore(anomaly detection): Include ad_config in store log

### DIFF
--- a/src/seer/anomaly_detection/anomaly_detection.py
+++ b/src/seer/anomaly_detection/anomaly_detection.py
@@ -424,6 +424,7 @@ class AnomalyDetection(BaseModel):
                     "external_alert_id": request.alert.id,
                     "num_datapoints": len(request.timeseries),
                     "minimum_required": min_len,
+                    "config": request.config.model_dump(),
                 },
             )
             raise ClientError("Insufficient time series data for alert")
@@ -435,6 +436,7 @@ class AnomalyDetection(BaseModel):
                 "project_id": request.project_id,
                 "external_alert_id": request.alert.id,
                 "num_datapoints": len(request.timeseries),
+                "config": request.config.model_dump(),
             },
         )
         ts, anomalies = self._batch_detect(request.timeseries, request.config)


### PR DESCRIPTION
- Includes the ad_config json in the logs upon storing the alert and when the `insufficient_timeseries_data` error is thrown