### PR TITLE
chore(anomaly detection): Convert exception to warning

### DIFF
--- a/src/seer/anomaly_detection/anomaly_detection.py
+++ b/src/seer/anomaly_detection/anomaly_detection.py
@@ -248,8 +248,7 @@ class AnomalyDetection(BaseModel):
         except Exception as e:
             # Reset task and capture exception
             alert_data_accessor.reset_cleanup_task(historic.external_alert_id)
-            sentry_sdk.capture_exception(e)
-            logger.exception(e)
+            logger.warning(f"Failed to queue cleanup task: {str(e)}")
 
         return ts_external, streamed_anomalies
 


### PR DESCRIPTION
- Converts the exception into a warning which is logged
- This exception is thrown when the cleanup times out due to `compute_matrix_profile` taking a long time due to a cold start but the task is requeued and will succeed in the subsequent attempt if this occurs.