### PR TITLE
fix(autofix): Remove langfuse flushes to reduce cold starts

### DIFF
--- a/src/seer/automation/agent/agent.py
+++ b/src/seer/automation/agent/agent.py
@@ -108,10 +108,8 @@ class LlmAgent:
     def run(self, run_config: RunConfig):
         if run_config.run_name:
             langfuse_context.update_current_observation(name=run_config.run_name + " - Agent Run")
-            langfuse_context.flush()
         elif self.name:
             langfuse_context.update_current_observation(name=self.name + " - Agent Run")
-            langfuse_context.flush()
 
         if run_config.prompt:
             self.add_user_message(run_config.prompt)

--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -700,7 +700,6 @@ class LlmClient:
         try:
             if run_name:
                 langfuse_context.update_current_observation(name=run_name + " - Generate Text")
-                langfuse_context.flush()
 
             defaults = model.defaults
             default_temperature = defaults.temperature if defaults else None
@@ -800,7 +799,6 @@ class LlmClient:
                 langfuse_context.update_current_observation(
                     name=run_name + " - Generate Text Stream"
                 )
-                langfuse_context.flush()
 
             defaults = model.defaults
             default_temperature = defaults.temperature if defaults else None
@@ -851,7 +849,6 @@ class LlmClient:
         try:
             if run_name:
                 langfuse_context.update_current_observation(name=run_name + " - Generate Text")
-                langfuse_context.flush()
 
             defaults = model.defaults
             default_temperature = defaults.temperature if defaults else None

--- a/src/seer/langfuse.py
+++ b/src/seer/langfuse.py
@@ -45,14 +45,9 @@ def append_langfuse_observation_metadata(new_metadata: dict, langfuse: Langfuse 
     MUST BE RUN WITHIN A LANGFUSE OBSERVATION!
     """
     try:
-        observation_id = langfuse_context.get_current_observation_id()
-        langfuse_context.flush()
-        if observation_id:
-            observation = langfuse.get_observation(observation_id)
-
-            langfuse_context.update_current_observation(
-                metadata=(observation.metadata or {}) | new_metadata,
-            )
+        langfuse_context.update_current_observation(
+            metadata=new_metadata,
+        )
     except Exception as e:
         logger.exception(e)
 


### PR DESCRIPTION
Langfuse automatically flushes in the background. Correct me if I'm wrong, but I don't think we ever force terminate the program and would lose any data by relying on the automatic flushes.

These manual flushes block the main program and add ~750ms-1s of cold start on every LLM call, every keyword search, and every missing file fixer. (some profiles showed it taking up to 10s sometimes) Langfuse officially says to only use this when necessary as it is known to hurt performance.

So this would be a nice improvement to snappiness if we can get away with it.