### PR TITLE
fix(anomaly detection): Fix Integrity Error

### DIFF
--- a/src/seer/anomaly_detection/accessors.py
+++ b/src/seer/anomaly_detection/accessors.py
@@ -8,6 +8,7 @@ import numpy as np
 import sentry_sdk
 import stumpy  # type: ignore # mypy throws "missing library stubs"
 from pydantic import BaseModel
+from sqlalchemy import delete
 
 from seer.anomaly_detection.models import (
     AlgoConfig,
@@ -238,12 +239,10 @@ class DbAlertDataAccessor(AlertDataAccessor):
                         "external_alert_id": external_alert_id,
                     },
                 )
-                alert = (
-                    session.query(DbDynamicAlert)
-                    .filter_by(external_alert_id=external_alert_id)
-                    .one()
+                delete_q = delete(DbDynamicAlert).where(
+                    DbDynamicAlert.external_alert_id == external_alert_id
                 )
-                session.delete(alert)
+                session.execute(delete_q)
                 session.flush()
             algo_data = anomalies.get_anomaly_algo_data(len(timeseries))
             new_record = DbDynamicAlert(

--- a/src/seer/anomaly_detection/accessors.py
+++ b/src/seer/anomaly_detection/accessors.py
@@ -8,7 +8,6 @@ import numpy as np
 import sentry_sdk
 import stumpy  # type: ignore # mypy throws "missing library stubs"
 from pydantic import BaseModel
-from sqlalchemy import delete
 
 from seer.anomaly_detection.models import (
     AlgoConfig,
@@ -239,10 +238,13 @@ class DbAlertDataAccessor(AlertDataAccessor):
                         "external_alert_id": external_alert_id,
                     },
                 )
-                delete_q = delete(DbDynamicAlert).where(
-                    DbDynamicAlert.external_alert_id == external_alert_id
+                alert = (
+                    session.query(DbDynamicAlert)
+                    .filter_by(external_alert_id=external_alert_id)
+                    .one()
                 )
-                session.execute(delete_q)
+                session.delete(alert)
+                session.flush()
             algo_data = anomalies.get_anomaly_algo_data(len(timeseries))
             new_record = DbDynamicAlert(
                 organization_id=organization_id,


### PR DESCRIPTION
- Use `session.flush()` after the executed statement to separate delete and insert queries

Sources:
- https://m1lt0n.github.io/sqlalchemy/orm/python/delete-before-insert-sqlalchemy/
- https://github.com/sqlalchemy/sqlalchemy/issues/2501
- https://stackoverflow.com/questions/4201455/sqlalchemy-whats-the-difference-between-flush-and-commit
- https://docs.sqlalchemy.org/en/20/orm/session_basics.html#flushing