### PR TITLE
fix(anomaly detection): Recycle connection upon disconnect

### DIFF
--- a/src/seer/db.py
+++ b/src/seer/db.py
@@ -42,7 +42,10 @@ def initialize_database(
     app: Flask = injected,
 ):
     app.config["SQLALCHEMY_DATABASE_URI"] = config.DATABASE_URL
-    app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {"connect_args": {"prepare_threshold": None}}
+    app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {
+        "connect_args": {"prepare_threshold": None},
+        "pool_pre_ping": True,
+    }
 
     db.init_app(app)
     migrate.init_app(app, db)


### PR DESCRIPTION
- Enable the `pool_pre_ping` flag to allow connections to confirm disconnect and recycle all connections older than the current
- Pessimistic handling in this case should be correct since the connection is not dropped in the middle of a transaction

https://docs.sqlalchemy.org/en/20/core/pooling.html#pool-events