### PR TITLE
chore(anomaly-detection): do not store data if operation takes too long

### DIFF
--- a/src/seer/anomaly_detection/anomaly_detection.py
+++ b/src/seer/anomaly_detection/anomaly_detection.py
@@ -62,6 +62,7 @@ class AnomalyDetection(BaseModel):
         config: AnomalyDetectionConfig,
         window_size: int | None = None,
         algo_config: AlgoConfig = injected,
+        time_budget_ms: int | None = None,
     ) -> Tuple[List[TimeSeriesPoint], MPTimeSeriesAnomalies]:
         """
         Stateless batch anomaly detection on entire timeseries as provided. In batch mode, analysis of a
@@ -85,12 +86,18 @@ class AnomalyDetection(BaseModel):
             config,
             algo_config=algo_config,
             window_size=window_size,
+            time_budget_ms=(
+                time_budget_ms // 2 if time_budget_ms else None
+            ),  # Time budget is split between the two detection calls
         )
         anomalies_fixed = batch_detector.detect(
             convert_external_ts_to_internal(timeseries),
             config,
             algo_config=algo_config,
             window_size=algo_config.mp_fixed_window_size,
+            time_budget_ms=(
+                time_budget_ms // 2 if time_budget_ms else None
+            ),  # Time budget is split between the two detection calls
         )
         anomalies = DbAlertDataAccessor().combine_anomalies(
             anomalies_suss, anomalies_fixed, [True] * len(timeseries)
@@ -262,6 +269,7 @@ class AnomalyDetection(BaseModel):
         self,
         ts_with_history: TimeSeriesWithHistory,
         config: AnomalyDetectionConfig,
+        time_budget_ms: int | None = None,
     ) -> Tuple[List[TimeSeriesPoint], MPTimeSeriesAnomalies]:
         """
         Stateless online anomaly detection for a part of a time series. This function takes two parts of the time series -
@@ -309,8 +317,15 @@ class AnomalyDetection(BaseModel):
 
         # Run batch detect on history data
         batch_detector = MPBatchAnomalyDetector()
-        historic_anomalies_suss = batch_detector.detect(historic, config)
-        historic_anomalies_fixed = batch_detector.detect(historic, config, window_size=10)
+        historic_anomalies_suss = batch_detector.detect(
+            historic, config, time_budget_ms=time_budget_ms // 2 if time_budget_ms else None
+        )
+        historic_anomalies_fixed = batch_detector.detect(
+            historic,
+            config,
+            window_size=10,
+            time_budget_ms=time_budget_ms // 2 if time_budget_ms else None,
+        )
 
         # Run stream detection on current data
         # SuSS Window
@@ -396,9 +411,9 @@ class AnomalyDetection(BaseModel):
             sentry_sdk.set_tag(AnomalyDetectionTags.ALERT_ID, request.context.id)
             ts, anomalies = self._online_detect(request.context, request.config)
         elif isinstance(request.context, TimeSeriesWithHistory):
-            ts, anomalies = self._combo_detect(request.context, request.config)
+            ts, anomalies = self._combo_detect(request.context, request.config, time_budget_ms=4500)
         else:
-            ts, anomalies = self._batch_detect(request.context, request.config)
+            ts, anomalies = self._batch_detect(request.context, request.config, time_budget_ms=4500)
         self._update_anomalies(ts, anomalies)
         return DetectAnomaliesResponse(success=True, timeseries=ts)
 
@@ -407,7 +422,7 @@ class AnomalyDetection(BaseModel):
         self,
         request: StoreDataRequest,
         alert_data_accessor: AlertDataAccessor = injected,
-        timeout_ms: int = 4000,  # Allocating 4 seconds for batch detection as alerting system timesout after 5 seconds
+        time_budget_ms: int = 4500,  # Allocating 4.5 seconds as alerting system timesout after 5 seconds
     ) -> StoreDataResponse:
         """
         Main entry point for storing time series data for an alert.
@@ -444,9 +459,11 @@ class AnomalyDetection(BaseModel):
             },
         )
         time_start = datetime.datetime.now()
-        ts, anomalies = self._batch_detect(request.timeseries, request.config)
+        ts, anomalies = self._batch_detect(
+            request.timeseries, request.config, time_budget_ms=time_budget_ms
+        )
         time_elapsed = datetime.datetime.now() - time_start
-        time_allocated = datetime.timedelta(milliseconds=timeout_ms)
+        time_allocated = datetime.timedelta(milliseconds=time_budget_ms)
         if time_elapsed > time_allocated:
             sentry_sdk.set_extra("time_taken_for_batch_detection", time_elapsed)
             sentry_sdk.set_extra("time_allocated_for_batch_detection", time_allocated)

--- a/tests/seer/anomaly_detection/test_anomaly_detection.py
+++ b/tests/seer/anomaly_detection/test_anomaly_detection.py
@@ -83,12 +83,9 @@ class TestAnomalyDetection(unittest.TestCase):
             timeseries=ts,
         )
 
-        # timeseries: List[TimeSeriesPoint],
-        # config: AnomalyDetectionConfig,
-        # window_size: int | None = None,
-        # algo_config: AlgoConfig = injected,
-
-        def slow_function(timeseries, config, window_size=None, algo_config=None):
+        def slow_function(
+            timeseries, config, window_size=None, algo_config=None, time_budget_ms=None
+        ):
             time.sleep(0.2)  # Simulate a 200ms delay
             return timeseries, MPTimeSeriesAnomalies(
                 flags=[],
@@ -108,7 +105,7 @@ class TestAnomalyDetection(unittest.TestCase):
             AnomalyDetection().store_data(
                 request=request,
                 alert_data_accessor=mock_alert_data_accessor,
-                timeout_ms=100,
+                time_budget_ms=100,
             )
         assert "Batch detection took too long" in str(e.exception)
         mock_alert_data_accessor.save_alert.assert_not_called()
@@ -116,7 +113,7 @@ class TestAnomalyDetection(unittest.TestCase):
         response = AnomalyDetection().store_data(
             request=request,
             alert_data_accessor=mock_alert_data_accessor,
-            timeout_ms=300,
+            time_budget_ms=300,
         )
         assert isinstance(response, StoreDataResponse)
         assert response.success is True

--- a/tests/seer/anomaly_detection/test_anomaly_detection.py
+++ b/tests/seer/anomaly_detection/test_anomaly_detection.py
@@ -1,3 +1,4 @@
+import time
 import unittest
 from datetime import datetime
 from unittest.mock import MagicMock, patch
@@ -59,6 +60,67 @@ class TestAnomalyDetection(unittest.TestCase):
         assert "Store Data Response should be successful", response == StoreDataResponse(
             success=True
         )
+
+    @patch("seer.anomaly_detection.anomaly_detection.AnomalyDetection._batch_detect")
+    def test_store_data_batch_detection_timeout(self, mock_batch_detect):
+
+        mock_alert_data_accessor = MagicMock()
+        config = AnomalyDetectionConfig(
+            time_period=15, sensitivity="low", direction="both", expected_seasonality="auto"
+        )
+
+        loaded_synthetic_data = convert_synthetic_ts(
+            "tests/seer/anomaly_detection/test_data/synthetic_series", as_ts_datatype=True
+        )
+        ts = loaded_synthetic_data.timeseries[0]
+
+        alert = AlertInSeer(id=0)
+        request = StoreDataRequest(
+            organization_id=0,
+            project_id=0,
+            alert=alert,
+            config=config,
+            timeseries=ts,
+        )
+
+        # timeseries: List[TimeSeriesPoint],
+        # config: AnomalyDetectionConfig,
+        # window_size: int | None = None,
+        # algo_config: AlgoConfig = injected,
+
+        def slow_function(timeseries, config, window_size=None, algo_config=None):
+            time.sleep(0.2)  # Simulate a 200ms delay
+            return timeseries, MPTimeSeriesAnomalies(
+                flags=[],
+                scores=[],
+                matrix_profile_suss=np.array([]),
+                matrix_profile_fixed=np.array([]),
+                window_size=0,
+                thresholds=[],
+                original_flags=[],
+                use_suss=[],
+            )
+
+        mock_batch_detect.side_effect = slow_function
+
+        # Lower timeout setting should raise an error
+        with self.assertRaises(ServerError) as e:
+            AnomalyDetection().store_data(
+                request=request,
+                alert_data_accessor=mock_alert_data_accessor,
+                timeout_ms=100,
+            )
+        assert "Batch detection took too long" in str(e.exception)
+        mock_alert_data_accessor.save_alert.assert_not_called()
+
+        response = AnomalyDetection().store_data(
+            request=request,
+            alert_data_accessor=mock_alert_data_accessor,
+            timeout_ms=300,
+        )
+        assert isinstance(response, StoreDataResponse)
+        assert response.success is True
+        mock_alert_data_accessor.save_alert.assert_called_once()
 
     def test_detect_anomalies_batch(self):
 

--- a/tests/seer/anomaly_detection/test_utils.py
+++ b/tests/seer/anomaly_detection/test_utils.py
@@ -24,7 +24,7 @@ class LoadedSyntheticData(BaseModel):
     )
 
 
-def test_data_with_cycles(num_anomalous: int = 5) -> pd.DataFrame:
+def test_data_with_cycles(num_days: int = 29, num_anomalous: int = 5) -> pd.DataFrame:
     """
     Creates a time series with daily cycles and adds anomalies to the last num_anomalous points.
 
@@ -35,7 +35,7 @@ def test_data_with_cycles(num_anomalous: int = 5) -> pd.DataFrame:
     Returns:
     pd.DataFrame: A DataFrame with the time series data.
     """
-    date_range = pd.date_range(start="2023-01-01", periods=29, freq="D")
+    date_range = pd.date_range(start="2023-01-01", periods=num_days, freq="D")
 
     # Generate daily cycle values
     daily_cycle = np.sin(2 * np.pi * np.arange(24) / 24)


### PR DESCRIPTION
This change aborts saving data if the batch detection takes too long. This will help reduce the instances when Seer data goes out of sync with alerting system.

With this implementation, both `store_data` and `detect_anomalies` APIs return 500 - server error if the detection takes longer than 4.5 mins.