### PR TITLE
fix(seer): Fix multiple bootup problem

### DIFF
--- a/src/celery_app/app.py
+++ b/src/celery_app/app.py
@@ -29,9 +29,6 @@ def on_configure(*args: Any, sender: Celery, config: CeleryConfig = injected, **
 
 # on_after_finalize signal sent after celery app has been finalized. This should only be called from the celery worker and celery beat itself and not from flask or other external sources.
 def on_after_finalize(sender, **kwargs):
-    import traceback
-
-    traceback.print_stack()
     from celery_app.tasks import setup_periodic_tasks
 
     setup_periodic_tasks(sender)


### PR DESCRIPTION
Celery's `on_configure` is called to configure the "celery app" instance, this includes when you need to intialize it to send a task. This means that when we were submitting a task, such as through `apply_async` **we were actually calling `bootup` again.**

This is fixed by moving the bootup calls for both the celery worker and celerybeat to its own init signal handlers

Fixes [SEER-9P](https://sentry.sentry.io/issues/5731122470/)


----
This issue was able to be reproduced locally by simulating _multiple instances of seer_ locally, then in the logs it was clear that when we were scheduling the task, the _bootup_ call was being called from wherever the task was being scheduled from, **not** from the forked worker process like we thought. Although I didn't get the SQLAlchemy error like in prod, it was clearly calling bootup multiple times when bootup has already been called in that instance, I'm not sure why I'm not getting that error locally.