### PR TITLE
feat(autofix): Support profiles as context

### DIFF
--- a/src/seer/automation/autofix/components/coding/component.py
+++ b/src/seer/automation/autofix/components/coding/component.py
@@ -287,6 +287,7 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
                                 repo_names=[repo.full_name for repo in state.request.repos],
                                 original_instruction=request.original_instruction,
                                 root_cause_extra_instruction=request.root_cause_extra_instruction,
+                                code_map=request.profile,
                                 has_tools=True,
                             ),
                         ),

--- a/src/seer/automation/autofix/components/coding/models.py
+++ b/src/seer/automation/autofix/components/coding/models.py
@@ -11,7 +11,7 @@ from seer.automation.autofix.components.root_cause.models import (
 )
 from seer.automation.autofix.utils import remove_code_backticks
 from seer.automation.component import BaseComponentOutput, BaseComponentRequest
-from seer.automation.models import EventDetails, PromptXmlModel
+from seer.automation.models import EventDetails, Profile, PromptXmlModel
 from seer.automation.summarize.issue import IssueSummary
 
 
@@ -22,6 +22,7 @@ class CodingRequest(BaseComponentRequest):
     root_cause_extra_instruction: str | None = None
     summary: Optional[IssueSummary] = None
     initial_memory: list[Message] = []
+    profile: Profile | None = None
 
 
 class SnippetXml(PromptXmlModel, tag="snippet"):

--- a/src/seer/automation/autofix/components/coding/prompts.py
+++ b/src/seer/automation/autofix/components/coding/prompts.py
@@ -7,8 +7,13 @@ from seer.automation.autofix.components.coding.models import (
     RootCausePlanTaskPromptXml,
 )
 from seer.automation.autofix.components.root_cause.models import RootCauseAnalysisItem
-from seer.automation.autofix.prompts import format_instruction, format_repo_names, format_summary
-from seer.automation.models import EventDetails
+from seer.automation.autofix.prompts import (
+    format_code_map,
+    format_instruction,
+    format_repo_names,
+    format_summary,
+)
+from seer.automation.models import EventDetails, Profile
 from seer.automation.summarize.issue import IssueSummary
 
 
@@ -61,6 +66,7 @@ class CodingPrompts:
         root_cause_extra_instruction: str | None,
         summary: Optional[IssueSummary] = None,
         has_tools: bool = True,
+        code_map: Optional[Profile] = None,
     ):
         return textwrap.dedent(
             """\
@@ -68,6 +74,8 @@ class CodingPrompts:
             Given the issue: {summary_str}
             {event_str}{original_instruction}
             {root_cause_str}{root_cause_extra_instruction}
+
+            {code_map_str}
 
             # Your goal:
             Provide the most actionable and effective steps to fix the issue.
@@ -127,6 +135,7 @@ class CodingPrompts:
                 if has_tools
                 else ""
             ),
+            code_map_str=format_code_map(code_map),
         )
 
     @staticmethod

--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -67,6 +67,7 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
                             RootCauseAnalysisPrompts.format_default_msg(
                                 event=request.event_details.format_event(),
                                 summary=request.summary,
+                                code_map=request.profile,
                                 instruction=request.instruction,
                                 repo_names=[repo.full_name for repo in state.request.repos],
                             )

--- a/src/seer/automation/autofix/components/root_cause/models.py
+++ b/src/seer/automation/autofix/components/root_cause/models.py
@@ -6,7 +6,7 @@ from pydantic_xml import attr
 from seer.automation.agent.models import Message
 from seer.automation.autofix.utils import remove_code_backticks
 from seer.automation.component import BaseComponentOutput, BaseComponentRequest
-from seer.automation.models import EventDetails, PromptXmlModel
+from seer.automation.models import EventDetails, Profile, PromptXmlModel
 from seer.automation.summarize.issue import IssueSummary
 
 
@@ -162,6 +162,7 @@ class RootCauseAnalysisRequest(BaseComponentRequest):
     instruction: Optional[str] = None
     summary: Optional[IssueSummary] = None
     initial_memory: list[Message] = []
+    profile: Profile | None = None
 
 
 class RootCauseAnalysisOutput(BaseComponentOutput):

--- a/src/seer/automation/autofix/components/root_cause/prompts.py
+++ b/src/seer/automation/autofix/components/root_cause/prompts.py
@@ -1,7 +1,13 @@
 import textwrap
 from typing import Optional
 
-from seer.automation.autofix.prompts import format_instruction, format_repo_names, format_summary
+from seer.automation.autofix.prompts import (
+    format_code_map,
+    format_instruction,
+    format_repo_names,
+    format_summary,
+)
+from seer.automation.models import Profile
 from seer.automation.summarize.issue import IssueSummary
 
 
@@ -48,6 +54,7 @@ class RootCauseAnalysisPrompts:
         repo_names: list[str],
         instruction: Optional[str] = None,
         summary: Optional[IssueSummary] = None,
+        code_map: Optional[Profile] = None,
     ):
         return textwrap.dedent(
             """\
@@ -69,6 +76,7 @@ class RootCauseAnalysisPrompts:
             repo_names_str=format_repo_names(repo_names),
             instruction_str=format_instruction(instruction),
             summary_str=format_summary(summary),
+            code_map_str=format_code_map(code_map),
         )
 
     @staticmethod

--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -1,12 +1,12 @@
 import datetime
 import enum
 import uuid
-from typing import Annotated, Any, Literal, Optional, Union
+from typing import Annotated, Any, Literal, Optional, Set, Union
 
 from johen import gen
 from johen.examples import Examples
 from johen.generators import specialized
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
 
 from seer.automation.agent.models import Message, Usage
 from seer.automation.autofix.components.insight_sharing.models import InsightSharingOutput
@@ -305,6 +305,33 @@ class AutofixRequest(BaseModel):
     profile: Profile | None = None
 
     options: AutofixRequestOptions = Field(default_factory=AutofixRequestOptions)
+
+    @field_validator("profile", mode="before")
+    @classmethod
+    def extract_relevant_functions(
+        cls, profile: Profile | None, info: ValidationInfo
+    ) -> Profile | None:
+        if profile is not None and "issue" in info.data:
+            issue = info.data["issue"]
+            if not isinstance(issue, IssueDetails):
+                return profile
+
+            relevant_functions: Set[str] = set()
+
+            # Extract functions from exceptions
+            for event in issue.events:
+                for entry in event.get("entries", []):
+                    if entry.get("type") == "exception":
+                        for exception in entry.get("data", {}).get("values", []):
+                            if "stacktrace" in exception:
+                                for frame in exception["stacktrace"].get("frames", []):
+                                    if frame.get("function") and frame.get("in_app", False):
+                                        relevant_functions.add(frame["function"])
+
+            if relevant_functions:
+                profile.relevant_functions = relevant_functions
+
+        return profile
 
     @field_validator("issue_summary", mode="before")
     @classmethod

--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -12,7 +12,14 @@ from seer.automation.agent.models import Message, Usage
 from seer.automation.autofix.components.insight_sharing.models import InsightSharingOutput
 from seer.automation.autofix.components.root_cause.models import RootCauseAnalysisItem
 from seer.automation.autofix.config import AUTOFIX_HARD_TIME_OUT_MINS, AUTOFIX_UPDATE_TIMEOUT_SECS
-from seer.automation.models import FileChange, FilePatch, IssueDetails, Line, RepoDefinition
+from seer.automation.models import (
+    FileChange,
+    FilePatch,
+    IssueDetails,
+    Line,
+    Profile,
+    RepoDefinition,
+)
 from seer.automation.summarize.issue import IssueSummary
 from seer.automation.utils import make_kill_signal
 from seer.db import DbRunMemory
@@ -295,6 +302,7 @@ class AutofixRequest(BaseModel):
     invoking_user: Optional[AutofixUserDetails] = None
     instruction: Optional[str] = Field(default=None, validation_alias="additional_context")
     issue_summary: Optional[IssueSummary] = None
+    profile: Profile | None = None
 
     options: AutofixRequestOptions = Field(default_factory=AutofixRequestOptions)
 

--- a/src/seer/automation/autofix/prompts.py
+++ b/src/seer/automation/autofix/prompts.py
@@ -48,4 +48,4 @@ def format_summary(summary: IssueSummary | None) -> str:
 def format_code_map(code_map: Profile | None):
     if not code_map:
         return ""
-    return f"Here's a partial record of the code execution {('at the time of the issue' if code_map.profile_matches_issue else 'as it should generally work')}: \n{code_map.format_profile()}"
+    return f"Here's a partial map of the code{('at the time of the issue' if code_map.profile_matches_issue else 'that may help')}: \n{code_map.format_profile()}"

--- a/src/seer/automation/autofix/prompts.py
+++ b/src/seer/automation/autofix/prompts.py
@@ -1,5 +1,6 @@
 import textwrap
 
+from seer.automation.models import Profile
 from seer.automation.summarize.issue import IssueSummary
 
 
@@ -42,3 +43,9 @@ def format_summary(summary: IssueSummary | None) -> str:
         trace=summary.session_related_issues,
         possible_cause=summary.possible_cause,
     )
+
+
+def format_code_map(code_map: Profile | None):
+    if not code_map:
+        return ""
+    return f"Here's a partial record of the code execution {('at the time of the issue' if code_map.profile_matches_issue else 'as it should generally work')}: \n{code_map.format_profile()}"

--- a/src/seer/automation/autofix/steps/root_cause_step.py
+++ b/src/seer/automation/autofix/steps/root_cause_step.py
@@ -72,6 +72,7 @@ class RootCauseStep(AutofixPipelineStep):
                 instruction=state.request.instruction,
                 summary=summary,
                 initial_memory=self.request.initial_memory,
+                profile=state.request.profile,
             )
         )
 

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -501,7 +501,7 @@ class Profile(BaseModel):
             if node.module:
                 func_line += f" [{node.module}]"
 
-            location = f"{node.filename}:{node.lineno}"
+            location = f"{node.filename}"
             func_line += f" ({location})"
 
             result.append(func_line)

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -571,9 +571,6 @@ class Profile(BaseModel):
             indent_str = "  " * indent
 
             func_line = f"{indent_str}→ {node.function}"
-            if node.module:
-                func_line += f" [{node.module}]"
-
             location = f"{node.filename}"
             func_line += f" ({location})"
 

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -483,7 +483,7 @@ class Profile(BaseModel):
         self,
         indent: int = 0,
         context_before: int = 20,
-        context_after: int = 5,
+        context_after: int = 3,
     ) -> str:
         """
         Format the profile tree, focusing on relevant functions from the stacktrace.
@@ -508,7 +508,7 @@ class Profile(BaseModel):
         return full_profile
 
     def _get_relevant_code_window(
-        self, code: str, context_before: int = 20, context_after: int = 5
+        self, code: str, context_before: int = 20, context_after: int = 3
     ) -> str | None:
         """
         Find the relevant section of code containing functions from the stacktrace.

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -537,7 +537,9 @@ class Profile(BaseModel):
                 last_relevant_line = i
 
         if first_relevant_line is None:
-            return None
+            first_relevant_line = 0
+        if last_relevant_line is None:
+            last_relevant_line = len(lines) - 1
 
         # Calculate window boundaries with context
         start_line = max(0, first_relevant_line - context_before)

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -477,9 +477,80 @@ class ProfileFrame(BaseModel):
 class Profile(BaseModel):
     profile_matches_issue: bool
     execution_tree: list[ProfileFrame]
+    relevant_functions: set[str] = Field(default_factory=set)
 
-    def format_profile(self, indent: int = 0) -> str:
-        return self._format_profile_helper(self.execution_tree, indent)
+    def format_profile(
+        self,
+        indent: int = 0,
+        context_before: int = 20,
+        context_after: int = 5,
+    ) -> str:
+        """
+        Format the profile tree, focusing on relevant functions from the stacktrace.
+
+        Args:
+            indent: Base indentation level for the tree
+            context_before: Number of lines to include before first relevant function
+            context_after: Number of lines to include after last relevant function
+
+        Returns:
+            str: Formatted profile string, showing relevant sections of the execution tree
+        """
+        full_profile = self._format_profile_helper(self.execution_tree, indent)
+
+        if self.relevant_functions:
+            relevant_window = self._get_relevant_code_window(
+                full_profile, context_before=context_before, context_after=context_after
+            )
+            if relevant_window:
+                return relevant_window
+
+        return full_profile
+
+    def _get_relevant_code_window(
+        self, code: str, context_before: int = 20, context_after: int = 5
+    ) -> str | None:
+        """
+        Find the relevant section of code containing functions from the stacktrace.
+        Expands the selection to include context lines before and after.
+
+        Args:
+            code: Multi-line string of formatted profile to analyze
+            context_before: Number of lines to include before first relevant line
+            context_after: Number of lines to include after last relevant line
+
+        Returns:
+            str | None: Selected profile window with context, or None if no relevant functions found
+        """
+        if not self.relevant_functions or not code:
+            return None
+
+        lines = code.splitlines()
+        first_relevant_line = None
+        last_relevant_line = None
+
+        # Find first and last lines containing relevant functions
+        for i, line in enumerate(lines):
+            if any(func in line for func in self.relevant_functions):
+                if first_relevant_line is None:
+                    first_relevant_line = i
+                last_relevant_line = i
+
+        if first_relevant_line is None:
+            return None
+
+        # Calculate window boundaries with context
+        start_line = max(0, first_relevant_line - context_before)
+        end_line = min(len(lines), last_relevant_line + context_after + 1)
+
+        result = []
+        if start_line > 0:
+            result.append("...")
+        result.extend(lines[start_line:end_line])
+        if end_line < len(lines):
+            result.append("...")
+
+        return "\n".join(result)
 
     def _format_profile_helper(self, tree: list[ProfileFrame], indent: int = 0) -> str:
         """

--- a/tests/automation/test_automation_models.py
+++ b/tests/automation/test_automation_models.py
@@ -436,7 +436,7 @@ def test_profile_format_no_relevant_functions():
         ],
     )
 
-    expected = "→ main [app] (app.py)\n  → helper [utils] (utils.py)"
+    expected = "→ main (app.py)\n  → helper (utils.py)"
     assert profile.format_profile() == expected
 
 
@@ -481,7 +481,9 @@ def test_profile_format_with_relevant_functions():
 
     # Should only show the relevant function with context
     formatted = profile.format_profile(context_before=1, context_after=1)
-    expected = "...\n  → process_data [utils] (utils.py)\n  → relevant_func [core] (core.py)\n  → cleanup [utils] (utils.py)"
+    expected = (
+        "...\n  → process_data (utils.py)\n  → relevant_func (core.py)\n  → cleanup (utils.py)"
+    )
     assert formatted == expected
 
 
@@ -526,7 +528,7 @@ def test_profile_format_with_multiple_relevant_functions():
 
     # Should show both relevant functions with context
     formatted = profile.format_profile(context_before=1, context_after=1)
-    expected = "→ main [app] (app.py)\n  → relevant_func1 [core] (core.py)\n  → process_data [utils] (utils.py)\n  → relevant_func2 [core] (core.py)"
+    expected = "→ main (app.py)\n  → relevant_func1 (core.py)\n  → process_data (utils.py)\n  → relevant_func2 (core.py)"
     assert formatted == expected
 
 
@@ -566,9 +568,7 @@ def test_profile_format_with_nested_relevant_functions():
 
     # Should show the nested structure leading to the relevant function
     formatted = profile.format_profile(context_before=2, context_after=0)
-    expected = (
-        "→ main [app] (app.py)\n  → outer [core] (core.py)\n    → relevant_func [core] (core.py)"
-    )
+    expected = "→ main (app.py)\n  → outer (core.py)\n    → relevant_func (core.py)"
     assert formatted == expected
 
 
@@ -613,11 +613,8 @@ def test_profile_format_with_custom_context():
 
     # Test with minimal context
     minimal_context = profile.format_profile(context_before=0, context_after=0)
-    assert minimal_context == "...\n  → relevant_func [core] (core.py)\n..."
+    assert minimal_context == "...\n  → relevant_func (core.py)\n..."
 
     # Test with asymmetric context
     asymmetric_context = profile.format_profile(context_before=1, context_after=0)
-    assert (
-        asymmetric_context
-        == "...\n  → func1 [utils] (utils.py)\n  → relevant_func [core] (core.py)\n..."
-    )
+    assert asymmetric_context == "...\n  → func1 (utils.py)\n  → relevant_func (core.py)\n..."


### PR DESCRIPTION
Allow a profile to be passed into the Autofix request and add a map of code execution to the initial prompt.
Uses the stack trace to filter the map to the relevant section, with some extra context before and after. This should keep things from going out of control.

For example, if we have an error in `scrub_pii`, we'll tell Autofix: "Here's a partial map of the code at the time of the issue":
```
...
        → RepoClient.__init__ (seer/automation/codebase/repo_client.py)
          → get_github_app_auth_and_installation (seer/automation/codebase/repo_client.py)
          → RepoClient.get_default_branch_head_sha (seer/automation/codebase/repo_client.py)
            → RepoClient.get_branch_head_sha (seer/automation/codebase/repo_client.py)
    → RepoClient.get_valid_file_paths (seer/automation/codebase/repo_client.py)
    → potential_frame_match (seer/automation/codebase/utils.py)
→ AutofixContext.get_issue_summary (seer/automation/autofix/autofix_context.py)
→ CodingComponent.invoke (seer/automation/autofix/components/coding/component.py)
  → CodingComponent._prefill_initial_memory (seer/automation/autofix/components/coding/component.py)
    → AutofixContext.get_file_contents (seer/automation/autofix/autofix_context.py)
      → RepoClient.get_file_content (seer/automation/codebase/repo_client.py)
      → DbState.get (seer/automation/state.py)
    → DbState.update (seer/automation/state.py)
  → inject.<locals>.wrapper (seer/dependency_injection.py)
    → CodingComponent._is_obvious (seer/automation/autofix/components/coding/component.py)
      → CodingPrompts.format_is_obvious_msg (seer/automation/autofix/components/coding/prompts.py)
        → EventDetails.format_event (seer/automation/models.py)
          → EventDetails.format_exceptions (seer/automation/models.py)
            → EventDetails.format_exceptions.<locals>.<genexpr> (seer/automation/models.py)
              → Stacktrace.to_str (seer/automation/models.py)
                → Stacktrace._scrub_pii (seer/automation/models.py)
  → LlmClient.generate_structured (seer/automation/agent/client.py)
    → OpenAiProvider.generate_structured (seer/automation/agent/client.py)
      → OpenAiProvider.get_client (seer/automation/agent/client.py)
...
```