### PR TITLE
fix(autofix): Truncate long keyword search context

### DIFF
--- a/src/seer/automation/autofix/tools.py
+++ b/src/seer/automation/autofix/tools.py
@@ -207,6 +207,8 @@ class BaseTools:
         file_names = []
         for result in results:
             for match in result.matches:
+                if len(match.context) > 2000:  # truncate context if it's too long
+                    match.context = match.context[:2000] + "..."
                 match_xml = MatchXml(
                     path=result.relative_path,
                     context=match.context,

--- a/src/seer/automation/autofix/tools.py
+++ b/src/seer/automation/autofix/tools.py
@@ -207,8 +207,6 @@ class BaseTools:
         file_names = []
         for result in results:
             for match in result.matches:
-                if len(match.context) > 2000:  # truncate context if it's too long
-                    match.context = match.context[:2000] + "..."
                 match_xml = MatchXml(
                     path=result.relative_path,
                     context=match.context,

--- a/src/seer/automation/codebase/code_search.py
+++ b/src/seer/automation/codebase/code_search.py
@@ -15,6 +15,7 @@ class CodeSearcher:
         supported_extensions: set,
         max_results: int = 16,
         max_file_size_bytes: int = 1_000_000,  # 1 MB by default
+        max_context_characters: int = 2000,
         start_path: Optional[str] = None,
         default_encoding: str = "utf-8",
     ):
@@ -23,6 +24,7 @@ class CodeSearcher:
         self.max_results = max_results
         self.start_path = start_path
         self.max_file_size_bytes = max_file_size_bytes
+        self.max_context_characters = max_context_characters
         self.default_encoding = default_encoding
 
     def calculate_proximity_score(self, file_path: str) -> float:
@@ -110,6 +112,8 @@ class CodeSearcher:
                     start = max(0, i - 8)
                     end = min(len(lines), i + 9)
                     context = "".join(lines[start:end])
+                    if len(context) > self.max_context_characters:
+                        context = context[: self.max_context_characters] + "..."
                     matches.append(Match(line_number=i + 1, context=context))
                     break  # Stop after finding the first match
 


### PR DESCRIPTION
Sometimes the code context returned by keyword search would be really long (usually when there was a ton of code on one line, like some js core bundles), causing the LLM to error out. This PR limits each piece of context to 2000 characters.

NOTE: waiting on security issue to be resolved before I push working cassettes