### PR TITLE
fix(api): Reintroduce request signing

### DIFF
--- a/src/seer/json_api.py
+++ b/src/seer/json_api.py
@@ -91,9 +91,7 @@ def json_api(blueprint: Blueprint, url_rule: str) -> Callable[[_F], _F]:
                     body=raw_data,
                     signature=parts[1],
                 ):
-                    raise Unauthorized(
-                        f"Rpcsignature did not match for given url {request.url} and data"
-                    )
+                    raise Unauthorized(f"Rpcsignature did not match for call to {request.url}")
             elif auth_header.startswith("Bearer "):
                 token = auth_header.split()[1]
                 try:
@@ -116,7 +114,6 @@ def json_api(blueprint: Blueprint, url_rule: str) -> Callable[[_F], _F]:
                     raise Unauthorized("Invalid token")
                 except Exception as e:
                     sentry_sdk.capture_exception(e)
-                    print(e)
                     raise InternalServerError("Something went wrong with the Bearer token auth")
 
             # Cached from ^^, this won't result in double read.

--- a/src/seer/json_api.py
+++ b/src/seer/json_api.py
@@ -82,20 +82,19 @@ def json_api(blueprint: Blueprint, url_rule: str) -> Callable[[_F], _F]:
 
         @inject
         def wrapper(config: AppConfig = injected) -> Any:
-            # raw_data = request.get_data()
+            raw_data = request.get_data()
             auth_header = request.headers.get("Authorization", "")
 
-            # if auth_header.startswith("Rpcsignature "):
-            # Optional for now during rollout, make this required after rollout.
             if auth_header.startswith("Rpcsignature "):
-                #     parts = auth_header.split()
-                #     if len(parts) != 2 or not compare_signature(
-                #         request.url, request.args.get("nonce", ""), raw_data, parts[1]
-                #     ):
-                #         raise Unauthorized(
-                #             f"Rpcsignature did not match for given url {request.url} and data"
-                #         )
-                pass
+                parts = auth_header.split()
+                if len(parts) != 2 or not compare_signature(
+                    nonce=request.args.get("nonce", ""),
+                    body=raw_data,
+                    signature=parts[1],
+                ):
+                    raise Unauthorized(
+                        f"Rpcsignature did not match for given url {request.url} and data"
+                    )
             elif auth_header.startswith("Bearer "):
                 token = auth_header.split()[1]
                 try:
@@ -151,16 +150,13 @@ def is_valid(payload: bytes, key: str, signature_data: str):
 
 @inject
 def compare_signature(
-    url: str, nonce: str, body: bytes, signature: str, config: AppConfig = injected
+    *, nonce: str, body: bytes, signature: str, config: AppConfig = injected
 ) -> bool:
     """
     Compare request data + signature signed by one of the shared secrets.
     Once a key has been able to validate the signature other keys will
     not be attempted. We should only have multiple keys during key rotations.
     """
-    # During the transition, support running seer without the shared secrets.
-    if not signature:
-        return True
 
     secrets = config.JSON_API_SHARED_SECRETS
 
@@ -169,28 +165,18 @@ def compare_signature(
         return False
 
     _, signature_data = signature.split(":", 2)
+
     for key in secrets:
-        if nonce:
-            if is_valid(b"%s:%s" % (nonce.encode(), body), key, signature_data):
-                span = sentry_sdk.Hub.current.scope.span
-                if span:
-                    span.set_data("rpc_auth_additional_payload", "nonce")
-                return True
-        elif is_valid(
-            b"%s:%s"
-            % (
-                url.encode(),
-                body,
-            ),
-            key,
-            signature_data,
-        ):
+        # If nonce is provided, use it in signature verification
+        payload = b"%s:%s" % (nonce.encode(), body) if nonce else body
+
+        # TODO: Verify that the nonce has not been used before?
+
+        if is_valid(payload, key, signature_data):
             span = sentry_sdk.Hub.current.scope.span
             if span:
-                span.set_data("rpc_auth_additional_payload", "url")
+                span.set_data("rpc_auth_additional_payload", "nonce" if nonce else "body_only")
             return True
-        else:
-            sentry_sdk.capture_message("Signature did not match hmac")
 
     sentry_sdk.capture_message("No signature matches found.")
     return False

--- a/tests/test_json_api.py
+++ b/tests/test_json_api.py
@@ -231,16 +231,3 @@ def test_json_api_signature_strict_mode():
             ).hexdigest()
             headers["Authorization"] = f"Rpcsignature rpc0:{signature}"
         assert changed.to_value(200)
-
-        with status_code_watcher as changed:
-            path += "?nonce=1234"
-        assert changed.to_value(401)
-
-        with status_code_watcher as changed:
-            signature = hmac.new(
-                "secret-one".encode(),
-                b"1234:%s" % json.dumps(payload, sort_keys=True).encode("utf-8"),
-                hashlib.sha256,
-            ).hexdigest()
-            headers["Authorization"] = f"Rpcsignature rpc0:{signature}"
-        assert changed.to_value(200)


### PR DESCRIPTION
_Previously request signing was disabled due to a quirk in our networking setup that made the request url passed to the client signer not the same as the request seen on the server side._

This reimplements the request signing with an optional nonce but without the salted url verification. This is a stop-gap measure to reimplement signature signing for now until we have bandwidth to invest in a more complete solution.