### PR TITLE
ref(autofix): remove repo_id and namespace_id

### DIFF
--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -212,15 +212,12 @@ class AutofixContext(PipelineContext):
     def commit_changes(
         self,
         repo_external_id: str | None = None,
-        repo_id: int | None = None,
         make_pr: bool = False,
         pr_to_comment_on_url: str | None = None,
     ):
         state = self.state.get()
         for codebase_state in state.codebases.values():
-            if (
-                repo_external_id is None and repo_id is None
-            ) or codebase_state.repo_external_id == repo_external_id:
+            if (repo_external_id is None) or codebase_state.repo_external_id == repo_external_id:
                 changes_step = state.find_step(key="changes")
                 if not changes_step:
                     raise ValueError("Changes step not found")
@@ -234,7 +231,7 @@ class AutofixContext(PipelineContext):
                     (None, None),
                 )
                 if codebase_state.file_changes and change_state and changes_state_index is not None:
-                    key = codebase_state.repo_external_id or codebase_state.repo_id
+                    key = codebase_state.repo_external_id
 
                     if key is None:
                         raise ValueError("Repo key not found")

--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -217,7 +217,7 @@ class AutofixContext(PipelineContext):
     ):
         state = self.state.get()
         for codebase_state in state.codebases.values():
-            if (repo_external_id is None) or codebase_state.repo_external_id == repo_external_id:
+            if repo_external_id is None or codebase_state.repo_external_id == repo_external_id:
                 changes_step = state.find_step(key="changes")
                 if not changes_step:
                     raise ValueError("Changes step not found")

--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -103,7 +103,6 @@ class CommittedPullRequestDetails(BaseModel):
 
 
 class CodebaseChange(BaseModel):
-    repo_id: int | None = None
     repo_external_id: str | None = None
     repo_name: str
     title: str
@@ -222,8 +221,6 @@ Step = Union[DefaultStep, RootCauseStep, ChangesStep]
 
 
 class CodebaseState(BaseModel):
-    repo_id: int | None = None
-    namespace_id: int | None = None
     repo_external_id: str | None = None
     file_changes: list[FileChange] = []
 
@@ -373,14 +370,12 @@ class AutofixRootCauseUpdatePayload(BaseModel):
 class AutofixCreatePrUpdatePayload(BaseModel):
     type: Literal[AutofixUpdateType.CREATE_PR] = AutofixUpdateType.CREATE_PR
     repo_external_id: str | None = None
-    repo_id: int | None = None  # TODO: Remove this when we won't be breaking LA customers.
     make_pr: bool = True
 
 
 class AutofixCreateBranchUpdatePayload(BaseModel):
     type: Literal[AutofixUpdateType.CREATE_BRANCH] = AutofixUpdateType.CREATE_BRANCH
     repo_external_id: str | None = None
-    repo_id: int | None = None  # TODO: Remove this when we won't be breaking LA customers.
     make_pr: bool = False
 
 
@@ -402,7 +397,9 @@ class AutofixUpdateCodeChangePayload(BaseModel):
     hunk_index: int
     lines: list[Line]
     file_path: str
-    repo_id: str | None = None
+    repo_external_id: str | None = Field(default=None, alias="repo_id")
+
+    model_config = ConfigDict(populate_by_name=True)  # Allows both field name and alias
 
 
 class AutofixCommentThreadPayload(BaseModel):

--- a/src/seer/automation/autofix/steps/change_describer_step.py
+++ b/src/seer/automation/autofix/steps/change_describer_step.py
@@ -84,7 +84,6 @@ class AutofixChangeDescriberStep(AutofixPipelineStep):
                     )
 
                     change = CodebaseChange(
-                        repo_id=1,
                         repo_external_id=codebase_state.repo_external_id,
                         repo_name=repo_definition.full_name,
                         title=change_description.title if change_description else "Code Changes",
@@ -111,7 +110,6 @@ class AutofixChangeDescriberStep(AutofixPipelineStep):
             for repo in cur_state.request.repos:
                 self.context.commit_changes(
                     repo_external_id=repo.external_id,
-                    repo_id=None,
                     pr_to_comment_on_url=self.request.pr_to_comment_on,
                     make_pr=True,
                 )

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -218,7 +218,6 @@ def run_autofix_push_changes(
 
     context.commit_changes(
         repo_external_id=request.payload.repo_external_id,
-        repo_id=request.payload.repo_id,
         make_pr=request.payload.make_pr,
     )
 
@@ -436,7 +435,7 @@ def update_code_change(request: AutofixUpdateRequest):
     state = ContinuationState(request.run_id)
     cur_state = state.get()
 
-    repo_id = request.payload.repo_id
+    repo_external_id = request.payload.repo_external_id
     hunk_index = request.payload.hunk_index
     lines = request.payload.lines
     file_path = request.payload.file_path
@@ -451,7 +450,7 @@ def update_code_change(request: AutofixUpdateRequest):
     matching_change = None
     change_index = 0
     for i, change in enumerate(changes):
-        if change.repo_external_id == repo_id:
+        if change.repo_external_id == repo_external_id:
             matching_change = change
             change_index = i
             break

--- a/tests/automation/autofix/test_autofix_context.py
+++ b/tests/automation/autofix/test_autofix_context.py
@@ -324,7 +324,6 @@ class TestAutofixContextPrCommit(unittest.TestCase):
             cur.codebases = {
                 "1": CodebaseState(
                     repo_external_id="1",
-                    namespace_id=1,
                     file_changes=[
                         FileChange(
                             path="test.py",

--- a/tests/automation/autofix/test_autofix_tasks.py
+++ b/tests/automation/autofix/test_autofix_tasks.py
@@ -792,7 +792,7 @@ def test_update_code_change_happy_path():
         run_id=1,
         payload=AutofixUpdateCodeChangePayload(
             type=AutofixUpdateType.UPDATE_CODE_CHANGE,
-            repo_id="test_repo",
+            repo_external_id="test_repo",
             hunk_index=0,
             lines=new_lines,
             file_path="test_file.py",
@@ -866,7 +866,7 @@ def test_update_code_change_no_matching_repo():
         run_id=1,
         payload=AutofixUpdateCodeChangePayload(
             type=AutofixUpdateType.UPDATE_CODE_CHANGE,
-            repo_id="test_repo",
+            repo_external_id="test_repo",
             hunk_index=0,
             lines=[],
             file_path="test_file.py",
@@ -913,7 +913,7 @@ def test_update_code_change_no_matching_file():
         run_id=1,
         payload=AutofixUpdateCodeChangePayload(
             type=AutofixUpdateType.UPDATE_CODE_CHANGE,
-            repo_id="test_repo",
+            repo_external_id="test_repo",
             hunk_index=0,
             lines=[],
             file_path="test_file.py",
@@ -968,7 +968,7 @@ def test_update_code_change_invalid_hunk_index():
         run_id=1,
         payload=AutofixUpdateCodeChangePayload(
             type=AutofixUpdateType.UPDATE_CODE_CHANGE,
-            repo_id="test_repo",
+            repo_external_id="test_repo",
             hunk_index=99,  # Invalid index
             lines=[],
             file_path="test_file.py",
@@ -992,7 +992,7 @@ def test_update_code_change_non_changes_step():
         run_id=1,
         payload=AutofixUpdateCodeChangePayload(
             type=AutofixUpdateType.UPDATE_CODE_CHANGE,
-            repo_id="test_repo",
+            repo_external_id="test_repo",
             hunk_index=0,
             lines=[],
             file_path="test_file.py",

--- a/tests/automation/autofix/test_models.py
+++ b/tests/automation/autofix/test_models.py
@@ -47,7 +47,6 @@ class TestStacktraceHelpers(unittest.TestCase):
                 col_no=20,
                 context=[(10, "    main()")],
                 repo_name="my_repo",
-                repo_id=1,
                 in_app=True,
             ),
             StacktraceFrame(
@@ -58,7 +57,6 @@ class TestStacktraceHelpers(unittest.TestCase):
                 col_no=None,
                 context=[(15, "    helper()")],
                 repo_name="my_repo",
-                repo_id=1,
                 in_app=False,
             ),
         ]
@@ -81,7 +79,6 @@ class TestStacktraceHelpers(unittest.TestCase):
                 col_no=20,
                 context=[],
                 repo_name="my_repo",
-                repo_id=1,
                 in_app=True,
             ),
         ]
@@ -101,7 +98,6 @@ class TestStacktraceHelpers(unittest.TestCase):
                 col_no=20,
                 context=[(10, "    unknown()")],
                 repo_name=None,
-                repo_id=None,
                 in_app=True,
             ),
         ]
@@ -119,7 +115,6 @@ class TestStacktraceHelpers(unittest.TestCase):
                 col_no=None,
                 context=[(i * 10, f"    function_{i}()")],
                 repo_name="my_repo",
-                repo_id=1,
                 in_app=(i % 2 == 0),
             )
             for i in range(20)
@@ -191,7 +186,6 @@ class TestStacktraceHelpers(unittest.TestCase):
                 col_no=20,
                 context=[(10, "    main()")],
                 repo_name="my_repo",
-                repo_id=1,
                 in_app=True,
             ),
             StacktraceFrame(
@@ -202,7 +196,6 @@ class TestStacktraceHelpers(unittest.TestCase):
                 col_no=None,
                 context=[(15, "    helper()")],
                 repo_name="my_repo",
-                repo_id=1,
                 in_app=False,
             ),
         ]

--- a/tests/data/autofix_full_finished_run.json
+++ b/tests/data/autofix_full_finished_run.json
@@ -155,7 +155,6 @@
             "output_stream": null,
             "changes": [
                 {
-                    "repo_id": 1,
                     "repo_external_id": "439438299",
                     "repo_name": "getsentry/seer",
                     "title": "Ah yes Uncommented Unit Test and Reproduction Fields in Root Cause Models",
@@ -721,8 +720,6 @@
     "status": "COMPLETED",
     "codebases": {
         "439438299": {
-            "repo_id": null,
-            "namespace_id": null,
             "repo_external_id": "439438299",
             "file_changes": [
                 {

--- a/tests/data/autofix_root_cause_run.json
+++ b/tests/data/autofix_root_cause_run.json
@@ -135,8 +135,6 @@
     "status": "COMPLETED",
     "codebases": {
         "439438299": {
-            "repo_id": null,
-            "namespace_id": null,
             "repo_external_id": "439438299",
             "file_changes": []
         }


### PR DESCRIPTION
Remove unused `repo_id` and `namespace_id` from the codebase indexing days, we now use `repo_external_id`