### PR TITLE
fix(autofix): Clear file changes on step reset without changes

### DIFF
--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -239,7 +239,7 @@ class AutofixEventManager:
 
             # Clear file changes if the changes step is not present.
             if not next((step for step in cur.steps if step.key == self.changes_step.key), None):
-                self.clear_file_changes()
+                cur.clear_file_changes()
 
         count = 0
         while make_kill_signal() in self.state.get().signals:

--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -237,6 +237,10 @@ class AutofixEventManager:
                 )
                 cur.steps[-1] = step
 
+            # Clear file changes if the changes step is not present.
+            if not next((step for step in cur.steps if step.key == self.changes_step.key), None):
+                self.clear_file_changes()
+
         count = 0
         while make_kill_signal() in self.state.get().signals:
             time.sleep(0.5)  # wait for all steps to be killed

--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -526,9 +526,8 @@ class AutofixContinuation(AutofixGroupState):
             self.steps = self.steps[: found_index + (0 if include_current else 1)]
 
     def clear_file_changes(self):
-        for key, codebase in self.codebases.items():
+        for codebase in self.codebases.values():
             codebase.file_changes = []
-            self.codebases[key] = codebase
 
     @property
     def is_running(self):

--- a/tests/automation/autofix/test_autofix_event_manager.py
+++ b/tests/automation/autofix/test_autofix_event_manager.py
@@ -188,7 +188,7 @@ class TestAutofixEventManager:
                 MagicMock(signals=[make_kill_signal()]),
                 MagicMock(signals=[make_kill_signal()]),
                 MagicMock(signals=[make_kill_signal()]),
-                MagicMock(signals=[make_kill_signal()]),
+                MagicMock(signals=[]),
                 MagicMock(signals=[]),
             ]
             mock_time.reset_mock()


### PR DESCRIPTION
When rethinking, we just clear the file changes if there is no more changes step.

Tested locally to ensure fully working.

Fixes #1465 