### PR TITLE
fix(issue summary) Increase OpenAI max_retries from 2 to 4

### DIFF
--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -75,7 +75,7 @@ class OpenAiProvider:
 
     @staticmethod
     def get_client() -> openai.Client:
-        return openai.Client()
+        return openai.Client(max_retries=4)
 
     @classmethod
     def model(cls, model_name: str) -> "OpenAiProvider":


### PR DESCRIPTION
The client [retries](https://github.com/openai/openai-python/blob/d16e6edde5a155626910b5758a0b939bfedb9ced/src/openai/_base_client.py#L723-L726) on APITimeoutErrors. The timeout for issue summary is [7 seconds](https://github.com/getsentry/seer/blob/c504fcbc506585b65cd548dbf75ea96f90fee558/src/seer/automation/summarize/issue.py#L88).