### PR TITLE
fix(autofix): Handle empty thoughts in insight sharing

### DIFF
--- a/src/seer/automation/autofix/components/insight_sharing/component.py
+++ b/src/seer/automation/autofix/components/insight_sharing/component.py
@@ -54,7 +54,7 @@ class InsightSharingPrompts:
 
         return textwrap.dedent(template).format(
             latest_thought=latest_thought,
-            insights=" ".join(past_insights) if past_insights else "not started yet",
+            insights=" ".join(past_insights) if past_insights else "[paragraph is empty]",
             no_insight_instruction=no_insight_instruction,
         )
 
@@ -88,6 +88,9 @@ def create_insight_output(
     llm_client: LlmClient = injected,
 ) -> tuple[InsightSharingOutput | None, Usage]:
     usage = Usage()
+
+    if not latest_thought or len(latest_thought.strip()) < 10:
+        return None, usage
 
     prompt_one = InsightSharingPrompts.format_step_one(
         step_type=step_type,


### PR DESCRIPTION
Weird hallucinations would happen if the insight card prompt didn't contain any input.