### PR TITLE
feat(autofix-evals): o3-mini for evals + rca eval scorer prompt

### DIFF
--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -68,6 +68,10 @@ class OpenAiProvider:
             defaults=LlmProviderDefaults(temperature=1.0),
         ),
         LlmModelDefaultConfig(
+            match=r"^o3-mini.*",
+            defaults=LlmProviderDefaults(temperature=1.0),
+        ),
+        LlmModelDefaultConfig(
             match=r".*",
             defaults=LlmProviderDefaults(temperature=0.0),
         ),
@@ -375,6 +379,20 @@ class OpenAiProvider:
             content="".join(content_chunks) if content_chunks else None,
             tool_calls=tool_calls if tool_calls else None,
         )
+
+    async def arun(self, prompt: str) -> str:
+        """Async version of run method"""
+        # Add async implementation here based on your agent client
+        # This will depend on your specific agent implementation
+        response = await self._acall_agent(prompt)
+        return response
+
+    async def _acall_agent(self, prompt: str) -> str:
+        """Async implementation of agent call"""
+        # Implement based on your agent client
+        # Example:
+        # return await self.client.acomplete(prompt)
+        raise NotImplementedError("Please implement async agent calls")
 
 
 @dataclass

--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -380,20 +380,6 @@ class OpenAiProvider:
             tool_calls=tool_calls if tool_calls else None,
         )
 
-    async def arun(self, prompt: str) -> str:
-        """Async version of run method"""
-        # Add async implementation here based on your agent client
-        # This will depend on your specific agent implementation
-        response = await self._acall_agent(prompt)
-        return response
-
-    async def _acall_agent(self, prompt: str) -> str:
-        """Async implementation of agent call"""
-        # Implement based on your agent client
-        # Example:
-        # return await self.client.acomplete(prompt)
-        raise NotImplementedError("Please implement async agent calls")
-
 
 @dataclass
 class AnthropicProvider:

--- a/src/seer/automation/autofix/evaluations.py
+++ b/src/seer/automation/autofix/evaluations.py
@@ -325,23 +325,32 @@ def score_root_cause_single_it(
 
             Given the above issue, we know the correct root cause of the issue is:
 
+            <true_root_cause>
             {expected_output}
 
-            The model outputted the following possible root causes and solutions:
+            The solution to this root cause is:
+            {expected_solution_description}
+            {expected_solution_diff}
+            </true_root_cause>
 
-            <predicted_solutions>
+            We have an AI model say that the root cause of the issue is:
+
+            <predicted_root_cause>
             {predicted_solution}
-            </predicted_solutions>
+            </predicted_root_cause>
 
-            Score how well the predicted root cause and solution matches the expected root cause and solution with a float score from 0 to 1, where 1 means the solution fully fixes the issue and 0 means the solution does not fix the issue at all.
-            - The model will return multiple predicted root causes and solutions, ordered from most likely to least likely.
+            Score how well the AI model's predicted root cause aligns with the true known root cause with a float score from 0 to 1, where 1 means the predicted root cause is the correct root cause and 0 means the predicted root cause is completely incorrect.
 
-            Think step-by-step inside a <thoughts> tag before giving scores.
-            Score each solution inside a <score> tag, such as <score>0.5</score>.
-            Also, return your verdict of whether the predicted solution is the correct root cause of the issue with a boolean value inside a <verdict> tag, such as <verdict>True</verdict> or <verdict>False</verdict>."""
+            Provide your reasoning of why you gave this score inside a <reasoning> tag.
+
+            Place the score inside a <score> tag, such as <score>0.5</score>.
+            Also, return your verdict of whether the predicted root cause accurately represents the true root cause of the issue with a boolean value inside a <verdict> tag, such as <verdict>True</verdict> or <verdict>False</verdict>.
+            You should also grade whether the model's predicted root cause would be helpful to the developer in fixing the issue with a boolean value inside a <helpful> tag, such as <helpful>True</helpful> or <helpful>False</helpful>."""
     ).format(
         event_details=event_details.format_event(),
         expected_output=root_cause_expected_str,
+        expected_solution_description=expected_output["solution_diff"]["description"],
+        expected_solution_diff=expected_output["solution_diff"]["unified_diff"],
         predicted_solution=cause_xml.to_prompt_str(),
     )
     response = LlmClient().generate_text(

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -654,7 +654,7 @@ def run_autofix_evaluation_on_item(
     )
 
     scoring_n_panel = 5
-    scoring_model = "o1-mini-2024-09-12"
+    scoring_model = "o3-mini-2025-01-31"
 
     diff: str | None = None
     causes: list[RootCauseAnalysisItem] | None = None

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -802,7 +802,7 @@ def run_autofix_evaluation_on_item(
                 )
 
             if causes:
-                root_cause_score, root_cause_verdict = score_root_causes(
+                root_cause_score, root_cause_verdict, root_cause_helpful = score_root_causes(
                     dataset_item,
                     causes,
                     n_panel=scoring_n_panel,
@@ -820,6 +820,13 @@ def run_autofix_evaluation_on_item(
                         model=scoring_model, n_panel=scoring_n_panel, name="rc_is_correct"
                     ),
                     value=1 if root_cause_verdict else 0,
+                )
+                langfuse.score(
+                    trace_id=trace_id,
+                    name=make_score_name(
+                        model=scoring_model, n_panel=scoring_n_panel, name="rc_is_helpful"
+                    ),
+                    value=1 if root_cause_helpful else 0,
                 )
                 langfuse.score(
                     trace_id=trace_id,


### PR DESCRIPTION
o3 mini for scoring, + new prompt for root cause that should fix issues that we were seeing such as
- Mistaking the expected for the predicted
- Not being critical enough of the root cause
- Being _too strict_ 

Also adds a new metric for how helpful it is

![CleanShot 2025-02-04 at 15 40 06](https://github.com/user-attachments/assets/5e138b3e-eb04-469d-bdd6-9380a33caabe)
