### PR TITLE
chore(autofix): Replace 4o mini with Flash 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 aiohappyeyeballs==2.4.4
     # via aiohttp
-aiohttp==3.11.11
+aiohttp==3.11.12
     # via
     #   -r requirements-constraints.txt
     #   datasets
@@ -347,7 +347,7 @@ llvmlite==0.44.0
     # via numba
 lunarcalendar==0.0.9
     # via -r requirements-constraints.txt
-mako==1.3.8
+mako==1.3.9
     # via alembic
 markdown-it-py==3.0.0
     # via rich
@@ -426,7 +426,7 @@ onnx==1.16.0
     # via -r requirements-constraints.txt
 onnxruntime==1.20.1
     # via chromadb
-openai==1.61.0
+openai==1.61.1
     # via -r requirements-constraints.txt
 openapi-core==0.18.2
     # via -r requirements-constraints.txt
@@ -678,7 +678,7 @@ sentencepiece==0.2.0
     # via
     #   sentence-transformers
     #   transformers
-sentry-protos==0.1.58
+sentry-protos==0.1.59
     # via -r requirements-constraints.txt
 sentry-sdk==2.18.0
     # via -r requirements-constraints.txt

--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -770,7 +770,6 @@ class GeminiProvider:
                 response_schema=response_format,
             ),
         )
-        structured_result = response.parsed
 
         usage = Usage(
             completion_tokens=response.usage_metadata.candidates_token_count,
@@ -780,7 +779,7 @@ class GeminiProvider:
         langfuse_context.update_current_observation(model=self.model_name, usage=usage)
 
         return LlmGenerateStructuredResponse(
-            parsed=structured_result,
+            parsed=response.parsed,
             metadata=LlmResponseMetadata(
                 model=self.model_name,
                 provider_name=self.provider_name,

--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -767,11 +767,10 @@ class GeminiProvider:
                 temperature=temperature or 0.0,
                 response_mime_type="application/json",
                 max_output_tokens=max_tokens or 8192,
-                response_schema=response_format.model_json_schema(),  # type: ignore[attr-defined]
+                response_schema=response_format,
             ),
         )
-        result = response.text
-        structured_result = response_format.model_validate_json(result)  # type: ignore[attr-defined]
+        structured_result = response.parsed
 
         usage = Usage(
             completion_tokens=response.usage_metadata.candidates_token_count,

--- a/src/seer/automation/autofix/components/coding/component.py
+++ b/src/seer/automation/autofix/components/coding/component.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from sentry_sdk.ai.monitoring import ai_track
 
 from seer.automation.agent.agent import AgentConfig, RunConfig
-from seer.automation.agent.client import AnthropicProvider, LlmClient, OpenAiProvider
+from seer.automation.agent.client import AnthropicProvider, GeminiProvider, LlmClient
 from seer.automation.agent.models import Message
 from seer.automation.autofix.autofix_agent import AutofixAgent
 from seer.automation.autofix.autofix_context import AutofixContext
@@ -122,7 +122,7 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
                     custom_solution=request.solution if isinstance(request.solution, str) else None,
                     mode=request.mode,
                 ),
-                model=OpenAiProvider.model("gpt-4o-mini"),
+                model=GeminiProvider.model("gemini-2.0-flash-001"),
                 response_format=IsObviousOutput,
             )
 
@@ -142,7 +142,7 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
             output = llm_client.generate_structured(
                 messages=memory,
                 prompt="Given the above instruction, do you need to search the codebase for more context or have an immediate answer?",
-                model=OpenAiProvider.model("gpt-4o-mini"),
+                model=GeminiProvider.model("gemini-2.0-flash-001"),
                 response_format=NeedToSearchCodebaseOutput,
             )
 

--- a/src/seer/automation/autofix/components/is_root_cause_obvious.py
+++ b/src/seer/automation/autofix/components/is_root_cause_obvious.py
@@ -3,7 +3,7 @@ import textwrap
 from langfuse.decorators import observe
 from sentry_sdk.ai.monitoring import ai_track
 
-from seer.automation.agent.client import LlmClient, OpenAiProvider
+from seer.automation.agent.client import GeminiProvider, LlmClient
 from seer.automation.autofix.autofix_context import AutofixContext
 from seer.automation.component import BaseComponent, BaseComponentOutput, BaseComponentRequest
 from seer.automation.models import EventDetails
@@ -52,7 +52,7 @@ class IsRootCauseObviousComponent(
             prompt=IsRootCauseObviousPrompts.format_default_msg(
                 event_details=request.event_details,
             ),
-            model=OpenAiProvider.model("gpt-4o-mini"),
+            model=GeminiProvider.model("gemini-2.0-flash-001"),
             response_format=IsRootCauseObviousOutput,
         )
         data = output.parsed

--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -4,7 +4,7 @@ from langfuse.decorators import observe
 from sentry_sdk.ai.monitoring import ai_track
 
 from seer.automation.agent.agent import AgentConfig, RunConfig
-from seer.automation.agent.client import AnthropicProvider, LlmClient, OpenAiProvider
+from seer.automation.agent.client import AnthropicProvider, GeminiProvider, LlmClient
 from seer.automation.autofix.autofix_agent import AutofixAgent
 from seer.automation.autofix.autofix_context import AutofixContext
 from seer.automation.autofix.components.is_root_cause_obvious import (
@@ -100,7 +100,7 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
                 formatted_response = llm_client.generate_structured(
                     messages=agent.memory,
                     prompt=RootCauseAnalysisPrompts.root_cause_formatter_msg(),
-                    model=OpenAiProvider.model("gpt-4o-mini"),
+                    model=GeminiProvider.model("gemini-2.0-flash-001"),
                     response_format=MultipleRootCauseAnalysisOutputPrompt,
                     run_name="Root Cause Extraction & Formatting",
                     max_tokens=4096,

--- a/src/seer/automation/autofix/components/root_cause/models.py
+++ b/src/seer/automation/autofix/components/root_cause/models.py
@@ -19,7 +19,7 @@ class TimelineEvent(BaseModel):
     timeline_item_type: (
         Literal["internal_code", "external_system", "human_action"] | str
     )  # TODO put back to literal only when not breaking anything
-    relevant_code_file: RelevantCodeFile | None
+    relevant_code_file: RelevantCodeFile
     is_most_important_event: bool
 
 
@@ -42,7 +42,7 @@ class RootCauseAnalysisItem(BaseModel):
 
 
 class RootCauseAnalysisItemPrompt(BaseModel):
-    root_cause_reproduction: list[TimelineEvent] | None = None
+    root_cause_reproduction: list[TimelineEvent]
 
     @classmethod
     def from_model(cls, model: RootCauseAnalysisItem):

--- a/src/seer/automation/autofix/components/solution/component.py
+++ b/src/seer/automation/autofix/components/solution/component.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from sentry_sdk.ai.monitoring import ai_track
 
 from seer.automation.agent.agent import AgentConfig, RunConfig
-from seer.automation.agent.client import AnthropicProvider, LlmClient, OpenAiProvider
+from seer.automation.agent.client import AnthropicProvider, GeminiProvider, LlmClient
 from seer.automation.agent.models import Message, ToolCall
 from seer.automation.autofix.autofix_agent import AutofixAgent
 from seer.automation.autofix.autofix_context import AutofixContext
@@ -102,7 +102,7 @@ class SolutionComponent(BaseComponent[SolutionRequest, SolutionOutput]):
                     root_cause=request.root_cause_and_fix,
                     original_instruction=request.original_instruction,
                 ),
-                model=OpenAiProvider.model("gpt-4o-mini"),
+                model=GeminiProvider.model("gemini-2.0-flash-001"),
                 response_format=IsObviousOutput,
             )
 
@@ -172,7 +172,7 @@ class SolutionComponent(BaseComponent[SolutionRequest, SolutionOutput]):
             formatted_response = llm_client.generate_structured(
                 messages=agent.memory,
                 prompt=SolutionPrompts.solution_formatter_msg(request.root_cause_and_fix),
-                model=OpenAiProvider.model("gpt-4o-mini"),
+                model=GeminiProvider.model("gemini-2.0-flash-001"),
                 response_format=SolutionOutput,
                 run_name="Solution Extraction & Formatting",
                 max_tokens=4096,

--- a/src/seer/automation/autofix/components/solution/models.py
+++ b/src/seer/automation/autofix/components/solution/models.py
@@ -20,7 +20,7 @@ class SolutionTimelineEvent(BaseModel):
     timeline_item_type: (
         Literal["internal_code", "external_system", "human_action"] | str
     )  # TODO put back to literal only when not breaking anything
-    relevant_code_file: RelevantCodeFile | None
+    relevant_code_file: RelevantCodeFile
     is_new_event: bool
 
 

--- a/tests/automation/autofix/test_autofix_tasks.py
+++ b/tests/automation/autofix/test_autofix_tasks.py
@@ -219,9 +219,7 @@ def test_autofix_run_full(autofix_request: AutofixRequest):
         run_autofix_coding(
             AutofixUpdateRequest(
                 run_id=run_id,
-                payload=AutofixSolutionUpdatePayload(
-                    custom_solution="we should uncomment out the unit test parts"
-                ),
+                payload=AutofixSolutionUpdatePayload(custom_solution="fix it however you see fit"),
             )
         )
 


### PR DESCRIPTION
Replaces all uses of 4o mini in Autofix with Flash 2.0. This means short circuiters and formatters. Cut 45 seconds off run time, improved root cause eval from 80 to 84%, but dropped fix eval from 39% to 35%.