### PR TITLE
devenv: Allow multiple seers to run at the same time

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,8 @@ CODECOV_SUPER_TOKEN=...
 
 RPC_SHARED_SECRET="seers-also-very-long-value-haha" # Match with SEER_RPC_SHARED_SECRET=[""] in sentry.conf.py
 SBX_PROJECT=eng-dev-sbx--XXX # If using push-image and https://github.com/getsentry/terraform-sandboxes.private
+
+RABBITMQ_PORT=5672
+RABBITMQ_CONFIG_PORT=15672
+DB_PORT=5433
+APP_PORT=9091

--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ docker compose down --volumes
 make update && make dev
 ```
 
+## Running Multiple Instances of Seer
+
+To run multiple instances of Seer, you should set unique port values for each instance in the `.env` file.
+
+```
+RABBITMQ_PORT=...
+RABBITMQ_CONFIG_PORT=...
+DB_PORT=...
+APP_PORT=...
+```
+
 ## Langfuse Integration
 
 To enable Langfuse tracing, set these environment variables:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
 services:
     rabbitmq:
         image: rabbitmq:3.8-alpine
-        container_name: "rabbitmq_lightweight"
         ports:
-            - "5672:5672"
-            - "15672:15672"
+            - "${RABBITMQ_PORT:-5672}:5672"
+            - "${RABBITMQ_CONFIG_PORT:-15672}:15672"
     db:
         image: pgvector/pgvector:pg14
         restart: always
@@ -15,7 +14,7 @@ services:
         volumes:
             - pgdata:/var/lib/postgresql/data
         ports:
-            - "5433:5432"
+            - "${DB_PORT:-5433}:5432"
     test-db:
         image: pgvector/pgvector:pg14
         restart: always
@@ -65,7 +64,7 @@ services:
             - USE_EU_REGION=0
             - IGNORE_API_AUTH=1
         ports:
-            - "9091:9091" # Local dev sentry app looks for port 9091 for the seer service.
+            - "${APP_PORT:-9091}:9091" # Local dev sentry app looks for port 9091 for the seer service.
 volumes:
     pgdata:
     pgdata_test:


### PR DESCRIPTION
If you set unique ports for each version of seer, docker compose should just work.