### PR TITLE
build(ci): Parallelize tests and optimize image building

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,7 +113,7 @@ jobs:
           fi
 
       - name: Restore test durations cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .pytest_cache
           key: ${{ runner.os }}-pytest-split-cache-${{ hashFiles('requirements*.txt') }}
@@ -127,7 +127,7 @@ jobs:
             pytest --splits 8 --group ${{ matrix.group }} --cov . --cov-report=\"xml:.artifacts/coverage.xml\" -vv"
 
       - name: Save updated test durations cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .pytest_cache
           key: ${{ runner.os }}-pytest-split-cache-${{ hashFiles('requirements*.txt') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,6 +112,9 @@ jobs:
           id_token_include_email: true
           create_credentials_file: true
 
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
       - name: Pull pre-built Docker image
         run: |
           docker pull ghcr.io/getsentry/seer:${IMAGE_TAG}
@@ -131,9 +134,6 @@ jobs:
           pip install -r scripts/requirements.txt
           make vcr-decrypt
 
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
-
       - name: Fetch models
         if: github.event_name == 'push'
         run: |
@@ -142,7 +142,11 @@ jobs:
 
       - name: Set test environment flags
         run: |
-          echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_REAL_MODELS=1 -e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
+          else
+            echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
+          fi
 
       # - name: Restore test durations cache
       #   uses: actions/cache@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
+      packages: "write"
     steps:
       - uses: actions/checkout@v4
 
@@ -61,7 +62,6 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
-      packages: "write"
     env:
       TEST: 1
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,7 @@ jobs:
         run: docker compose run app mypy
 
   test:
+    name: Parallelized Tests
     needs: [build_and_push]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1, 2, 3, 4, 5]
+        group: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - uses: actions/checkout@v4
 
@@ -89,6 +89,7 @@ jobs:
       - name: Pull pre-built Docker image
         run: |
           docker pull ghcr.io/getsentry/seer:cache-${{ github.sha }}
+          cp docker-compose.ci.yml docker-compose.override.yml
       - name: Create blank .env
         run: |
           make .env
@@ -114,7 +115,8 @@ jobs:
       - name: Test with pytest
         run: |
           docker compose up -d test-db
-          docker compose run ${{ env.EXTRA_COMPOSE_TEST_OPTIONS }} app bash -c "pip install pytest-split && pytest --splits 5 --group ${{ matrix.group }} --cov . --cov-report=\"xml:.artifacts/coverage.xml\" -vv"
+          docker compose run ${{ env.EXTRA_COMPOSE_TEST_OPTIONS }} app bash -c "pip install pytest-split && pytest --splits 8 --group ${{ matrix.group }} --cov . --cov-report=\"xml:.artifacts/coverage.xml\" -vv"
+
       - name: Upload to codecov
         if: ${{ always() }}
         uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - id: "auth"
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: "projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool"
+          service_account: "gha-seer-models@sac-prod-sa.iam.gserviceaccount.com"
+          token_format: "id_token"
+          id_token_audience: "610575311308-9bsjtgqg4jm01mt058rncpopujgk3627.apps.googleusercontent.com"
+          id_token_include_email: true
+          create_credentials_file: true
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Fetch models
+        # if: github.event_name == 'push'
+        run: |
+          rm -rf ./models
+          gcloud storage cp -r gs://sentry-ml/seer/models ./
+
       - name: Build and push Docker image
         run: |
           make .env
@@ -102,9 +121,6 @@ jobs:
           id_token_include_email: true
           create_credentials_file: true
 
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
-
       - name: Pull pre-built Docker image
         run: |
           docker pull ghcr.io/getsentry/seer:${IMAGE_TAG}
@@ -135,9 +151,9 @@ jobs:
       - name: Restore test durations cache
         uses: actions/cache@v4
         with:
-          path: .pytest_cache
-          key: ${{ runner.os }}-pytest-split-cache-${{ hashFiles('requirements*.txt') }}
-          restore-keys: ${{ runner.os }}-pytest-split-cache-
+          path: test-durations.json
+          key: ${{ runner.os }}-test-durations-cache-${{ hashFiles('requirements*.txt') }}
+          restore-keys: ${{ runner.os }}-test-durations-cache-
 
       - name: Test with pytest
         run: |
@@ -145,13 +161,6 @@ jobs:
           docker compose run ${{ env.EXTRA_COMPOSE_TEST_OPTIONS }} app bash -c "\
             pip install pytest-split && \
             pytest --splits 8 --group ${{ matrix.group }} --cov . --cov-report=\"xml:.artifacts/coverage.xml\" -vv"
-
-      - name: Save updated test durations cache
-        uses: actions/cache@v4
-        with:
-          path: .pytest_cache
-          key: ${{ runner.os }}-pytest-split-cache-${{ hashFiles('requirements*.txt') }}
-          restore-keys: ${{ runner.os }}-pytest-split-cache-
 
       - name: Upload to codecov
         if: ${{ always() }}
@@ -162,3 +171,79 @@ jobs:
           override_commit: ${{ github.event.pull_request.head.sha }}
           plugin: noop
           verbose: true
+
+  test_durations:
+    needs: [build_and_push]
+    runs-on: ubuntu-latest
+    # if: github.event_name == 'push'
+    permissions:
+      contents: "read"
+      id-token: "write"
+      packages: "read"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: "auth"
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: "projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool"
+          service_account: "gha-seer-models@sac-prod-sa.iam.gserviceaccount.com"
+          token_format: "id_token"
+          id_token_audience: "610575311308-9bsjtgqg4jm01mt058rncpopujgk3627.apps.googleusercontent.com"
+          id_token_include_email: true
+          create_credentials_file: true
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Pull pre-built Docker image
+        run: |
+          docker pull ghcr.io/getsentry/seer:${IMAGE_TAG}
+          cp docker-compose.ci.yml docker-compose.override.yml
+
+      - name: Create blank .env
+        run: make .env
+
+      - name: Migrate database
+        run: docker compose run app flask db upgrade
+
+      - name: Decrypt VCR cassettes
+        run: |
+          pip install -r scripts/requirements.txt
+          make vcr-decrypt
+
+      - name: Set test environment flags
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_REAL_MODELS=1 -e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
+          else
+            echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
+          fi
+
+      - name: Restore test durations cache
+        uses: actions/cache@v4
+        with:
+          path: test-durations.json
+          key: ${{ runner.os }}-test-durations-cache-${{ hashFiles('requirements*.txt') }}
+          restore-keys: ${{ runner.os }}-test-durations-cache-
+
+      - name: Test with pytest
+        run: |
+          docker compose up -d test-db
+          docker compose run ${{ env.EXTRA_COMPOSE_TEST_OPTIONS }} app bash -c "\
+            pip install pytest-split && \
+            pytest --store-durations --durations-path=test-durations.json -vv"
+
+      - name: Save updated test durations cache
+        uses: actions/cache@v4
+        with:
+          path: test-durations.json
+          key: ${{ runner.os }}-test-durations-cache-${{ hashFiles('requirements*.txt') }}
+          restore-keys: ${{ runner.os }}-test-durations-cache-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -180,6 +180,9 @@ jobs:
       contents: "read"
       id-token: "write"
       packages: "read"
+    env:
+      TEST: 1
+      IMAGE_TAG: cache-${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,12 +55,10 @@ jobs:
           cp docker-compose.ci.yml docker-compose.override.yml
 
       - name: Create blank .env
-        run: |
-          make .env
+        run: make .env
 
       - name: Typecheck with mypy
-        run: |
-          docker compose run app mypy
+        run: docker compose run app mypy
 
   test:
     needs: [build_and_push]
@@ -87,21 +85,24 @@ jobs:
           id_token_audience: "610575311308-9bsjtgqg4jm01mt058rncpopujgk3627.apps.googleusercontent.com"
           id_token_include_email: true
           create_credentials_file: true
+
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
+
       - name: Pull pre-built Docker image
         run: |
           docker pull ghcr.io/getsentry/seer:${IMAGE_TAG}
           cp docker-compose.ci.yml docker-compose.override.yml
+
       - name: Create blank .env
-        run: |
-          make .env
+        run: make .env
+
       - name: Migrate database
-        run: |
-          docker compose run app flask db upgrade
+        run: docker compose run app flask db upgrade
+
       - name: Validate no pending migrations
-        run: |
-          make check-no-pending-migrations
+        run: make check-no-pending-migrations
+
       - name: Decrypt VCR cassettes
         run: |
           pip install -r scripts/requirements.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,10 +112,26 @@ jobs:
             echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
           fi
 
+      - name: Restore test durations cache
+        uses: actions/cache@v3
+        with:
+          path: .pytest_cache
+          key: ${{ runner.os }}-pytest-split-cache-${{ hashFiles('requirements*.txt') }}
+          restore-keys: ${{ runner.os }}-pytest-split-cache-
+
       - name: Test with pytest
         run: |
           docker compose up -d test-db
-          docker compose run ${{ env.EXTRA_COMPOSE_TEST_OPTIONS }} app bash -c "pip install pytest-split && pytest --splits 8 --group ${{ matrix.group }} --cov . --cov-report=\"xml:.artifacts/coverage.xml\" -vv"
+          docker compose run ${{ env.EXTRA_COMPOSE_TEST_OPTIONS }} app bash -c "\
+            pip install pytest-split && \
+            pytest --splits 8 --group ${{ matrix.group }} --cov . --cov-report=\"xml:.artifacts/coverage.xml\" -vv"
+
+      - name: Save updated test durations cache
+        uses: actions/cache@v3
+        with:
+          path: .pytest_cache
+          key: ${{ runner.os }}-pytest-split-cache-${{ hashFiles('requirements*.txt') }}
+          restore-keys: ${{ runner.os }}-pytest-split-cache-
 
       - name: Upload to codecov
         if: ${{ always() }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,10 @@ jobs:
       packages: "write"
     env:
       TEST: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v4
       - id: "auth"
@@ -91,10 +95,12 @@ jobs:
           make vcr-decrypt
       - name: Test with pytest
         run: |
-          make test
+          docker compose run app pip install pytest-split
+          docker compose up -d test-db
+          docker compose run $(EXTRA_COMPOSE_TEST_OPTIONS) app pytest --cov . --cov-report="xml:.artifacts/coverage.xml" -vv  --splits 5 --group ${{ matrix.group }}
       - name: Upload to codecov
         if: ${{ always() }}
-        uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
+        uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ".artifacts/coverage.xml"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,7 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
+      packages: "read"
     env:
       IMAGE_TAG: cache-${{ github.sha }}
     steps:
@@ -66,6 +67,7 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
+      packages: "read"
     env:
       TEST: 1
       IMAGE_TAG: cache-${{ github.sha }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,15 +39,6 @@ jobs:
           id_token_include_email: true
           create_credentials_file: true
 
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
-
-      - name: Fetch models
-        # if: github.event_name == 'push'
-        run: |
-          rm -rf ./models
-          gcloud storage cp -r gs://sentry-ml/seer/models ./
-
       - name: Build and push Docker image
         run: |
           make .env
@@ -140,20 +131,25 @@ jobs:
           pip install -r scripts/requirements.txt
           make vcr-decrypt
 
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+
+      - name: Fetch models
+        if: github.event_name == 'push'
+        run: |
+          rm -rf ./models
+          gcloud storage cp -r gs://sentry-ml/seer/models ./
+
       - name: Set test environment flags
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_REAL_MODELS=1 -e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
-          else
-            echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
-          fi
+          echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
 
-      - name: Restore test durations cache
-        uses: actions/cache@v4
-        with:
-          path: test-durations.json
-          key: ${{ runner.os }}-test-durations-cache-${{ hashFiles('requirements*.txt') }}
-          restore-keys: ${{ runner.os }}-test-durations-cache-
+      # - name: Restore test durations cache
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: test-durations.json
+      #     key: ${{ runner.os }}-test-durations-cache-${{ hashFiles('test-durations.json') }}
+      #     restore-keys: ${{ runner.os }}-test-durations-cache-
 
       - name: Test with pytest
         run: |
@@ -172,81 +168,81 @@ jobs:
           plugin: noop
           verbose: true
 
-  test_durations:
-    needs: [build_and_push]
-    runs-on: ubuntu-latest
-    # if: github.event_name == 'push'
-    permissions:
-      contents: "read"
-      id-token: "write"
-      packages: "read"
-    env:
-      TEST: 1
-      IMAGE_TAG: cache-${{ github.sha }}
-    steps:
-      - uses: actions/checkout@v4
+  # test_durations:
+  #   needs: [build_and_push]
+  #   runs-on: ubuntu-latest
+  #   # if: github.event_name == 'push'
+  #   permissions:
+  #     contents: "read"
+  #     id-token: "write"
+  #     packages: "read"
+  #   env:
+  #     TEST: 1
+  #     IMAGE_TAG: cache-${{ github.sha }}
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Login to GitHub Container Registry
+  #       uses: docker/login-action@v3
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: "auth"
-        uses: google-github-actions/auth@v1
-        with:
-          workload_identity_provider: "projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool"
-          service_account: "gha-seer-models@sac-prod-sa.iam.gserviceaccount.com"
-          token_format: "id_token"
-          id_token_audience: "610575311308-9bsjtgqg4jm01mt058rncpopujgk3627.apps.googleusercontent.com"
-          id_token_include_email: true
-          create_credentials_file: true
+  #     - id: "auth"
+  #       uses: google-github-actions/auth@v1
+  #       with:
+  #         workload_identity_provider: "projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool"
+  #         service_account: "gha-seer-models@sac-prod-sa.iam.gserviceaccount.com"
+  #         token_format: "id_token"
+  #         id_token_audience: "610575311308-9bsjtgqg4jm01mt058rncpopujgk3627.apps.googleusercontent.com"
+  #         id_token_include_email: true
+  #         create_credentials_file: true
 
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
+  #     - name: Set up Cloud SDK
+  #       uses: google-github-actions/setup-gcloud@v1
 
-      - name: Pull pre-built Docker image
-        run: |
-          docker pull ghcr.io/getsentry/seer:${IMAGE_TAG}
-          cp docker-compose.ci.yml docker-compose.override.yml
+  #     - name: Pull pre-built Docker image
+  #       run: |
+  #         docker pull ghcr.io/getsentry/seer:${IMAGE_TAG}
+  #         cp docker-compose.ci.yml docker-compose.override.yml
 
-      - name: Create blank .env
-        run: make .env
+  #     - name: Create blank .env
+  #       run: make .env
 
-      - name: Migrate database
-        run: docker compose run app flask db upgrade
+  #     - name: Migrate database
+  #       run: docker compose run app flask db upgrade
 
-      - name: Decrypt VCR cassettes
-        run: |
-          pip install -r scripts/requirements.txt
-          make vcr-decrypt
+  #     - name: Decrypt VCR cassettes
+  #       run: |
+  #         pip install -r scripts/requirements.txt
+  #         make vcr-decrypt
 
-      - name: Set test environment flags
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_REAL_MODELS=1 -e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
-          else
-            echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
-          fi
+  #     - name: Set test environment flags
+  #       run: |
+  #         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+  #           echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_REAL_MODELS=1 -e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
+  #         else
+  #           echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
+  #         fi
 
-      - name: Restore test durations cache
-        uses: actions/cache@v4
-        with:
-          path: test-durations.json
-          key: ${{ runner.os }}-test-durations-cache-${{ hashFiles('requirements*.txt') }}
-          restore-keys: ${{ runner.os }}-test-durations-cache-
+  #     - name: Restore test durations cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: test-durations.json
+  #         key: ${{ runner.os }}-test-durations-cache-${{ hashFiles('test-durations.json') }}
+  #         restore-keys: ${{ runner.os }}-test-durations-cache-
 
-      - name: Test with pytest
-        run: |
-          docker compose up -d test-db
-          docker compose run ${{ env.EXTRA_COMPOSE_TEST_OPTIONS }} app bash -c "\
-            pip install pytest-split && \
-            pytest --store-durations --durations-path=test-durations.json -vv"
+  #     - name: Test with pytest
+  #       run: |
+  #         docker compose up -d test-db
+  #         docker compose run ${{ env.EXTRA_COMPOSE_TEST_OPTIONS }} app bash -c "\
+  #           pip install pytest-split && \
+  #           pytest --store-durations --durations-path=/app/test-durations.json -vv"
 
-      - name: Save updated test durations cache
-        uses: actions/cache@v4
-        with:
-          path: test-durations.json
-          key: ${{ runner.os }}-test-durations-cache-${{ hashFiles('requirements*.txt') }}
-          restore-keys: ${{ runner.os }}-test-durations-cache-
+  #     - name: Save updated test durations cache
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: test-durations.json
+  #         key: ${{ runner.os }}-test-durations-cache-${{ hashFiles('test-durations.json') }}
+  #         restore-keys: ${{ runner.os }}-test-durations-cache-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           docker compose run app pip install pytest-split
           docker compose up -d test-db
-          docker compose run $(EXTRA_COMPOSE_TEST_OPTIONS) app pytest --cov . --cov-report="xml:.artifacts/coverage.xml" -vv  --splits 5 --group ${{ matrix.group }}
+          docker compose run $EXTRA_COMPOSE_TEST_OPTIONS app pytest --cov . --cov-report="xml:.artifacts/coverage.xml" -vv  --splits 5 --group ${{ matrix.group }}
       - name: Upload to codecov
         if: ${{ always() }}
         uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,9 +32,9 @@ jobs:
         run: |
           make .env
           docker buildx bake --file docker-compose.yml --file docker-compose-cache.json \
-            --cache-to type=registry,ref=ghcr.io/getsentry/seer:cache,mode=max \
-            --cache-from type=registry,ref=ghcr.io/getsentry/seer:cache \
-            --load \
+            --set *.cache-to=type=registry,ref=ghcr.io/getsentry/seer:cache,mode=max \
+            --set *.cache-from=type=registry,ref=ghcr.io/getsentry/seer:cache \
+            --set *.load=true \
             --set *.tags=ghcr.io/getsentry/seer:cache:${{ github.sha }}
           docker push ghcr.io/getsentry/seer:cache:${{ github.sha }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,10 +104,8 @@ jobs:
           make vcr-decrypt
       - name: Test with pytest
         run: |
-          docker compose run app pip install pytest-split
           docker compose up -d test-db
-          docker compose run app pytest --cov . --cov-report="xml:.artifacts/coverage.xml" -vv \
-            --splits 5 --group ${{ matrix.group }}
+          docker compose run app pip install pytest-split && pytest --splits 5 --group ${{ matrix.group }} --cov . --cov-report="xml:.artifacts/coverage.xml" -vv \
       - name: Upload to codecov
         if: ${{ always() }}
         uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,30 +10,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  typecheck:
+  build_and_push:
     runs-on: ubuntu-latest
     permissions:
       contents: "read"
       id-token: "write"
     steps:
       - uses: actions/checkout@v4
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Build image
+
+      - name: Build and push Docker image
         run: |
           make .env
-          docker buildx bake --file docker-compose.yml --file docker-compose-cache.json --load
+          docker buildx bake --file docker-compose.yml --file docker-compose-cache.json --load \
+            -t ghcr.io/your_org/your_repo:${{ github.sha }} \
+            -t ghcr.io/your_org/your_repo:latest
+          docker push ghcr.io/your_org/your_repo:${{ github.sha }}
+          docker push ghcr.io/your_org/your_repo:latest
+
+  typecheck:
+    needs: [build_and_push]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      id-token: "write"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pull pre-built Docker image
+        run: |
+          docker pull ghcr.io/your_org/your_repo:${{ github.sha }}
+
       - name: Typecheck with mypy
         run: |
           make mypy
 
   test:
+    needs: [build_and_push]
     runs-on: ubuntu-latest
     permissions:
       contents: "read"
@@ -47,6 +69,7 @@ jobs:
         group: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v4
+
       - id: "auth"
         uses: google-github-actions/auth@v1
         with:
@@ -58,30 +81,9 @@ jobs:
           create_credentials_file: true
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Fetch models
-        if: github.event_name == 'push'
+      - name: Pull pre-built Docker image
         run: |
-          rm -rf ./models
-          gcloud storage cp -r gs://sentry-ml/seer/models ./
-      - name: Build image
-        run: |
-          make .env
-          docker buildx bake --file docker-compose.yml --file docker-compose-cache.json --load
-      - name: Set EXTRA_COMPOSE_TEST_OPTIONS
-        run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_REAL_MODELS=1 -e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
-          else
-            echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
-          fi
+          docker pull ghcr.io/your_org/your_repo:${{ github.sha }}
       - name: Migrate database
         run: |
           docker compose run app flask db history
@@ -97,7 +99,8 @@ jobs:
         run: |
           docker compose run app pip install pytest-split
           docker compose up -d test-db
-          docker compose run $EXTRA_COMPOSE_TEST_OPTIONS app pytest --cov . --cov-report="xml:.artifacts/coverage.xml" -vv  --splits 5 --group ${{ matrix.group }}
+          docker compose run app pytest --cov . --cov-report="xml:.artifacts/coverage.xml" -vv \
+            --splits 5 --group ${{ matrix.group }}
       - name: Upload to codecov
         if: ${{ always() }}
         uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,10 @@ jobs:
         run: |
           docker pull ghcr.io/getsentry/seer:cache-${{ github.sha }}
 
+      - name: Create blank .env
+        run: |
+          make .env
+
       - name: Typecheck with mypy
         run: |
           make mypy
@@ -85,6 +89,9 @@ jobs:
       - name: Pull pre-built Docker image
         run: |
           docker pull ghcr.io/getsentry/seer:cache-${{ github.sha }}
+      - name: Create blank .env
+        run: |
+          make .env
       - name: Migrate database
         run: |
           docker compose run app flask db history

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,14 +136,18 @@ jobs:
           make vcr-decrypt
 
       - name: Fetch models
-        # if: github.event_name == 'push'
+        if: github.event_name == 'push'
         run: |
           rm -rf ./models
           gcloud storage cp -r gs://sentry-ml/seer/models ./
 
       - name: Set test environment flags
         run: |
-          echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_REAL_MODELS=1 -e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
+          else
+            echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
+          fi
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Pull pre-built Docker image
         run: |
           docker pull ghcr.io/getsentry/seer:${IMAGE_TAG}
@@ -77,6 +84,13 @@ jobs:
         group: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: "auth"
         uses: google-github-actions/auth@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,8 +35,8 @@ jobs:
             --set *.cache-to=type=registry,ref=ghcr.io/getsentry/seer:cache,mode=max \
             --set *.cache-from=type=registry,ref=ghcr.io/getsentry/seer:cache \
             --set *.load=true \
-            --set *.tags=ghcr.io/getsentry/seer:cache:${{ github.sha }}
-          docker push ghcr.io/getsentry/seer:cache:${{ github.sha }}
+            --set *.tags=ghcr.io/getsentry/seer:cache-${{ github.sha }}
+          docker push ghcr.io/getsentry/seer:cache-${{ github.sha }}
 
   typecheck:
     needs: [build_and_push]
@@ -49,7 +49,7 @@ jobs:
 
       - name: Pull pre-built Docker image
         run: |
-          docker pull ghcr.io/getsentry/seer:cache:${{ github.sha }}
+          docker pull ghcr.io/getsentry/seer:cache-${{ github.sha }}
 
       - name: Typecheck with mypy
         run: |
@@ -84,7 +84,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1
       - name: Pull pre-built Docker image
         run: |
-          docker pull ghcr.io/getsentry/seer:cache:${{ github.sha }}
+          docker pull ghcr.io/getsentry/seer:cache-${{ github.sha }}
       - name: Migrate database
         run: |
           docker compose run app flask db history

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -149,13 +149,6 @@ jobs:
             echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
           fi
 
-      # - name: Restore test durations cache
-      #   uses: actions/cache@v4
-      #   with:
-      #     path: test-durations.json
-      #     key: ${{ runner.os }}-test-durations-cache-${{ hashFiles('test-durations.json') }}
-      #     restore-keys: ${{ runner.os }}-test-durations-cache-
-
       - name: Test with pytest
         run: |
           docker compose up -d test-db
@@ -172,82 +165,3 @@ jobs:
           override_commit: ${{ github.event.pull_request.head.sha }}
           plugin: noop
           verbose: true
-
-  # test_durations:
-  #   needs: [build_and_push]
-  #   runs-on: ubuntu-latest
-  #   # if: github.event_name == 'push'
-  #   permissions:
-  #     contents: "read"
-  #     id-token: "write"
-  #     packages: "read"
-  #   env:
-  #     TEST: 1
-  #     IMAGE_TAG: cache-${{ github.sha }}
-  #   steps:
-  #     - uses: actions/checkout@v4
-
-  #     - name: Login to GitHub Container Registry
-  #       uses: docker/login-action@v3
-  #       with:
-  #         registry: ghcr.io
-  #         username: ${{ github.actor }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
-
-  #     - id: "auth"
-  #       uses: google-github-actions/auth@v1
-  #       with:
-  #         workload_identity_provider: "projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool"
-  #         service_account: "gha-seer-models@sac-prod-sa.iam.gserviceaccount.com"
-  #         token_format: "id_token"
-  #         id_token_audience: "610575311308-9bsjtgqg4jm01mt058rncpopujgk3627.apps.googleusercontent.com"
-  #         id_token_include_email: true
-  #         create_credentials_file: true
-
-  #     - name: Set up Cloud SDK
-  #       uses: google-github-actions/setup-gcloud@v1
-
-  #     - name: Pull pre-built Docker image
-  #       run: |
-  #         docker pull ghcr.io/getsentry/seer:${IMAGE_TAG}
-  #         cp docker-compose.ci.yml docker-compose.override.yml
-
-  #     - name: Create blank .env
-  #       run: make .env
-
-  #     - name: Migrate database
-  #       run: docker compose run app flask db upgrade
-
-  #     - name: Decrypt VCR cassettes
-  #       run: |
-  #         pip install -r scripts/requirements.txt
-  #         make vcr-decrypt
-
-  #     - name: Set test environment flags
-  #       run: |
-  #         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-  #           echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_REAL_MODELS=1 -e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
-  #         else
-  #           echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
-  #         fi
-
-  #     - name: Restore test durations cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: test-durations.json
-  #         key: ${{ runner.os }}-test-durations-cache-${{ hashFiles('test-durations.json') }}
-  #         restore-keys: ${{ runner.os }}-test-durations-cache-
-
-  #     - name: Test with pytest
-  #       run: |
-  #         docker compose up -d test-db
-  #         docker compose run ${{ env.EXTRA_COMPOSE_TEST_OPTIONS }} app bash -c "\
-  #           pip install pytest-split && \
-  #           pytest --store-durations --durations-path=/app/test-durations.json -vv"
-
-  #     - name: Save updated test durations cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: test-durations.json
-  #         key: ${{ runner.os }}-test-durations-cache-${{ hashFiles('test-durations.json') }}
-  #         restore-keys: ${{ runner.os }}-test-durations-cache-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Pull pre-built Docker image
         run: |
           docker pull ghcr.io/getsentry/seer:cache-${{ github.sha }}
+          cp docker-compose.ci.yml docker-compose.override.yml
 
       - name: Create blank .env
         run: |
@@ -58,7 +59,7 @@ jobs:
 
       - name: Typecheck with mypy
         run: |
-          make mypy
+          IMAGE_TAG=cache-${{ github.sha }} docker compose run app mypy
 
   test:
     needs: [build_and_push]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,11 +31,12 @@ jobs:
       - name: Build and push Docker image
         run: |
           make .env
-          docker buildx bake --file docker-compose.yml --file docker-compose-cache.json --load \
-            -t ghcr.io/your_org/your_repo:${{ github.sha }} \
-            -t ghcr.io/your_org/your_repo:latest
-          docker push ghcr.io/your_org/your_repo:${{ github.sha }}
-          docker push ghcr.io/your_org/your_repo:latest
+          docker buildx bake --file docker-compose.yml --file docker-compose-cache.json \
+            --cache-to type=registry,ref=ghcr.io/getsentry/seer:cache,mode=max \
+            --cache-from type=registry,ref=ghcr.io/getsentry/seer:cache \
+            --load \
+            --set *.tags=ghcr.io/getsentry/seer:cache:${{ github.sha }}
+          docker push ghcr.io/getsentry/seer:cache:${{ github.sha }}
 
   typecheck:
     needs: [build_and_push]
@@ -48,7 +49,7 @@ jobs:
 
       - name: Pull pre-built Docker image
         run: |
-          docker pull ghcr.io/your_org/your_repo:${{ github.sha }}
+          docker pull ghcr.io/getsentry/seer:cache:${{ github.sha }}
 
       - name: Typecheck with mypy
         run: |
@@ -83,7 +84,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1
       - name: Pull pre-built Docker image
         run: |
-          docker pull ghcr.io/your_org/your_repo:${{ github.sha }}
+          docker pull ghcr.io/getsentry/seer:cache:${{ github.sha }}
       - name: Migrate database
         run: |
           docker compose run app flask db history

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,6 @@ jobs:
           make .env
       - name: Migrate database
         run: |
-          docker compose run app flask db history
           docker compose run app flask db upgrade
       - name: Validate no pending migrations
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,10 +102,21 @@ jobs:
         run: |
           pip install -r scripts/requirements.txt
           make vcr-decrypt
+
+      - name: Set test environment flags
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_REAL_MODELS=1 -e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
+          else
+            echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
+          fi
+
       - name: Test with pytest
         run: |
           docker compose up -d test-db
-          docker compose run app pip install pytest-split && pytest --splits 5 --group ${{ matrix.group }} --cov . --cov-report="xml:.artifacts/coverage.xml" -vv \
+          docker compose run ${{ env.EXTRA_COMPOSE_TEST_OPTIONS }} app \
+            pip install pytest-split && \
+            pytest --splits 5 --group ${{ matrix.group }} --cov . --cov-report="xml:.artifacts/coverage.xml" -vv
       - name: Upload to codecov
         if: ${{ always() }}
         uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,12 +44,14 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
+    env:
+      IMAGE_TAG: cache-${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Pull pre-built Docker image
         run: |
-          docker pull ghcr.io/getsentry/seer:cache-${{ github.sha }}
+          docker pull ghcr.io/getsentry/seer:${IMAGE_TAG}
           cp docker-compose.ci.yml docker-compose.override.yml
 
       - name: Create blank .env
@@ -58,7 +60,7 @@ jobs:
 
       - name: Typecheck with mypy
         run: |
-          IMAGE_TAG=cache-${{ github.sha }} docker compose run app mypy
+          docker compose run app mypy
 
   test:
     needs: [build_and_push]
@@ -68,6 +70,7 @@ jobs:
       id-token: "write"
     env:
       TEST: 1
+      IMAGE_TAG: cache-${{ github.sha }}
     strategy:
       fail-fast: false
       matrix:
@@ -88,7 +91,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v1
       - name: Pull pre-built Docker image
         run: |
-          docker pull ghcr.io/getsentry/seer:cache-${{ github.sha }}
+          docker pull ghcr.io/getsentry/seer:${IMAGE_TAG}
           cp docker-compose.ci.yml docker-compose.override.yml
       - name: Create blank .env
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,9 +35,8 @@ jobs:
           docker buildx bake --file docker-compose.yml --file docker-compose-cache.json \
             --set *.cache-to=type=registry,ref=ghcr.io/getsentry/seer:cache,mode=max \
             --set *.cache-from=type=registry,ref=ghcr.io/getsentry/seer:cache \
-            --set *.load=true \
+            --set *.output=type=registry \
             --set *.tags=ghcr.io/getsentry/seer:cache-${{ github.sha }}
-          docker push ghcr.io/getsentry/seer:cache-${{ github.sha }}
 
   typecheck:
     needs: [build_and_push]
@@ -115,7 +114,7 @@ jobs:
       - name: Test with pytest
         run: |
           docker compose up -d test-db
-          docker compose run ${{ env.EXTRA_COMPOSE_TEST_OPTIONS }} app pip install pytest-split && pytest --splits 5 --group ${{ matrix.group }} --cov . --cov-report="xml:.artifacts/coverage.xml" -vv
+          docker compose run ${{ env.EXTRA_COMPOSE_TEST_OPTIONS }} app bash -c "pip install pytest-split && pytest --splits 5 --group ${{ matrix.group }} --cov . --cov-report=\"xml:.artifacts/coverage.xml\" -vv"
       - name: Upload to codecov
         if: ${{ always() }}
         uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -136,18 +136,14 @@ jobs:
           make vcr-decrypt
 
       - name: Fetch models
-        if: github.event_name == 'push'
+        # if: github.event_name == 'push'
         run: |
           rm -rf ./models
           gcloud storage cp -r gs://sentry-ml/seer/models ./
 
       - name: Set test environment flags
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_REAL_MODELS=1 -e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
-          else
-            echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
-          fi
+          echo "EXTRA_COMPOSE_TEST_OPTIONS=-e NO_SENTRY_INTEGRATION=1 -e CI=1" >> $GITHUB_ENV
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,9 +114,7 @@ jobs:
       - name: Test with pytest
         run: |
           docker compose up -d test-db
-          docker compose run ${{ env.EXTRA_COMPOSE_TEST_OPTIONS }} app \
-            pip install pytest-split && \
-            pytest --splits 5 --group ${{ matrix.group }} --cov . --cov-report="xml:.artifacts/coverage.xml" -vv
+          docker compose run ${{ env.EXTRA_COMPOSE_TEST_OPTIONS }} app pip install pytest-split && pytest --splits 5 --group ${{ matrix.group }} --cov . --cov-report="xml:.artifacts/coverage.xml" -vv
       - name: Upload to codecov
         if: ${{ always() }}
         uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,4 @@
+services:
+    app:
+        image: ghcr.io/getsentry/seer:${IMAGE_TAG}
+        build: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,6 @@ services:
             - ./models:/app/models
             - ./data/chroma:/app/data/chroma
             - ~/.config/gcloud:/root/.config/gcloud
-            - ./test-durations.json:/app/test-durations.json
             # Codecov test artifacts
             - ./.artifacts:/app/.artifacts
         healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
             - ./models:/app/models
             - ./data/chroma:/app/data/chroma
             - ~/.config/gcloud:/root/.config/gcloud
+            - ./test-durations.json:/app/test-durations.json
             # Codecov test artifacts
             - ./.artifacts:/app/.artifacts
         healthcheck:

--- a/gocd/templates/bash/check-github.sh
+++ b/gocd/templates/bash/check-github.sh
@@ -3,4 +3,4 @@
 /devinfra/scripts/checks/githubactions/checkruns.py \
   getsentry/seer \
   "${GO_REVISION_SEER_REPO}" \
-  build
+  test

--- a/gocd/templates/bash/check-github.sh
+++ b/gocd/templates/bash/check-github.sh
@@ -3,4 +3,4 @@
 /devinfra/scripts/checks/githubactions/checkruns.py \
   getsentry/seer \
   "${GO_REVISION_SEER_REPO}" \
-  test
+  "Parallelized Tests"


### PR DESCRIPTION
1. Parallelizes the tests using `pytest-split`
2. Uses a single build and push command for the docker image, then pulls it for every other job instead of calling Buildx every time
3. Points GoCD to look at the new parallelized tests check

**_Reduces total CI runtime from ~20 minutes to ~5 minutes._** This will also have the same effect on _deploy_ times!