### PR TITLE
fix(autofix) Retry Gemini 429

### DIFF
--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -763,8 +763,12 @@ class GeminiProvider:
 
     @staticmethod
     def is_completion_exception_retryable(exception: Exception) -> bool:
-        # https://sentry.sentry.io/issues/6301072208
-        retryable_errors = ("429 RESOURCE_EXHAUSTED",)
+        retryable_errors = (
+            "429 RESOURCE_EXHAUSTED",
+            # https://sentry.sentry.io/issues/6301072208
+            "TLS/SSL connection has been closed",
+            "Max retries exceeded with url",
+        )
         return isinstance(exception, ClientError) and any(
             error in str(exception) for error in retryable_errors
         )


### PR DESCRIPTION
Updates the 429 error for Gemini to the one based on the [Sentry issue](https://sentry.sentry.io/issues/6301072208).

My previous guess for the shape of this error was based on [this message in the docs](https://cloud.google.com/vertex-ai/generative-ai/docs/error-code-429), but that message has [never been encountered](https://console.cloud.google.com/logs/query;query=labels.%22k8s-pod%2Fenvironment%22%3D%22autofix%22%0A%2528%0A%20%20%20%20--%20%2528SEARCH%2528%22APIStatusError%22%2529%20AND%20severity%3D%22ERROR%22%2529%20%20--%20Anthropic%0A%20%20%20%20%2528SEARCH%2528%22ResourceExhausted%22%2529%20AND%20severity%3D%22ERROR%22%2529%20%20--%20Gemini%0A%20%20%20%20--%20%2528SEARCH%2528%22MaxTriesExceeded%22%2529%20AND%20severity%3D%22ERROR%22%2529%0A%20%20%20%20--%20OR%20%2528SEARCH%2528%22Retried%20call%20successful%22%2529%20AND%20severity%3D%22ERROR%22%2529%0A%20%20%20%20--%20OR%20%2528SEARCH%2528%22Encountered%22%2529%20AND%20severity%3D%22ERROR%22%2529%0A%2529%0A;cursorTimestamp=2025-02-14T21:30:33.064798273Z;duration=P30D?hl=en&project=internal-sentry&rapt=AEjHL4M4PWfNuRCdHBQfWwz5EOnuUfzv1Fz3flOA8YGyrbeKwVotlChejLqXi2jZjm-oOcT0fXVPx85nKqD9Kbpowd7BGfVZQckUGW0y-_REajA7Hbj6uWI).