### PR TITLE
fix(autofix): Add fallback for code application step

### DIFF
--- a/src/seer/automation/autofix/components/coding/component.py
+++ b/src/seer/automation/autofix/components/coding/component.py
@@ -151,11 +151,8 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
             Here is an example of a unified diff format:
             <example>
             --- a/path/to/file.py
-
             +++ b/path/to/file.py
-
             @@ -1,3 +1,3 @@
-
             x = 1
             y = 2
             -for i in range(10):

--- a/src/seer/automation/autofix/components/coding/component.py
+++ b/src/seer/automation/autofix/components/coding/component.py
@@ -173,12 +173,14 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
             Provide the exact unified diff that covers the changes and no other text.
             """
         ).format(original_content=original_content, new_content=new_content)
-        diff = llm_client.generate_text(
+        response = llm_client.generate_text(
             system_prompt=system_prompt,
             prompt=fallback_prompt,
             model=GeminiProvider.model("gemini-2.0-flash-001"),
         )
-        return diff.message.content + "\n"
+        if not response.message.content:
+            return None
+        return response.message.content + "\n"
 
     @observe(name="Is Obvious")
     @ai_track(description="Is Obvious")

--- a/src/seer/automation/autofix/components/coding/component.py
+++ b/src/seer/automation/autofix/components/coding/component.py
@@ -22,6 +22,7 @@ from seer.automation.autofix.autofix_agent import AutofixAgent
 from seer.automation.autofix.autofix_context import AutofixContext
 from seer.automation.autofix.components.coding.models import (
     CodeChangesPromptXml,
+    CodeChangeXml,
     CodingOutput,
     CodingRequest,
     PlanTaskPromptXml,
@@ -338,7 +339,7 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
 
         @observe(name="Process Change Task")
         @ai_track(description="Process Change Task")
-        def process_task(task: PlanTaskPromptXml, llm_client: LlmClient, app_config: AppConfig):
+        def process_task(task: CodeChangeXml, llm_client: LlmClient, app_config: AppConfig):
             module = Module()
             module.enable()
 

--- a/src/seer/automation/autofix/components/coding/component.py
+++ b/src/seer/automation/autofix/components/coding/component.py
@@ -144,7 +144,7 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
 
         # fallback to writing a unified diff directly
         fallback_prompt = textwrap.dedent(
-            """
+            """\
             You are an expert software engineer. You are given a code snippet and a proposed update to the code.
             You need to generate the exact unified diff that shows the changes to the code, but only specific portions. You do NOT need to include the entire file in the diff, but you should include up to 3 lines of unchanged lines before and after the changes for context. Please preserve indentation.
 


### PR DESCRIPTION
Occasionally, the apply model would not complete its response with a `</updated_code>` tag or it would be truncated for some other reason, causing the "new content" to be empty and cause the whole file to be deleted.

Now if there is no new content from the apply model (meaning something went wrong), fall back to asking Gemini Flash to directly write a unified diff. (I tested always just writing a diff, but the fix accuracy went down, so just using it as a fallback).