### PR TITLE
chore(ci): Container registry cache cleanup

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 18 * * *" # at 6:00 PM UTC every day
-  pull_request: # TODO: Remove this once we have tested.
 
 jobs:
   cleanup:
@@ -17,6 +16,5 @@ jobs:
           account: getsentry
           token: ${{ secrets.GITHUB_TOKEN }}
           image-names: "seer"
-          cut-off: 2d # Keep images up to 14 days old
+          cut-off: 14d # Keep images up to 14 days old
           keep-n-most-recent: 16 # Keep 16 most recent regardless of age
-          dry-run: true

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -20,7 +20,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: snok/container-retention-policy@v3.0.0
         with:
-          account: snok
+          account: ${{ github.actor }}
           token: ${{ secrets.GITHUB_TOKEN }}
           image-names: "seer"
           cut-off: 4d # TODO

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -12,16 +12,10 @@ jobs:
     permissions:
       packages: "write"
     steps:
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - uses: snok/container-retention-policy@v3.0.0
         with:
           account: getsentry
           token: ${{ secrets.GITHUB_TOKEN }}
           image-names: "seer"
-          cut-off: 4d # TODO
-          dry-run: true
+          cut-off: 14d # Keep images up to 14 days old
+          keep-n-most-recent: 16 # Keep 16 most recent regardless of age

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,0 +1,23 @@
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 18 * * *" # at 6:00 PM UTC every day
+  pull_request: # TODO: Remove this once we have tested.
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: "write"
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/delete-package-versions@v5
+        with:
+          package-name: "seer"
+          package-type: "container"
+          min-versions-to-keep: 64 # Keep the latest 64 versions

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -17,5 +17,6 @@ jobs:
           account: getsentry
           token: ${{ secrets.GITHUB_TOKEN }}
           image-names: "seer"
-          cut-off: 14d # Keep images up to 14 days old
+          cut-off: 2d # Keep images up to 14 days old
           keep-n-most-recent: 16 # Keep 16 most recent regardless of age
+          dry-run: true

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -20,7 +20,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: snok/container-retention-policy@v3.0.0
         with:
-          account: ${{ github.actor }}
+          account: getsentry
           token: ${{ secrets.GITHUB_TOKEN }}
           image-names: "seer"
           cut-off: 4d # TODO

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,3 +1,5 @@
+name: Container Registry Cleanup
+
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: snok/container-retention-policy@v3.0.0
         with:
           account: snok
+          token: ${{ secrets.GITHUB_TOKEN }}
           image-names: "seer"
           cut-off: 4d # TODO
           dry-run: true

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -16,8 +16,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/delete-package-versions@v5
+      - uses: snok/container-retention-policy@v3.0.0
         with:
-          package-name: "seer"
-          package-type: "container"
-          min-versions-to-keep: 64 # Keep the latest 64 versions
+          account: snok
+          image-names: "seer"
+          cut-off: 4d # TODO
+          dry-run: true


### PR DESCRIPTION
Cron job that runs every day at 18:00 UTC (10am PT) to clean up cached build containers **_older than 14 days._** Regardless of date, we will keep a minimum of 16 containers.