### PR TITLE
fix(autofix): Stricter threshold for detected encodings

### DIFF
--- a/src/seer/automation/codebase/code_search.py
+++ b/src/seer/automation/codebase/code_search.py
@@ -60,9 +60,8 @@ class CodeSearcher:
         """
         # First try: Read a sample to detect encoding
         try:
-            # Read only first 32KB to detect encoding for large files
+            # Read only first 256KB to detect encoding for large files
             with open(file_path, "rb") as f:
-                # note the number of bytes to read is increased from 32KB to 256KB
                 # theoretically, this could cause an incorrectly detected encoding if there are some special characters
                 # in the file after the first 256KB of data
                 # Hopefully it is a corner case, especially since files larger than 1MB are ignored from search

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -23,7 +23,7 @@ from github.Repository import Repository
 
 from seer.automation.autofix.utils import generate_random_string, sanitize_branch_name
 from seer.automation.codebase.models import GithubPrReviewComment
-from seer.automation.codebase.utils import get_language_from_path
+from seer.automation.codebase.utils import get_all_supported_extensions, get_language_from_path
 from seer.automation.models import FileChange, FilePatch, InitializationError, RepoDefinition
 from seer.automation.utils import detect_encoding
 from seer.configuration import AppConfig
@@ -366,9 +366,12 @@ class RepoClient:
             )
 
         valid_file_paths: set[str] = set()
+        valid_file_extensions = get_all_supported_extensions()
 
         for file in tree.tree:
-            if file.type == "blob":
+            if file.type == "blob" and any(
+                file.path.endswith(ext) for ext in valid_file_extensions
+            ):
                 valid_file_paths.add(file.path)
 
         return valid_file_paths

--- a/src/seer/automation/codebase/utils.py
+++ b/src/seer/automation/codebase/utils.py
@@ -61,6 +61,19 @@ language_to_extensions = {
 
 
 @functools.cache
+def get_all_supported_extensions() -> set[str]:
+    """
+    Returns a set of all supported file extensions across all languages.
+
+    :return: A set of file extensions including the dot prefix (e.g. {'.py', '.js'})
+    """
+    extensions = set()
+    for extensions_list in language_to_extensions.values():
+        extensions.update(extensions_list)
+    return extensions
+
+
+@functools.cache
 def get_extension_to_language_map():
     extension_to_language: dict[str, str] = {}
     for language, extensions in language_to_extensions.items():

--- a/src/seer/automation/utils.py
+++ b/src/seer/automation/utils.py
@@ -256,7 +256,7 @@ def detect_encoding(raw_data: bytes, fallback_encoding: str = "utf-8"):
     """
     try:
         result = chardet.detect(raw_data)
-        encoding = result["encoding"] if result["confidence"] > 0.6 else fallback_encoding
+        encoding = result["encoding"] if result["confidence"] > 0.9 else fallback_encoding
     # if something went wrong, fallback
     except Exception as e:
         logger.exception(f"Error detecting encoding of data: {e}")


### PR DESCRIPTION
We're getting a good amount of errors decoding files: https://sentry.sentry.io/issues/6183118961/

It's mostly because of: 
1. Detecting the wrong encoding. So let's only choose a new encoding if we're confident.
2. The agent was trying to read images and other invalid files because we showed them to it in some tools. So let's exclude these unsupported files.