### PR TITLE
chore(evals): Improve final fix scoring prompt

### DIFF
--- a/src/seer/automation/autofix/evaluations.py
+++ b/src/seer/automation/autofix/evaluations.py
@@ -260,32 +260,45 @@ def score_fix_single_it(
 
     prompt = textwrap.dedent(
         """\
+            <goal>
+            Score how well the predicted solution fixes the issue, given the known solution, with a float score from 0 to 1, where 1 means the solution fully fixes the issue and 0 means the solution does not fix the issue at all.
+            </goal>
+
+            <reasoning_rules>
+            When thinking/reasoning about the score, consider the following:
+            1. Use the known solution to understand what the issue is.
+            2. Consider that there are multiple ways to fix an issue.
+            3. Judge whether the predicted solution actually fixes the issue.
+            </reasoning_rules>
+
+            <output_format>
+            1. Provide your reasoning of your judgement of the predicted solution inside a <reasoning> tag.
+            2. Provide the score inside a <score> tag.
+            3. Given all that you know, now provide your verdict of whether the predicted solution actually fixes the issue with a boolean value inside a <verdict> tag, such as <verdict>True</verdict> or <verdict>False</verdict>.
+            </output_format>
+
+            Given the below issue:
+
+            <issue>
             {event_details}
+            </issue>
 
-            Given the above issue, we know the correct fix is:
+            We have a known correct solution:
 
-            <expected_solution>
+            <known_solution>
             <description>
             {expected_description}
             </description>
             <diff>
             {expected_diff}
             </diff>
-            </expected_solution>
+            </known_solution>
 
             The model outputted the following solution:
 
             <predicted_solution>
             {predicted_diff}
-            </predicted_solution>
-
-            Score how well the predicted solution matches the expected solution with a float score from 0 to 1, where 1 means the solution fully fixes the issue and 0 means the solution does not fix the issue at all.
-            - Consider the context of the issue and the diff
-            - Consider that there are multiple ways to fix an issue
-
-            Think step-by-step inside a <thoughts> tag before giving a score.
-            Return the score inside a <score> tag.
-            Then, return your verdict of whether the predicted solution fixes the issue with a boolean value inside a <verdict> tag, such as <verdict>True</verdict> or <verdict>False</verdict>."""
+            </predicted_solution>"""
     ).format(
         event_details=event_details.format_event(),
         expected_description=expected_output["solution_diff"]["description"],


### PR DESCRIPTION
An issue with the prior prompt was that we were having it overfocus on scoring how well the predicted solution "matches" an expected output, rather than scoring how well the issue is fixed.

This prompt update:
1. Changes the concept of an "expected" solution to a "known" solution and prompts o3-mini to use it to inform what the issue was
2. The score is now on how well the predicted solution fixes the issue rather than asking it to score how well it "matches"
3. Prompt format adjustment to place context at the end for reasoning models.

(ignore the latency, i was running multiple evals at the same time so it slowed)
![CleanShot 2025-02-19 at 15 22 39@2x](https://github.com/user-attachments/assets/c042422c-5bb4-4a4b-b134-ef40e09b8261)
