### PR TITLE
chore(seer): Set number of celery workers based on env

### DIFF
--- a/celeryworker.sh
+++ b/celeryworker.sh
@@ -7,7 +7,14 @@ if [ "$CELERY_WORKER_QUEUE" != "" ]; then
     QUEUE="$CELERY_WORKER_QUEUE"
 fi
 
-WORKER_CMD="celery -A src.celery_app.tasks worker --loglevel=info -Q $QUEUE $CELERY_WORKER_OPTIONS"
+# You can set the number of celery workers via the NUM_CELERY_WORKERS environment variable.
+# If not set, the default number of workers is 16.
+NUM_WORKERS="16"
+if [ "$NUM_CELERY_WORKERS" != "" ]; then
+    NUM_WORKERS="$NUM_CELERY_WORKERS"
+fi
+
+WORKER_CMD="celery -A src.celery_app.tasks worker --loglevel=info -Q $QUEUE -c $NUM_WORKERS $CELERY_WORKER_OPTIONS"
 
 if [ "$CELERY_WORKER_ENABLE" = "true" ]; then
     if [ "$DEV" = "true" ] || [ "$DEV" = "1" ]; then

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -31,7 +31,7 @@ stderr_logfile_maxbytes=0
 
 ; The celery worker program is disabled by default. Set CELERY_WORKER_ENABLE=true in the environment to enable it.
 [program:celeryworker-default]
-command=env CELERY_WORKER_OPTIONS="-c 16 -n seer@%%h" /app/celeryworker.sh
+command=env /app/celeryworker.sh
 directory=/app
 startsecs=0
 autostart=true


### PR DESCRIPTION
- Update env script to include `NUM_CELERY_WORKERS` from env. Defaults to 16 if not specified
- Simplify command in `supervisord.conf` 

note: Everything worked and ran locally. Unsure if there are other specific ways to test this.