### PR TITLE
fix(relevant-warnings): Fix serialization on overwatch payload

### DIFF
--- a/src/seer/automation/codegen/relevant_warnings_step.py
+++ b/src/seer/automation/codegen/relevant_warnings_step.py
@@ -83,7 +83,7 @@ class RelevantWarningsStep(CodegenStep):
             "run_id": self.context.run_id,
             "results": relevant_warnings_output.model_dump()["relevant_warning_results"],
         }
-        request_data = json.dumps(request).encode("utf-8")
+        request_data = json.dumps(request, separators=(",", ":")).encode("utf-8")
         headers = get_codecov_auth_header(
             request_data,
             signature_header="X-GEN-AI-AUTH-SIGNATURE",


### PR DESCRIPTION
The overwatch payload expects the json serialization to exclude spaces e.g. like `{"run_id":"test-123"}` not `{"run_id": "test-123"` (note the space before "test-123") and since the exact string needs to match when signed with the shared secret, need to add this extra serialization rule