### PR TITLE
fix(autofix): Timeout + retry on stream first token and hanging

### DIFF
--- a/src/seer/automation/agent/models.py
+++ b/src/seer/automation/agent/models.py
@@ -87,3 +87,21 @@ class LlmRefusalError(Exception):
     """Raised when the LLM refuses to complete the request."""
 
     pass
+
+
+class LlmStreamTimeoutError(TimeoutError):
+    """Raised when the LLM stream times out."""
+
+    pass
+
+
+class LlmStreamFirstTokenTimeoutError(LlmStreamTimeoutError):
+    """Raised when the LLM takes too long to generate the first token."""
+
+    pass
+
+
+class LlmStreamInactivityTimeoutError(LlmStreamTimeoutError):
+    """Raised when the LLM stream times out due to inactivity."""
+
+    pass

--- a/src/seer/automation/autofix/autofix_agent.py
+++ b/src/seer/automation/autofix/autofix_agent.py
@@ -9,6 +9,7 @@ from sentry_sdk.ai.monitoring import ai_track
 from seer.automation.agent.agent import AgentConfig, LlmAgent, RunConfig
 from seer.automation.agent.models import (
     LlmGenerateTextResponse,
+    LlmProviderType,
     LlmResponseMetadata,
     Message,
     ToolCall,
@@ -88,6 +89,12 @@ class AutofixAgent(LlmAgent):
             tools=(self.tools if len(self.tools) > 0 else None),
             temperature=run_config.temperature or 0.0,
             reasoning_effort=run_config.reasoning_effort,
+            first_token_timeout=(
+                90.0
+                if (run_config.model.provider_name == LlmProviderType.OPENAI)
+                and run_config.model.model_name.startswith("o")
+                else 40.0
+            ),
         )
 
         cleared = False

--- a/tests/automation/agent/test_client.py
+++ b/tests/automation/agent/test_client.py
@@ -1,4 +1,5 @@
 import json
+import time
 
 import numpy as np
 import pytest
@@ -12,16 +13,20 @@ from seer.automation.agent.client import (
     AnthropicProvider,
     GeminiProvider,
     LlmClient,
+    OpenAiProvider,
+)
+from seer.automation.agent.embeddings import GoogleProviderEmbeddings
+from seer.automation.agent.models import (
     LlmGenerateStructuredResponse,
     LlmGenerateTextResponse,
     LlmProviderType,
+    LlmRefusalError,
+    LlmStreamFirstTokenTimeoutError,
+    LlmStreamInactivityTimeoutError,
     Message,
-    OpenAiProvider,
     ToolCall,
     Usage,
 )
-from seer.automation.agent.embeddings import GoogleProviderEmbeddings
-from seer.automation.agent.models import LlmRefusalError
 from seer.automation.agent.tools import FunctionTool
 
 
@@ -827,3 +832,198 @@ class TestGoogleProviderEmbeddings:
         for text, embedding in zip(texts, embeddings, strict=True):
             embedding_expected = model.encode([text])[0]
             assert np.allclose(embedding, embedding_expected, atol=1e-4)
+
+
+@pytest.mark.parametrize(
+    "provider_class,model_name",
+    [
+        (OpenAiProvider, "gpt-3.5-turbo"),
+        (AnthropicProvider, "claude-3-5-sonnet@20240620"),
+        (GeminiProvider, "gemini-2.0-flash-exp"),
+    ],
+)
+def test_generate_text_stream_with_first_token_timeout(provider_class, model_name, monkeypatch):
+    """Test that first token timeout is correctly applied."""
+    llm_client = LlmClient()
+    model = provider_class.model(model_name)
+
+    def mock_stream_gen_with_first_token_delay(*args, **kwargs):
+        # Simulate delay before yielding first token
+        time.sleep(0.1)
+        yield "First token"
+
+        # Subsequent tokens come quickly
+        for i in range(3):
+            yield f"Token {i+2}"
+
+        # Yield usage info at the end
+        yield Usage(completion_tokens=5, prompt_tokens=5, total_tokens=10)
+
+    monkeypatch.setattr(model, "generate_text_stream", mock_stream_gen_with_first_token_delay)
+
+    # Should complete successfully with reasonable timeout values
+    stream_items = list(
+        llm_client.generate_text_stream(
+            prompt="test",
+            model=model,
+            first_token_timeout=0.5,  # Long enough for our simulated delay
+            inactivity_timeout=0.5,
+        )
+    )
+
+    assert len(stream_items) == 5  # 4 tokens + usage info
+    assert stream_items[0] == "First token"
+
+    # Should timeout with too short first token timeout
+    with pytest.raises(LlmStreamFirstTokenTimeoutError, match="time to first token timeout"):
+        list(
+            llm_client.generate_text_stream(
+                prompt="test",
+                model=model,
+                first_token_timeout=0.05,  # Too short for our simulated delay
+                inactivity_timeout=1.0,
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "provider_class,model_name",
+    [
+        (OpenAiProvider, "gpt-3.5-turbo"),
+        (AnthropicProvider, "claude-3-5-sonnet@20240620"),
+        (GeminiProvider, "gemini-2.0-flash-exp"),
+    ],
+)
+def test_generate_text_stream_with_inactivity_timeout(provider_class, model_name, monkeypatch):
+    """Test that inactivity timeout is correctly applied after first token."""
+    llm_client = LlmClient()
+    model = provider_class.model(model_name)
+
+    def mock_stream_gen_with_inactivity_delay(*args, **kwargs):
+        # First token comes quickly
+        yield "First token"
+
+        # Simulate delay between first and second token
+        time.sleep(0.2)
+        yield "Second token"
+
+        # More tokens come at normal speed
+        for i in range(2):
+            yield f"Token {i+3}"
+
+        # Yield usage info at the end
+        yield Usage(completion_tokens=5, prompt_tokens=5, total_tokens=10)
+
+    monkeypatch.setattr(model, "generate_text_stream", mock_stream_gen_with_inactivity_delay)
+
+    # Should complete successfully with reasonable timeout values
+    stream_items = list(
+        llm_client.generate_text_stream(
+            prompt="test",
+            model=model,
+            first_token_timeout=1.0,
+            inactivity_timeout=0.5,  # Long enough for our simulated delay
+        )
+    )
+
+    assert len(stream_items) == 5  # 4 tokens + usage info
+    assert stream_items[0] == "First token"
+    assert stream_items[1] == "Second token"
+
+    # Should timeout with too short inactivity timeout
+    with pytest.raises(LlmStreamInactivityTimeoutError, match="inactivity timeout"):
+        list(
+            llm_client.generate_text_stream(
+                prompt="test",
+                model=model,
+                first_token_timeout=1.0,
+                inactivity_timeout=0.1,  # Too short for our simulated delay
+            )
+        )
+
+
+def test_generate_text_stream_different_timeouts(monkeypatch):
+    """Test that first token and inactivity timeouts are correctly differentiated."""
+    llm_client = LlmClient()
+    model = OpenAiProvider.model("gpt-3.5-turbo")
+
+    tokens_generated = []
+    start_time = time.time()
+
+    def mock_stream_gen(*args, **kwargs):
+        nonlocal tokens_generated, start_time
+
+        # Record when this generator is first called
+        start_time = time.time()
+
+        # First token takes 0.3 seconds
+        time.sleep(0.3)
+        # Record token only after it would be yielded (after timeout check)
+        yield_token = "First token"
+        yield yield_token
+        tokens_generated.append(("first", time.time() - start_time))
+
+        # Second token takes 0.2 seconds after first token
+        time.sleep(0.2)
+        yield_token = "Second token"
+        yield yield_token
+        tokens_generated.append(("second", time.time() - start_time))
+
+        # Remaining tokens come quickly
+        for i in range(3):
+            time.sleep(0.05)
+            yield_token = f"Token {i+3}"
+            yield yield_token
+            tokens_generated.append((f"token{i+3}", time.time() - start_time))
+
+        # Yield usage info at the end
+        yield Usage(completion_tokens=5, prompt_tokens=5, total_tokens=10)
+
+    monkeypatch.setattr(model, "generate_text_stream", mock_stream_gen)
+
+    # Should complete successfully with first token timeout > 0.3s and inactivity timeout > 0.2s
+    tokens_generated = []
+    stream_items = list(
+        llm_client.generate_text_stream(
+            prompt="test",
+            model=model,
+            first_token_timeout=0.5,
+            inactivity_timeout=0.3,
+        )
+    )
+
+    assert len(stream_items) == 6  # 5 tokens + usage info
+    assert len(tokens_generated) == 5  # 5 tokens were generated
+    assert tokens_generated[0][0] == "first"
+    assert tokens_generated[1][0] == "second"
+
+    # Should timeout on first token if first token timeout is too low
+    tokens_generated = []
+    with pytest.raises(LlmStreamFirstTokenTimeoutError, match="time to first token timeout"):
+        list(
+            llm_client.generate_text_stream(
+                prompt="test",
+                model=model,
+                first_token_timeout=0.2,  # Too short for first token (0.3s)
+                inactivity_timeout=0.3,
+            )
+        )
+
+    # First token should not have been generated since timeout occurred before yield
+    assert len(tokens_generated) == 0
+
+    # Should timeout on inactivity if inactivity timeout is too low
+    tokens_generated = []
+    with pytest.raises(LlmStreamInactivityTimeoutError, match="inactivity timeout"):
+        list(
+            llm_client.generate_text_stream(
+                prompt="test",
+                model=model,
+                first_token_timeout=0.5,  # Enough for first token
+                inactivity_timeout=0.1,  # Too short for second token (0.2s)
+            )
+        )
+
+    # Only first token should have been generated before timeout
+    assert len(tokens_generated) == 1
+    assert tokens_generated[0][0] == "first"


### PR DESCRIPTION
Autofix run timeouts turns out happens (so far as we know) on 2 reasons:
1. A deploy goes out and kills the run
2. Streams hanging, especially from anthropic

This PR fixes the latter stream hanging issue by introducing a time to first token timeout and a stream inactivity timeout.