### PR TITLE
chore(anomaly detection): Speedup Threshold Recovery

### DIFF
--- a/src/seer/anomaly_detection/detectors/mp_boxcox_scorer.py
+++ b/src/seer/anomaly_detection/detectors/mp_boxcox_scorer.py
@@ -137,7 +137,7 @@ class MPBoxCoxScorer(MPScorer):
         location_detector: LocationDetector = injected,
     ) -> FlagsAndScores:
         z_scores, threshold, std, threshold_transformed = self._get_z_scores(
-            mp_dist, ad_config.sensitivity
+            mp_dist[len(mp_dist) // 2 :], ad_config.sensitivity
         )
         scores = []
         flags = []
@@ -207,7 +207,7 @@ class MPBoxCoxScorer(MPScorer):
         # Include current value in z-score calculation
         values = np.append(history_mp_dist, streamed_mp_dist)
         z_scores, threshold, std, threshold_transformed = self._get_z_scores(
-            values, ad_config.sensitivity
+            values[len(values) // 2 :], ad_config.sensitivity
         )
 
         # Get z-score for streamed value

--- a/src/seer/anomaly_detection/detectors/mp_boxcox_scorer.py
+++ b/src/seer/anomaly_detection/detectors/mp_boxcox_scorer.py
@@ -137,7 +137,7 @@ class MPBoxCoxScorer(MPScorer):
         location_detector: LocationDetector = injected,
     ) -> FlagsAndScores:
         z_scores, threshold, std, threshold_transformed = self._get_z_scores(
-            mp_dist[len(mp_dist) // 2 :], ad_config.sensitivity
+            mp_dist, ad_config.sensitivity
         )
         scores = []
         flags = []

--- a/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
+++ b/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
@@ -279,12 +279,12 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
             "anomaly_higher_confidence",
             "anomaly_higher_confidence",
             "anomaly_higher_confidence",
-            "anomaly_higher_confidence",
-            "anomaly_higher_confidence",
-            "anomaly_higher_confidence",
-            "anomaly_higher_confidence",
-            "anomaly_higher_confidence",
-            "anomaly_higher_confidence",
+            "none",
+            "none",
+            "none",
+            "none",
+            "none",
+            "none",
             "none",
         ]
         assert history_anomalies.window_size == 3


### PR DESCRIPTION
- Speeds up threshold recovery from a large spike by using the latter half of the calculated MP Distances during the boxcox threshold calculation
- 28 days of data is still used to calculate the matrix profiles ensuring the full history is used, but only 14 days worth of MP Distances are used for the ultimate calculation