### PR TITLE
feat(autofix-evals): Separate solution & coding evals

### DIFF
--- a/src/seer/automation/autofix/evaluations.py
+++ b/src/seer/automation/autofix/evaluations.py
@@ -202,34 +202,34 @@ def sync_run_evaluation_on_item(item: DatasetItemClient) -> AutofixContinuation:
 
     run_id = state.get().run_id
 
-    RootCauseStep.get_signature(
-        RootCauseStepRequest(
-            run_id=run_id,
-        )
-    ).apply()
-
-    state_after_root_cause = state.get()
-    root_cause_step = state_after_root_cause.find_step(key="root_cause_analysis")
-
-    if not isinstance(root_cause_step, RootCauseStepModel) or not root_cause_step.causes:
-        return state.get()
-
-    event_manager = AutofixEventManager(state)
-    event_manager.set_selected_solution(
-        AutofixSolutionUpdatePayload(
-            type=AutofixUpdateType.SELECT_SOLUTION,
-            custom_solution=None,
-            solution_selected=True,
-        )
-    )
-
     try:
+        RootCauseStep.get_signature(
+            RootCauseStepRequest(
+                run_id=run_id,
+            )
+        ).apply()
+
+        state_after_root_cause = state.get()
+        root_cause_step = state_after_root_cause.find_step(key="root_cause_analysis")
+
+        if not isinstance(root_cause_step, RootCauseStepModel) or not root_cause_step.causes:
+            return state.get()
+
+        event_manager = AutofixEventManager(state)
+        event_manager.set_selected_solution(
+            AutofixSolutionUpdatePayload(
+                type=AutofixUpdateType.SELECT_SOLUTION,
+                custom_solution=None,
+                solution_selected=True,
+            )
+        )
+
         AutofixCodingStep.get_signature(AutofixCodingStepRequest(run_id=run_id)).apply()
 
         return state.get()
     except Exception as e:
         logger.exception(f"Error running evaluation: {e}")
-        # Return the root cause step causes anyway to score.
+        # Return the state anyway to score.
         return state.get()
 
 

--- a/src/seer/automation/autofix/evaluations.py
+++ b/src/seer/automation/autofix/evaluations.py
@@ -4,6 +4,7 @@ from typing import Literal, TypedDict, cast
 
 from langfuse.client import DatasetItemClient
 from langfuse.decorators import observe
+from pydantic import BaseModel
 from pydantic_xml import attr, element
 
 from seer.automation.agent.client import LlmClient, OpenAiProvider
@@ -13,8 +14,10 @@ from seer.automation.autofix.components.root_cause.models import (
     RootCauseAnalysisItem,
     TimelineEvent,
 )
+from seer.automation.autofix.components.solution.models import SolutionTimelineEvent
 from seer.automation.autofix.event_manager import AutofixEventManager
 from seer.automation.autofix.models import (
+    AutofixContinuation,
     AutofixRequest,
     AutofixRequestOptions,
     AutofixRootCauseUpdatePayload,
@@ -182,8 +185,8 @@ def sync_run_execution(item: DatasetItemClient):
     return "\n".join(diffs)
 
 
-@observe(name="Sync run evaluation on item")
-def sync_run_evaluation_on_item(item: DatasetItemClient):
+@observe(name="Sync run evaluation on item (JENN)")
+def sync_run_evaluation_on_item(item: DatasetItemClient) -> AutofixContinuation:
     run_id = None
 
     input_data: AutofixRequestDict = item.input
@@ -209,7 +212,7 @@ def sync_run_evaluation_on_item(item: DatasetItemClient):
     root_cause_step = state_after_root_cause.find_step(key="root_cause_analysis")
 
     if not isinstance(root_cause_step, RootCauseStepModel) or not root_cause_step.causes:
-        return None, None
+        return state.get()
 
     event_manager = AutofixEventManager(state)
     event_manager.set_selected_solution(
@@ -223,32 +226,17 @@ def sync_run_evaluation_on_item(item: DatasetItemClient):
     try:
         AutofixCodingStep.get_signature(AutofixCodingStepRequest(run_id=run_id)).apply()
 
-        state_after_execution = state.get()
-        changes_step = state_after_execution.steps[-1]
-        if not isinstance(changes_step, ChangesStep):
-            return None, root_cause_step.causes
-
-        changes = changes_step.changes
-
-        if not changes:
-            return None, root_cause_step.causes
-
-        diffs: list[str] = []
-        for change in changes:
-            if change.diff_str:
-                diffs.append(change.diff_str)
-
-        return "\n".join(diffs), root_cause_step.causes
+        return state.get()
     except Exception as e:
         logger.exception(f"Error running evaluation: {e}")
         # Return the root cause step causes anyway to score.
-        return None, root_cause_step.causes
+        return state.get()
 
 
-@observe(name="Score fix")
-def score_fix_single_it(
-    dataset_item: DatasetItemClient, predicted_diff: str, model: str
-) -> tuple[float, bool]:
+@observe(name="Score solution iteration")
+def score_solution_single_it(
+    dataset_item: DatasetItemClient, final_state: AutofixContinuation, model: str
+) -> tuple[float, bool] | None:
     if not dataset_item.expected_output:
         raise ValueError("Expected output is missing from dataset item")
 
@@ -257,6 +245,18 @@ def score_fix_single_it(
     request = AutofixRequest.model_validate(input_data["request"])
 
     event_details = EventDetails.from_event(request.issue.events[0])
+
+    predicted_solution = final_state.solution_step
+
+    if not predicted_solution:
+        return None
+
+    class SolutionPrinting(BaseModel):
+        solution: list[SolutionTimelineEvent]
+
+    predicted_solution_str = SolutionPrinting(solution=predicted_solution.solution).model_dump_json(
+        indent=2
+    )
 
     prompt = textwrap.dedent(
         """\
@@ -297,13 +297,13 @@ def score_fix_single_it(
             The model outputted the following solution:
 
             <predicted_solution>
-            {predicted_diff}
+            {predicted_solution_str}
             </predicted_solution>"""
     ).format(
         event_details=event_details.format_event(),
         expected_description=expected_output["solution_diff"]["description"],
         expected_diff=expected_output["solution_diff"]["unified_diff"],
-        predicted_diff=predicted_diff,
+        predicted_solution_str=predicted_solution_str,
     )
     response = LlmClient().generate_text(
         model=OpenAiProvider.model(model),
@@ -322,17 +322,87 @@ def score_fix_single_it(
     return score, verdict_bool
 
 
+@observe(name="Score coding")
+def score_coding_single_it(
+    dataset_item: DatasetItemClient, final_state: AutofixContinuation, model: str
+) -> tuple[float, float] | None:
+
+    predicted_solution = final_state.solution_step
+
+    if not predicted_solution:
+        return None
+
+    class SolutionPrinting(BaseModel):
+        solution: list[SolutionTimelineEvent]
+
+    predicted_solution_str = SolutionPrinting(solution=predicted_solution.solution).model_dump_json(
+        indent=2
+    )
+
+    changes_step = final_state.changes_step
+    if not changes_step or not changes_step.changes:
+        return None
+
+    final_diff_str = changes_step.changes[0].diff_str
+
+    prompt = textwrap.dedent(
+        """\
+            You are an expert at judging code changes and code quality.
+
+            <goal>
+            Score the code from the outputted diff given the instructions.
+            </goal>
+
+            <output_format>
+            1. Provide your reasoning of your judgement of the predicted solution inside a <reasoning> tag.
+            2. Provide a float score from 0 to 1 of whether the diff is complete and correct, whether it includes the instructions, inside a <correctness_score> tag. For example, if the diff is missing a step, then the score should be low. If the diff doesn't import a necessary module, then the score should be low. A high score means the diff contains all the necessary code changes and is correct (imports required modules, does not remove any necessary code, etc.).
+            3. Provide a float score from 0 to 1 of how targeted and concise the diff is, inside a <conciseness_score> tag. For example, if the diff includes extra changes that were not asked for in the instructions, then the conciseness score should be low.
+            </output_format>
+
+            Given the below instructions:
+
+            <instructions>
+            {predicted_solution_str}
+            </instructions>
+
+            The AI model outputted the following diff:
+
+            <predicted_diff>
+            {final_diff_str}
+            </predicted_diff>"""
+    ).format(predicted_solution_str=predicted_solution_str, final_diff_str=final_diff_str)
+    response = LlmClient().generate_text(
+        model=OpenAiProvider.model(model),
+        prompt=prompt,
+    )
+
+    if not response.message.content:
+        raise ValueError("No response content")
+
+    correctness_score_str = extract_text_inside_tags(response.message.content, "correctness_score")
+    correctness_score = float(correctness_score_str) if correctness_score_str else 0
+
+    conciseness_score_str = extract_text_inside_tags(response.message.content, "conciseness_score")
+    conciseness_score = float(conciseness_score_str) if conciseness_score_str else 0
+
+    return correctness_score, conciseness_score
+
+
 @observe(name="Score root cause iteration")
 def score_root_cause_single_it(
-    dataset_item: DatasetItemClient, causes: list[RootCauseAnalysisItem], model: str
-) -> tuple[float, bool, bool]:
+    dataset_item: DatasetItemClient, final_state: AutofixContinuation, model: str
+) -> tuple[float, bool, bool] | None:
     if not dataset_item.expected_output:
         raise ValueError("Expected output is missing from dataset item")
 
     input_data: AutofixRequestDict = dataset_item.input
     expected_output: ExpectedOutputDict = dataset_item.expected_output
     root_cause_expected_str = expected_output.get("root_cause")
-    cause_xml = RootCausePlanTaskPromptXml.from_root_cause(causes[0])
+
+    if not final_state.root_cause_step or not final_state.root_cause_step.causes:
+        return None
+
+    cause_xml = RootCausePlanTaskPromptXml.from_root_cause(final_state.root_cause_step.causes[0])
 
     request = AutofixRequest.model_validate(input_data["request"])
 
@@ -391,11 +461,16 @@ def score_root_cause_single_it(
     return score, verdict_bool, helpful_bool
 
 
-@observe(name="Score one")
-def score_one(
-    dataset_item: DatasetItemClient, predicted_diff_str: str, n_panel: int, model: str
-) -> tuple[float, bool]:
-    results = [score_fix_single_it(dataset_item, predicted_diff_str, model) for _ in range(n_panel)]
+@observe(name="Score solution")
+def score_solution(
+    dataset_item: DatasetItemClient, final_state: AutofixContinuation, n_panel: int, model: str
+) -> tuple[float, bool] | None:
+    results = [score_solution_single_it(dataset_item, final_state, model) for _ in range(n_panel)]
+
+    if any(result is None for result in results):
+        return None
+
+    results = [result for result in results if result is not None]
 
     mean_score = round(sum([result[0] for result in results]) / n_panel, 2)
 
@@ -405,11 +480,33 @@ def score_one(
     return mean_score, verdict
 
 
+@observe(name="Score coding")
+def score_coding(
+    dataset_item: DatasetItemClient, final_state: AutofixContinuation, n_panel: int, model: str
+) -> tuple[float, float] | None:
+    results = [score_coding_single_it(dataset_item, final_state, model) for _ in range(n_panel)]
+
+    if any(result is None for result in results):
+        return None
+
+    results = [result for result in results if result is not None]
+
+    mean_correctness_score = round(sum([result[0] for result in results]) / n_panel, 2)
+    mean_conciseness_score = round(sum([result[1] for result in results]) / n_panel, 2)
+
+    return mean_correctness_score, mean_conciseness_score
+
+
 @observe(name="Score root cause")
 def score_root_causes(
-    dataset_item: DatasetItemClient, causes: list[RootCauseAnalysisItem], n_panel: int, model: str
-) -> tuple[float, bool, bool]:
-    results = [score_root_cause_single_it(dataset_item, causes, model) for _ in range(n_panel)]
+    dataset_item: DatasetItemClient, final_state: AutofixContinuation, n_panel: int, model: str
+) -> tuple[float, bool, bool] | None:
+    results = [score_root_cause_single_it(dataset_item, final_state, model) for _ in range(n_panel)]
+
+    if any(result is None for result in results):
+        return None
+
+    results = [result for result in results if result is not None]
 
     mean_score = round(sum([result[0] for result in results]) / len(results), 2)
 

--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -270,7 +270,6 @@ class AutofixEvaluationRequest(BaseModel):
     dataset_name: str
     run_name: str
     run_description: Optional[str] = None
-    run_type: Literal["root_cause", "full", "execution"] = "full"
     test: bool = False
     run_on_item_id: Optional[str] = None
     random_for_test: bool = False
@@ -535,6 +534,26 @@ class AutofixContinuation(AutofixGroupState):
     def set_last_step_completed_message(self, message: str):
         if self.steps:
             self.steps[-1].completedMessage = message
+
+    @property
+    def root_cause_step(self) -> RootCauseStep | None:
+        root_cause_step = self.find_step(key="root_cause_analysis")
+        return (
+            root_cause_step
+            if root_cause_step and isinstance(root_cause_step, RootCauseStep)
+            else None
+        )
+
+    @property
+    def solution_step(self) -> SolutionStep | None:
+        solution_step = self.find_step(key="solution")
+
+        return solution_step if solution_step and isinstance(solution_step, SolutionStep) else None
+
+    @property
+    def changes_step(self) -> ChangesStep | None:
+        changes_step = self.find_step(key="changes")
+        return changes_step if changes_step and isinstance(changes_step, ChangesStep) else None
 
     def get_selected_root_cause(
         self,

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 import random
 import textwrap
-from typing import Literal, Type, cast
+from typing import Type, cast
 
 import sentry_sdk
 from langfuse import Langfuse
@@ -16,14 +16,12 @@ from seer.automation.autofix.components.comment_thread import (
     CommentThreadRequest,
 )
 from seer.automation.autofix.components.insight_sharing.models import InsightSharingOutput
-from seer.automation.autofix.components.root_cause.models import RootCauseAnalysisItem
 from seer.automation.autofix.evaluations import (
     make_score_name,
-    score_one,
+    score_coding,
     score_root_causes,
+    score_solution,
     sync_run_evaluation_on_item,
-    sync_run_execution,
-    sync_run_root_cause,
 )
 from seer.automation.autofix.event_manager import AutofixEventManager
 from seer.automation.autofix.models import (
@@ -763,7 +761,6 @@ def run_autofix_evaluation(
                     item_id=item.id,
                     run_name=request.run_name,
                     run_description=request.run_description,
-                    run_type=request.run_type,
                     item_index=i,
                     item_count=len(items),
                 ),
@@ -777,7 +774,6 @@ def run_autofix_evaluation_on_item(
     item_id: str,
     run_name: str,
     run_description: str,
-    run_type: Literal["execution", "full", "root_cause"],
     item_index: int,
     item_count: int,
 ):
@@ -792,197 +788,127 @@ def run_autofix_evaluation_on_item(
     scoring_n_panel = 5
     scoring_model = "o3-mini-2025-01-31"
 
-    diff: str | None = None
-    causes: list[RootCauseAnalysisItem] | None = None
-
     with dataset_item.observe(run_name=run_name, run_description=run_description) as trace_id:
-        if run_type == "root_cause":
-            try:
-                causes = sync_run_root_cause(dataset_item, langfuse_session_id=trace_id)
-            except Exception as e:
-                logger.error(f"Error running root cause analysis: {e}")
 
-            if causes:
-                root_cause_score = score_root_causes(
-                    dataset_item,
-                    causes,
-                    n_panel=scoring_n_panel,
-                    model=scoring_model,
-                    langfuse_session_id=trace_id,
-                )
+        try:
+            final_state = sync_run_evaluation_on_item(dataset_item, langfuse_session_id=trace_id)  # type: ignore
+        except Exception as e:
+            logger.exception(f"Error running evaluation: {e}")
 
-                # Will output 4 scores for a run item:
-                # - `"highest_score"`: The score for the highest scored cause out of all the returned root causes.
-                # - `"positioning_score"`: Positioning of the highest scored cause, if the highest scored cause is first, this score is `1.0`. If it is last, it will be `0.0`. The score is calculated proportional to the number of causes provided.
-                # - `"mean_score"`: The mean score of all the root causes.
-                # - `"error_weighted_score"` This score is the same as the highest score but scored 0 if there is an error or no root cause returned. This is used to weight the score in the aggregated run result.
+        root_cause_scores = score_root_causes(
+            dataset_item,
+            final_state,
+            n_panel=scoring_n_panel,
+            model=scoring_model,
+            langfuse_session_id=trace_id,  # type: ignore
+        )
 
-                langfuse.score(
-                    trace_id=trace_id,
-                    name=make_score_name(
-                        model=scoring_model, n_panel=scoring_n_panel, name="error_weighted_score"
-                    ),
-                    value=root_cause_score.get("highest_score"),
-                )
-                langfuse.score(
-                    trace_id=trace_id,
-                    name=make_score_name(
-                        model=scoring_model, n_panel=scoring_n_panel, name="highest_score"
-                    ),
-                    value=root_cause_score.get("highest_score"),
-                )
-                langfuse.score(
-                    trace_id=trace_id,
-                    name=make_score_name(
-                        model=scoring_model, n_panel=scoring_n_panel, name="positioning_score"
-                    ),
-                    value=root_cause_score.get("position_score"),
-                )
-                langfuse.score(
-                    trace_id=trace_id,
-                    name=make_score_name(
-                        model=scoring_model, n_panel=scoring_n_panel, name="mean_score"
-                    ),
-                    value=root_cause_score.get("mean_score"),
-                )
-            else:
-                langfuse.score(
-                    trace_id=trace_id,
-                    name=make_score_name(
-                        model=scoring_model, n_panel=scoring_n_panel, name="error_weighted_score"
-                    ),
-                    value=0,
-                )
-        elif run_type == "execution":
-            try:
-                diff = sync_run_execution(dataset_item, langfuse_session_id=trace_id)
-            except Exception as e:
-                logger.error(f"Error running evaluation: {e}")
+        if root_cause_scores:
+            root_cause_score, root_cause_verdict, root_cause_helpful = root_cause_scores
 
-            if diff:
-                score = score_one(
-                    dataset_item,
-                    diff,
-                    n_panel=scoring_n_panel,
-                    model=scoring_model,
-                    langfuse_session_id=trace_id,
-                )
-
-                langfuse.score(
-                    trace_id=trace_id,
-                    name=make_score_name(
-                        model=scoring_model, n_panel=scoring_n_panel, name="error_weighted_score"
-                    ),
-                    value=score,
-                )
-                langfuse.score(
-                    trace_id=trace_id,
-                    name=make_score_name(
-                        model=scoring_model, n_panel=scoring_n_panel, name="score"
-                    ),
-                    value=score,
-                )
-            else:
-                langfuse.score(
-                    trace_id=trace_id,
-                    name=make_score_name(
-                        model=scoring_model, n_panel=scoring_n_panel, name="error_weighted_score"
-                    ),
-                    value=0,
-                )
+            langfuse.score(
+                trace_id=trace_id,
+                name=make_score_name(
+                    model=scoring_model, n_panel=scoring_n_panel, name="rc_is_correct"
+                ),
+                value=1 if root_cause_verdict else 0,
+            )
+            langfuse.score(
+                trace_id=trace_id,
+                name=make_score_name(
+                    model=scoring_model, n_panel=scoring_n_panel, name="rc_is_helpful"
+                ),
+                value=1 if root_cause_helpful else 0,
+            )
+            langfuse.score(
+                trace_id=trace_id,
+                name=make_score_name(
+                    model=scoring_model, n_panel=scoring_n_panel, name="rc_error_weighted_score"
+                ),
+                value=root_cause_score,
+            )
+            langfuse.score(
+                trace_id=trace_id,
+                name=make_score_name(model=scoring_model, n_panel=scoring_n_panel, name="rc_score"),
+                value=root_cause_score,
+            )
         else:
-            try:
-                diff, causes = sync_run_evaluation_on_item(
-                    dataset_item, langfuse_session_id=trace_id
-                )
-            except Exception as e:
-                logger.exception(f"Error running evaluation: {e}")
+            langfuse.score(
+                trace_id=trace_id,
+                name=make_score_name(
+                    model=scoring_model, n_panel=scoring_n_panel, name="rc_error_weighted_score"
+                ),
+                value=0,
+            )
 
-            if diff:
-                score, verdict = score_one(
-                    dataset_item,
-                    diff,
-                    n_panel=scoring_n_panel,
+        solution_scores = score_solution(
+            dataset_item,
+            final_state,
+            n_panel=scoring_n_panel,
+            model=scoring_model,
+            langfuse_session_id=trace_id,  # type: ignore
+        )
+
+        if solution_scores:
+            mean_score, verdict = solution_scores
+
+            langfuse.score(
+                trace_id=trace_id,
+                name=make_score_name(
+                    model=scoring_model, n_panel=scoring_n_panel, name="solution_is_fixed"
+                ),
+                value=1 if verdict else 0,
+            )
+            langfuse.score(
+                trace_id=trace_id,
+                name=make_score_name(
                     model=scoring_model,
-                    langfuse_session_id=trace_id,
-                )
-
-                langfuse.score(
-                    trace_id=trace_id,
-                    name=make_score_name(
-                        model=scoring_model, n_panel=scoring_n_panel, name="is_fixed"
-                    ),
-                    value=1 if verdict else 0,
-                )
-                langfuse.score(
-                    trace_id=trace_id,
-                    name=make_score_name(
-                        model=scoring_model, n_panel=scoring_n_panel, name="error_weighted_score"
-                    ),
-                    value=score,
-                )
-                langfuse.score(
-                    trace_id=trace_id,
-                    name=make_score_name(
-                        model=scoring_model, n_panel=scoring_n_panel, name="score"
-                    ),
-                    value=score,
-                )
-            else:
-                langfuse.score(
-                    trace_id=trace_id,
-                    name=make_score_name(
-                        model=scoring_model, n_panel=scoring_n_panel, name="error_weighted_score"
-                    ),
-                    value=0,
-                )
-
-            if causes:
-                root_cause_score, root_cause_verdict, root_cause_helpful = score_root_causes(
-                    dataset_item,
-                    causes,
                     n_panel=scoring_n_panel,
+                    name="solution_error_weighted_score",
+                ),
+                value=mean_score,
+            )
+            langfuse.score(
+                trace_id=trace_id,
+                name=make_score_name(
+                    model=scoring_model, n_panel=scoring_n_panel, name="solution_score"
+                ),
+                value=mean_score,
+            )
+        else:
+            langfuse.score(
+                trace_id=trace_id,
+                name=make_score_name(
                     model=scoring_model,
-                    langfuse_session_id=trace_id,
-                )
+                    n_panel=scoring_n_panel,
+                    name="solution_error_weighted_score",
+                ),
+                value=0,
+            )
 
-                # Will output 4 scores for a run item:
-                # - `"highest_score"`: The score for the highest scored cause out of all the returned root causes.
-                # - `"error_weighted_score"` This score is the same as the highest score but scored 0 if there is an error or no root cause returned. This is used to weight the score in the aggregated run result.
+        coding_scores = score_coding(
+            dataset_item,
+            final_state,
+            n_panel=scoring_n_panel,
+            model=scoring_model,
+            langfuse_session_id=trace_id,  # type: ignore
+        )
 
-                langfuse.score(
-                    trace_id=trace_id,
-                    name=make_score_name(
-                        model=scoring_model, n_panel=scoring_n_panel, name="rc_is_correct"
-                    ),
-                    value=1 if root_cause_verdict else 0,
-                )
-                langfuse.score(
-                    trace_id=trace_id,
-                    name=make_score_name(
-                        model=scoring_model, n_panel=scoring_n_panel, name="rc_is_helpful"
-                    ),
-                    value=1 if root_cause_helpful else 0,
-                )
-                langfuse.score(
-                    trace_id=trace_id,
-                    name=make_score_name(
-                        model=scoring_model, n_panel=scoring_n_panel, name="rc_error_weighted_score"
-                    ),
-                    value=root_cause_score,
-                )
-                langfuse.score(
-                    trace_id=trace_id,
-                    name=make_score_name(
-                        model=scoring_model, n_panel=scoring_n_panel, name="rc_score"
-                    ),
-                    value=root_cause_score,
-                )
-            else:
-                langfuse.score(
-                    trace_id=trace_id,
-                    name=make_score_name(
-                        model=scoring_model, n_panel=scoring_n_panel, name="rc_error_weighted_score"
-                    ),
-                    value=0,
-                )
+        if coding_scores:
+            mean_correctness_score, mean_conciseness_score = coding_scores
+
+            langfuse.score(
+                trace_id=trace_id,
+                name=make_score_name(
+                    model=scoring_model, n_panel=scoring_n_panel, name="code_correctness_score"
+                ),
+                value=mean_correctness_score,
+            )
+            langfuse.score(
+                trace_id=trace_id,
+                name=make_score_name(
+                    model=scoring_model, n_panel=scoring_n_panel, name="code_conciseness_score"
+                ),
+                value=mean_conciseness_score,
+            )
+        # If no coding scores, we don't do anything...

--- a/tests/automation/autofix/test_autofix_evaluations.py
+++ b/tests/automation/autofix/test_autofix_evaluations.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, PropertyMock, patch
 
 import pytest
 from johen import generate
@@ -16,13 +16,15 @@ from seer.automation.autofix.components.root_cause.models import (
     RootCauseAnalysisItem,
     TimelineEvent,
 )
+from seer.automation.autofix.components.solution.models import SolutionTimelineEvent
 from seer.automation.autofix.evaluations import (
-    score_fix_single_it,
-    score_one,
+    score_coding,
+    score_coding_single_it,
     score_root_cause_single_it,
     score_root_causes,
+    score_solution,
+    score_solution_single_it,
     sync_run_evaluation_on_item,
-    sync_run_root_cause,
 )
 from seer.automation.autofix.models import (
     AutofixContinuation,
@@ -35,6 +37,7 @@ from seer.automation.autofix.models import (
     RepoDefinition,
 )
 from seer.automation.autofix.models import RootCauseStep as RootCauseStepModel
+from seer.automation.autofix.models import SolutionStep
 from seer.automation.models import SentryEventData
 from seer.automation.state import LocalMemoryState
 
@@ -120,6 +123,7 @@ class TestSyncRunEvaluationOnItem:
         self.mock_root_cause_step_instance.apply.side_effect = root_cause_apply_side_effect
 
         changes_step = next(generate(ChangesStep))
+        changes_step.key = "changes"
         changes_step.changes = [
             CodebaseChange(
                 repo_external_id="1",
@@ -147,7 +151,7 @@ class TestSyncRunEvaluationOnItem:
         self.mock_planning_step_instance.apply.side_effect = planning_apply_side_effect
 
         # Run the function
-        result_diff, result_root_causes = sync_run_evaluation_on_item(self.mock_dataset_item)
+        result_state = sync_run_evaluation_on_item(self.mock_dataset_item)
 
         # Assertions
         assert self.mock_create_initial_run.called
@@ -164,13 +168,13 @@ class TestSyncRunEvaluationOnItem:
         assert self.mock_planning_step_instance.apply.called
 
         # Check that the state was updated
-        final_state = self.test_state.get()
-        assert len(final_state.steps) == 2
-        assert isinstance(final_state.steps[0], RootCauseStepModel)
-        assert isinstance(final_state.steps[1], ChangesStep)
-
-        assert result_diff == "diff str 1\ndiff str 2"
-        assert result_root_causes == root_cause_model.causes
+        assert len(result_state.steps) == 2
+        assert isinstance(result_state.steps[0], RootCauseStepModel)
+        assert isinstance(result_state.steps[1], ChangesStep)
+        assert result_state.root_cause_step is not None
+        assert result_state.changes_step is not None
+        assert result_state.changes_step.changes[0].diff_str == "diff str 1"
+        assert result_state.changes_step.changes[1].diff_str == "diff str 2"
 
     def test_sync_run_evaluation_on_item_no_root_causes(self):
         # Setup state changes for root cause step with no causes
@@ -189,148 +193,31 @@ class TestSyncRunEvaluationOnItem:
         self.mock_root_cause_step_instance.apply.side_effect = root_cause_apply_side_effect
 
         # Run the function
-        result = sync_run_evaluation_on_item(self.mock_dataset_item)
+        result_state = sync_run_evaluation_on_item(self.mock_dataset_item)
 
         # Assertions
-        assert result == (None, None)
+        assert result_state.root_cause_step is not None
+        assert not result_state.root_cause_step.causes
         assert not self.mock_planning_step.get_signature.called
 
-    def test_sync_run_evaluation_on_item_no_changes(self):
-        # Setup state changes for root cause step
-        root_cause_model = RootCauseStepModel(
-            id="root_cause_analysis",
-            key="root_cause_analysis",
-            title="Root Cause Analysis",
-            causes=[
-                RootCauseAnalysisItem(
-                    id=1,
-                    root_cause_reproduction=[
-                        TimelineEvent(
-                            title="Test Cause",
-                            code_snippet_and_analysis="The root cause of the issue is ...",
-                            timeline_item_type="internal_code",
-                            relevant_code_file=RelevantCodeFile(
-                                file_path="test.py",
-                                repo_name="owner/repo",
-                            ),
-                            is_most_important_event=True,
-                        )
-                    ],
-                )
-            ],
-        )
+    def test_sync_run_evaluation_on_item_exception(self):
+        # Setup mock to raise exception
+        self.mock_root_cause_step_instance.apply.side_effect = Exception("Test exception")
 
-        def root_cause_apply_side_effect():
-            with self.test_state.update() as cur:
-                cur.steps.append(root_cause_model)
-            return self.test_state
+        # Mock AutofixContinuation return value to simulate what happens after an exception
+        AutofixContinuation(request=self.autofix_request)
+        # We need to patch the AutofixEventManager to return our empty state
+        with patch(
+            "seer.automation.autofix.evaluations.create_initial_autofix_run",
+            return_value=self.test_state,
+        ):
+            # Run the function - should not raise the exception
+            result_state = sync_run_evaluation_on_item(self.mock_dataset_item)
 
-        self.mock_root_cause_step_instance.apply.side_effect = root_cause_apply_side_effect
-
-        # Setup state changes for planning step with no changes
-        changes_step = ChangesStep(id="changes", title="Changes", changes=[])
-
-        def planning_apply_side_effect():
-            with self.test_state.update() as cur:
-                cur.steps.append(changes_step)
-            return self.test_state
-
-        self.mock_planning_step_instance.apply.side_effect = planning_apply_side_effect
-
-        # Run the function
-        result = sync_run_evaluation_on_item(self.mock_dataset_item)
-
-        # Assertions
-        assert result == (None, root_cause_model.causes)
-        assert self.mock_planning_step.get_signature.called
-        assert self.mock_planning_step_instance.apply.called
-
-
-class TestSyncRunRootCause:
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.autofix_request = AutofixRequest(
-            organization_id=1,
-            project_id=2,
-            repos=[
-                RepoDefinition(provider="github", owner="test", name="test-repo", external_id="1")
-            ],
-            issue=IssueDetails(id=1, title="Test Issue", short_id="1", events=[]),
-            invoking_user=AutofixUserDetails(id=1, display_name="Test User"),
-            instruction="Fix the bug",
-            options=AutofixRequestOptions(),
-        )
-
-        self.mock_dataset_item = Mock(spec=DatasetItemClient)
-        self.mock_dataset_item.input = {"request": self.autofix_request.model_dump()}
-
-        self.test_state = LocalMemoryState(AutofixContinuation(request=self.autofix_request))
-
-        self.mock_root_cause_step_instance = Mock()
-
-        self.patch_create_initial_run = patch(
-            "seer.automation.autofix.evaluations.create_initial_autofix_run"
-        )
-        self.patch_root_cause_step = patch("seer.automation.autofix.evaluations.RootCauseStep")
-
-        self.mock_create_initial_run = self.patch_create_initial_run.start()
-        self.mock_root_cause_step = self.patch_root_cause_step.start()
-
-        self.mock_create_initial_run.return_value = self.test_state
-        self.mock_root_cause_step.get_signature.return_value = self.mock_root_cause_step_instance
-
-    def teardown_method(self):
-        self.patch_create_initial_run.stop()
-        self.patch_root_cause_step.stop()
-
-    def test_sync_run_root_cause_happy_path(self):
-        root_cause_model = next(generate(RootCauseStepModel))
-        root_cause_model.causes = [
-            RootCauseAnalysisItem(
-                id=1,
-                root_cause_reproduction=[
-                    TimelineEvent(
-                        title="Test Cause",
-                        code_snippet_and_analysis="The root cause of the issue is ...",
-                        timeline_item_type="internal_code",
-                        relevant_code_file=RelevantCodeFile(
-                            file_path="test.py",
-                            repo_name="owner/repo",
-                        ),
-                        is_most_important_event=True,
-                    )
-                ],
-            )
-        ]
-
-        def root_cause_apply_side_effect():
-            with self.test_state.update() as cur:
-                cur.steps.append(root_cause_model)
-            return self.test_state
-
-        self.mock_root_cause_step_instance.apply.side_effect = root_cause_apply_side_effect
-
-        result = sync_run_root_cause(self.mock_dataset_item)
-
-        assert self.mock_create_initial_run.called
-        assert self.mock_root_cause_step.get_signature.called
-        assert self.mock_root_cause_step_instance.apply.called
-        assert result == root_cause_model.causes
-
-    def test_sync_run_root_cause_no_causes(self):
-        root_cause_model = RootCauseStepModel(
-            id="root_cause_analysis", title="Root Cause Analysis", causes=[]
-        )
-
-        def root_cause_apply_side_effect():
-            with self.test_state.update() as cur:
-                cur.steps.append(root_cause_model)
-            return self.test_state
-
-        self.mock_root_cause_step_instance.apply.side_effect = root_cause_apply_side_effect
-
-        with pytest.raises(ValueError, match="Expected root cause step"):
-            sync_run_root_cause(self.mock_dataset_item)
+            # Assertions
+            assert result_state is not None
+            # In the actual implementation, we catch the exception and return state.get()
+            # So we're testing that it returns a state regardless of the exception
 
 
 class TestScoreRootCauseSingleIt:
@@ -365,8 +252,47 @@ class TestScoreRootCauseSingleIt:
         }
         return mock_item
 
+    @pytest.fixture
+    def mock_final_state(self):
+        request = AutofixRequest(
+            organization_id=1,
+            project_id=2,
+            repos=[
+                RepoDefinition(provider="github", owner="test", name="test-repo", external_id="1")
+            ],
+            issue=IssueDetails(id=1, title="Test Issue", short_id="1", events=[]),
+            invoking_user=AutofixUserDetails(id=1, display_name="Test User"),
+            instruction="Fix the bug",
+            options=AutofixRequestOptions(),
+        )
+        final_state = AutofixContinuation(request=request)
+        root_cause_step = RootCauseStepModel(
+            id="root_cause_analysis",
+            key="root_cause_analysis",
+            title="Root Cause Analysis",
+            causes=[
+                RootCauseAnalysisItem(
+                    id=1,
+                    root_cause_reproduction=[
+                        TimelineEvent(
+                            title="Test Cause",
+                            code_snippet_and_analysis="The root cause of the issue is ...",
+                            timeline_item_type="internal_code",
+                            relevant_code_file=RelevantCodeFile(
+                                file_path="test.py",
+                                repo_name="owner/repo",
+                            ),
+                            is_most_important_event=True,
+                        )
+                    ],
+                )
+            ],
+        )
+        final_state.steps.append(root_cause_step)
+        return final_state
+
     @patch("seer.automation.autofix.evaluations.LlmClient")
-    def test_score_root_cause_single_it(self, mock_llm_client, mock_dataset_item):
+    def test_score_root_cause_single_it(self, mock_llm_client, mock_dataset_item, mock_final_state):
         mock_llm_instance = Mock()
         mock_llm_client.return_value = mock_llm_instance
         mock_llm_instance.generate_text.return_value = LlmGenerateTextResponse(
@@ -381,31 +307,15 @@ class TestScoreRootCauseSingleIt:
             ),
         )
 
-        causes = [
-            RootCauseAnalysisItem(
-                id=1,
-                root_cause_reproduction=[
-                    TimelineEvent(
-                        title="Test Cause",
-                        code_snippet_and_analysis="The root cause of the issue is ...",
-                        timeline_item_type="internal_code",
-                        relevant_code_file=RelevantCodeFile(
-                            file_path="test.py",
-                            repo_name="owner/repo",
-                        ),
-                        is_most_important_event=True,
-                    )
-                ],
-            )
-        ]
-
-        result = score_root_cause_single_it(mock_dataset_item, causes, model="test_model")
+        result = score_root_cause_single_it(mock_dataset_item, mock_final_state, model="test_model")
 
         assert result == (0.8, True, True)
         mock_llm_instance.generate_text.assert_called_once()
 
     @patch("seer.automation.autofix.evaluations.LlmClient")
-    def test_score_root_cause_single_it_no_score(self, mock_llm_client, mock_dataset_item):
+    def test_score_root_cause_single_it_no_score(
+        self, mock_llm_client, mock_dataset_item, mock_final_state
+    ):
         mock_llm_instance = Mock()
         mock_llm_client.return_value = mock_llm_instance
         mock_llm_instance.generate_text.return_value = LlmGenerateTextResponse(
@@ -417,51 +327,33 @@ class TestScoreRootCauseSingleIt:
             ),
         )
 
-        causes = [
-            RootCauseAnalysisItem(
-                id=1,
-                root_cause_reproduction=[
-                    TimelineEvent(
-                        title="Test Cause",
-                        code_snippet_and_analysis="The root cause of the issue is ...",
-                        timeline_item_type="internal_code",
-                        relevant_code_file=RelevantCodeFile(
-                            file_path="test.py",
-                            repo_name="owner/repo",
-                        ),
-                        is_most_important_event=True,
-                    )
-                ],
-            )
-        ]
-
-        result = score_root_cause_single_it(mock_dataset_item, causes, model="test_model")
+        result = score_root_cause_single_it(mock_dataset_item, mock_final_state, model="test_model")
 
         assert result == (0, False, False)
 
-    def test_score_root_cause_single_it_missing_expected_output(self, mock_dataset_item):
+    def test_score_root_cause_single_it_missing_expected_output(
+        self, mock_dataset_item, mock_final_state
+    ):
         mock_dataset_item.expected_output = None
 
-        causes = [
-            RootCauseAnalysisItem(
-                id=1,
-                root_cause_reproduction=[
-                    TimelineEvent(
-                        title="Test Cause",
-                        code_snippet_and_analysis="The root cause of the issue is ...",
-                        timeline_item_type="internal_code",
-                        relevant_code_file=RelevantCodeFile(
-                            file_path="test.py",
-                            repo_name="owner/repo",
-                        ),
-                        is_most_important_event=True,
-                    )
-                ],
-            )
-        ]
-
         with pytest.raises(ValueError, match="Expected output is missing from dataset item"):
-            score_root_cause_single_it(mock_dataset_item, causes, model="test_model")
+            score_root_cause_single_it(mock_dataset_item, mock_final_state, model="test_model")
+
+    def test_score_root_cause_single_it_no_root_cause_step(self, mock_dataset_item):
+        request = AutofixRequest(
+            organization_id=1,
+            project_id=2,
+            repos=[
+                RepoDefinition(provider="github", owner="test", name="test-repo", external_id="1")
+            ],
+            issue=IssueDetails(id=1, title="Test Issue", short_id="1", events=[]),
+            invoking_user=AutofixUserDetails(id=1, display_name="Test User"),
+            instruction="Fix the bug",
+            options=AutofixRequestOptions(),
+        )
+        final_state = AutofixContinuation(request=request)
+        result = score_root_cause_single_it(mock_dataset_item, final_state, model="test_model")
+        assert result is None
 
 
 class TestScoreRootCauses:
@@ -469,40 +361,65 @@ class TestScoreRootCauses:
     def mock_dataset_item(self):
         return Mock(spec=DatasetItemClient)
 
+    @pytest.fixture
+    def mock_final_state(self):
+        request = AutofixRequest(
+            organization_id=1,
+            project_id=2,
+            repos=[
+                RepoDefinition(provider="github", owner="test", name="test-repo", external_id="1")
+            ],
+            issue=IssueDetails(id=1, title="Test Issue", short_id="1", events=[]),
+            invoking_user=AutofixUserDetails(id=1, display_name="Test User"),
+            instruction="Fix the bug",
+            options=AutofixRequestOptions(),
+        )
+        final_state = AutofixContinuation(request=request)
+        root_cause_step = RootCauseStepModel(
+            id="root_cause_analysis",
+            key="root_cause_analysis",
+            title="Root Cause Analysis",
+            causes=[
+                RootCauseAnalysisItem(
+                    id=1,
+                    root_cause_reproduction=[
+                        TimelineEvent(
+                            title="Test Cause",
+                            code_snippet_and_analysis="The root cause of the issue is ...",
+                            timeline_item_type="internal_code",
+                            relevant_code_file=RelevantCodeFile(
+                                file_path="test.py",
+                                repo_name="owner/repo",
+                            ),
+                            is_most_important_event=True,
+                        )
+                    ],
+                )
+            ],
+        )
+        final_state.steps.append(root_cause_step)
+        return final_state
+
     @patch("seer.automation.autofix.evaluations.score_root_cause_single_it")
-    def test_score_root_causes(self, mock_score_root_cause_single_it, mock_dataset_item):
+    def test_score_root_causes(
+        self, mock_score_root_cause_single_it, mock_dataset_item, mock_final_state
+    ):
         mock_score_root_cause_single_it.side_effect = [
             (0.8, True, True),
             (0.7, True, True),
             (0.9, True, True),
         ]
 
-        causes = [
-            RootCauseAnalysisItem(
-                id=1,
-                root_cause_reproduction=[
-                    TimelineEvent(
-                        title="Test Cause",
-                        code_snippet_and_analysis="The root cause of the issue is ...",
-                        timeline_item_type="internal_code",
-                        relevant_code_file=RelevantCodeFile(
-                            file_path="test.py",
-                            repo_name="owner/repo",
-                        ),
-                        is_most_important_event=True,
-                    )
-                ],
-            )
-        ]
-
-        result = score_root_causes(mock_dataset_item, causes, n_panel=3, model="test_model")
+        result = score_root_causes(
+            mock_dataset_item, mock_final_state, n_panel=3, model="test_model"
+        )
 
         assert result == (0.8, True, True)  # Average score and majority verdict
         assert mock_score_root_cause_single_it.call_count == 3
 
     @patch("seer.automation.autofix.evaluations.score_root_cause_single_it")
     def test_score_root_causes_custom_n_panel(
-        self, mock_score_root_cause_single_it, mock_dataset_item
+        self, mock_score_root_cause_single_it, mock_dataset_item, mock_final_state
     ):
         # Changed side effect to have majority True (2 True, 0 False)
         mock_score_root_cause_single_it.side_effect = [
@@ -510,31 +427,44 @@ class TestScoreRootCauses:
             (0.8, True, True),
         ]
 
-        causes = [
-            RootCauseAnalysisItem(
-                id=1,
-                root_cause_reproduction=[
-                    TimelineEvent(
-                        title="Test Cause",
-                        code_snippet_and_analysis="The root cause of the issue is ...",
-                        timeline_item_type="internal_code",
-                        relevant_code_file=RelevantCodeFile(
-                            file_path="test.py",
-                            repo_name="owner/repo",
-                        ),
-                        is_most_important_event=True,
-                    )
-                ],
-            )
-        ]
-
-        result = score_root_causes(mock_dataset_item, causes, n_panel=2, model="test_model")
+        result = score_root_causes(
+            mock_dataset_item, mock_final_state, n_panel=2, model="test_model"
+        )
 
         assert result == (0.7, True, True)  # Average score and majority verdict (2 True > 0 False)
         assert mock_score_root_cause_single_it.call_count == 2
 
+    @patch("seer.automation.autofix.evaluations.score_root_cause_single_it")
+    def test_score_root_causes_no_root_cause_step(
+        self, mock_score_root_cause_single_it, mock_dataset_item
+    ):
+        # Set the mock to return None to simulate no root cause
+        mock_score_root_cause_single_it.return_value = None
 
-class TestScoreFixSingleIt:
+        request = AutofixRequest(
+            organization_id=1,
+            project_id=2,
+            repos=[
+                RepoDefinition(provider="github", owner="test", name="test-repo", external_id="1")
+            ],
+            issue=IssueDetails(id=1, title="Test Issue", short_id="1", events=[]),
+            invoking_user=AutofixUserDetails(id=1, display_name="Test User"),
+            instruction="Fix the bug",
+            options=AutofixRequestOptions(),
+        )
+        final_state = AutofixContinuation(request=request)
+
+        # Patch the root_cause_step property to always return None
+        with patch.object(
+            AutofixContinuation, "root_cause_step", new_callable=PropertyMock, return_value=None
+        ):
+            result = score_root_causes(
+                mock_dataset_item, final_state, n_panel=3, model="test_model"
+            )
+            assert result is None
+
+
+class TestScoreSolutionSingleIt:
     @pytest.fixture
     def mock_dataset_item(self):
         mock_item = Mock(spec=DatasetItemClient)
@@ -565,8 +495,37 @@ class TestScoreFixSingleIt:
         }
         return mock_item
 
+    @pytest.fixture
+    def mock_final_state(self):
+        request = AutofixRequest(
+            organization_id=1,
+            project_id=2,
+            repos=[
+                RepoDefinition(provider="github", owner="test", name="test-repo", external_id="1")
+            ],
+            issue=IssueDetails(id=1, title="Test Issue", short_id="1", events=[]),
+            invoking_user=AutofixUserDetails(id=1, display_name="Test User"),
+            instruction="Fix the bug",
+            options=AutofixRequestOptions(),
+        )
+        final_state = AutofixContinuation(request=request)
+        solution_step = SolutionStep(
+            id="solution",
+            key="solution",
+            title="Solution",
+            solution=[
+                SolutionTimelineEvent(
+                    title="Test Solution",
+                    code_snippet_and_analysis="This is a test solution",
+                    relevant_code_file=None,
+                )
+            ],
+        )
+        final_state.steps.append(solution_step)
+        return final_state
+
     @patch("seer.automation.autofix.evaluations.LlmClient")
-    def test_score_fix_single_it(self, mock_llm_client, mock_dataset_item):
+    def test_score_solution_single_it(self, mock_llm_client, mock_dataset_item, mock_final_state):
         mock_llm_instance = Mock()
         mock_llm_client.return_value = mock_llm_instance
         mock_llm_instance.generate_text.return_value = LlmGenerateTextResponse(
@@ -578,13 +537,15 @@ class TestScoreFixSingleIt:
             ),
         )
 
-        result = score_fix_single_it(mock_dataset_item, "predicted diff", model="test_model")
+        result = score_solution_single_it(mock_dataset_item, mock_final_state, model="test_model")
 
         assert result == (0.8, True)
         mock_llm_instance.generate_text.assert_called_once()
 
     @patch("seer.automation.autofix.evaluations.LlmClient")
-    def test_score_fix_single_it_no_score(self, mock_llm_client, mock_dataset_item):
+    def test_score_solution_single_it_no_score(
+        self, mock_llm_client, mock_dataset_item, mock_final_state
+    ):
         mock_llm_instance = Mock()
         mock_llm_client.return_value = mock_llm_instance
         mock_llm_instance.generate_text.return_value = LlmGenerateTextResponse(
@@ -596,37 +557,387 @@ class TestScoreFixSingleIt:
             ),
         )
 
-        result = score_fix_single_it(mock_dataset_item, "predicted diff", model="test_model")
+        result = score_solution_single_it(mock_dataset_item, mock_final_state, model="test_model")
 
         assert result == (0, False)
 
-    def test_score_fix_single_it_missing_expected_output(self, mock_dataset_item):
+    def test_score_solution_single_it_missing_expected_output(
+        self, mock_dataset_item, mock_final_state
+    ):
         mock_dataset_item.expected_output = None
 
         with pytest.raises(ValueError, match="Expected output is missing from dataset item"):
-            score_fix_single_it(mock_dataset_item, "predicted diff", model="test_model")
+            score_solution_single_it(mock_dataset_item, mock_final_state, model="test_model")
+
+    def test_score_solution_single_it_no_solution_step(self, mock_dataset_item):
+        request = AutofixRequest(
+            organization_id=1,
+            project_id=2,
+            repos=[
+                RepoDefinition(provider="github", owner="test", name="test-repo", external_id="1")
+            ],
+            issue=IssueDetails(id=1, title="Test Issue", short_id="1", events=[]),
+            invoking_user=AutofixUserDetails(id=1, display_name="Test User"),
+            instruction="Fix the bug",
+            options=AutofixRequestOptions(),
+        )
+        final_state = AutofixContinuation(request=request)
+        result = score_solution_single_it(mock_dataset_item, final_state, model="test_model")
+        assert result is None
 
 
-class TestScoreOne:
+class TestScoreSolution:
     @pytest.fixture
     def mock_dataset_item(self):
         return Mock(spec=DatasetItemClient)
 
-    @patch("seer.automation.autofix.evaluations.score_fix_single_it")
-    def test_score_one(self, mock_score_fix_single_it, mock_dataset_item):
-        mock_score_fix_single_it.side_effect = [(0.7, True), (0.8, True), (0.9, True)]
+    @pytest.fixture
+    def mock_final_state(self):
+        request = AutofixRequest(
+            organization_id=1,
+            project_id=2,
+            repos=[
+                RepoDefinition(provider="github", owner="test", name="test-repo", external_id="1")
+            ],
+            issue=IssueDetails(id=1, title="Test Issue", short_id="1", events=[]),
+            invoking_user=AutofixUserDetails(id=1, display_name="Test User"),
+            instruction="Fix the bug",
+            options=AutofixRequestOptions(),
+        )
+        final_state = AutofixContinuation(request=request)
+        solution_step = SolutionStep(
+            id="solution",
+            key="solution",
+            title="Solution",
+            solution=[
+                SolutionTimelineEvent(
+                    title="Test Solution",
+                    code_snippet_and_analysis="This is a test solution",
+                    relevant_code_file=None,
+                )
+            ],
+        )
+        final_state.steps.append(solution_step)
+        return final_state
 
-        result = score_one(mock_dataset_item, "predicted diff", n_panel=3, model="test_model")
+    @patch("seer.automation.autofix.evaluations.score_solution_single_it")
+    def test_score_solution(
+        self, mock_score_solution_single_it, mock_dataset_item, mock_final_state
+    ):
+        mock_score_solution_single_it.side_effect = [(0.7, True), (0.8, True), (0.9, True)]
+
+        result = score_solution(mock_dataset_item, mock_final_state, n_panel=3, model="test_model")
 
         assert result == (0.8, True)  # Average score and majority verdict
-        assert mock_score_fix_single_it.call_count == 3
+        assert mock_score_solution_single_it.call_count == 3
 
-    @patch("seer.automation.autofix.evaluations.score_fix_single_it")
-    def test_score_one_custom_n_panel(self, mock_score_fix_single_it, mock_dataset_item):
+    @patch("seer.automation.autofix.evaluations.score_solution_single_it")
+    def test_score_solution_custom_n_panel(
+        self, mock_score_solution_single_it, mock_dataset_item, mock_final_state
+    ):
         # Changed side effect to have majority True (2 True, 0 False)
-        mock_score_fix_single_it.side_effect = [(0.6, True), (0.8, True)]
+        mock_score_solution_single_it.side_effect = [(0.6, True), (0.8, True)]
 
-        result = score_one(mock_dataset_item, "predicted diff", n_panel=2, model="test_model")
+        result = score_solution(mock_dataset_item, mock_final_state, n_panel=2, model="test_model")
 
         assert result == (0.7, True)  # Average score and majority verdict (2 True > 0 False)
-        assert mock_score_fix_single_it.call_count == 2
+        assert mock_score_solution_single_it.call_count == 2
+
+    @patch("seer.automation.autofix.evaluations.score_solution_single_it")
+    def test_score_solution_no_solution_step(
+        self, mock_score_solution_single_it, mock_dataset_item
+    ):
+        # Set the mock to return None to simulate no solution
+        mock_score_solution_single_it.return_value = None
+
+        request = AutofixRequest(
+            organization_id=1,
+            project_id=2,
+            repos=[
+                RepoDefinition(provider="github", owner="test", name="test-repo", external_id="1")
+            ],
+            issue=IssueDetails(id=1, title="Test Issue", short_id="1", events=[]),
+            invoking_user=AutofixUserDetails(id=1, display_name="Test User"),
+            instruction="Fix the bug",
+            options=AutofixRequestOptions(),
+        )
+        final_state = AutofixContinuation(request=request)
+
+        # Patch the solution_step property to always return None
+        with patch.object(
+            AutofixContinuation, "solution_step", new_callable=PropertyMock, return_value=None
+        ):
+            result = score_solution(mock_dataset_item, final_state, n_panel=3, model="test_model")
+            assert result is None
+
+
+class TestScoreCodingSingleIt:
+    @pytest.fixture
+    def mock_dataset_item(self):
+        mock_item = Mock(spec=DatasetItemClient)
+        mock_item.expected_output = {
+            "original_diff": "expected diff",
+            "solution_diff": {
+                "description": "expected solution diff",
+                "unified_diff": "expected solution diff",
+            },
+            "root_cause": "expected root cause",
+        }
+        mock_item.input = {
+            "request": AutofixRequest(
+                organization_id=1,
+                project_id=2,
+                repos=[
+                    RepoDefinition(
+                        provider="github", owner="test", name="test-repo", external_id="1"
+                    )
+                ],
+                issue=IssueDetails(
+                    id=1, title="Test Issue", short_id="1", events=[next(generate(SentryEventData))]
+                ),
+                invoking_user=AutofixUserDetails(id=1, display_name="Test User"),
+                instruction="Fix the bug",
+                options=AutofixRequestOptions(),
+            ).model_dump()
+        }
+        return mock_item
+
+    @pytest.fixture
+    def mock_final_state(self):
+        request = AutofixRequest(
+            organization_id=1,
+            project_id=2,
+            repos=[
+                RepoDefinition(provider="github", owner="test", name="test-repo", external_id="1")
+            ],
+            issue=IssueDetails(id=1, title="Test Issue", short_id="1", events=[]),
+            invoking_user=AutofixUserDetails(id=1, display_name="Test User"),
+            instruction="Fix the bug",
+            options=AutofixRequestOptions(),
+        )
+        final_state = AutofixContinuation(request=request)
+
+        # Add solution step
+        solution_step = SolutionStep(
+            id="solution",
+            key="solution",
+            title="Solution",
+            solution=[
+                SolutionTimelineEvent(
+                    title="Test Solution",
+                    code_snippet_and_analysis="This is a test solution",
+                    relevant_code_file=None,
+                )
+            ],
+        )
+        final_state.steps.append(solution_step)
+
+        # Add changes step
+        changes_step = ChangesStep(
+            id="changes",
+            key="changes",
+            title="Changes",
+            changes=[
+                CodebaseChange(
+                    repo_external_id="1",
+                    repo_name="test",
+                    title="Test Change",
+                    description="This is a test change",
+                    diff=[],
+                    diff_str="diff --git a/test.py b/test.py\nindex 123..456 789\n--- a/test.py\n+++ b/test.py\n@@ -1,1 +1,1 @@\n-old code\n+new code",
+                )
+            ],
+        )
+        final_state.steps.append(changes_step)
+
+        return final_state
+
+    @patch("seer.automation.autofix.evaluations.LlmClient")
+    def test_score_coding_single_it(self, mock_llm_client, mock_dataset_item, mock_final_state):
+        mock_llm_instance = Mock()
+        mock_llm_client.return_value = mock_llm_instance
+        mock_llm_instance.generate_text.return_value = LlmGenerateTextResponse(
+            message=Message(
+                role="assistant",
+                content="<correctness_score>0.8</correctness_score><conciseness_score>0.9</conciseness_score>",
+            ),
+            metadata=LlmResponseMetadata(
+                model="test_model",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            ),
+        )
+
+        result = score_coding_single_it(mock_dataset_item, mock_final_state, model="test_model")
+
+        assert result == (0.8, 0.9)
+        mock_llm_instance.generate_text.assert_called_once()
+
+    @patch("seer.automation.autofix.evaluations.LlmClient")
+    def test_score_coding_single_it_no_score(
+        self, mock_llm_client, mock_dataset_item, mock_final_state
+    ):
+        mock_llm_instance = Mock()
+        mock_llm_client.return_value = mock_llm_instance
+        mock_llm_instance.generate_text.return_value = LlmGenerateTextResponse(
+            message=Message(role="assistant", content="No score provided"),
+            metadata=LlmResponseMetadata(
+                model="test_model",
+                provider_name=LlmProviderType.OPENAI,
+                usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            ),
+        )
+
+        result = score_coding_single_it(mock_dataset_item, mock_final_state, model="test_model")
+
+        assert result == (0, 0)
+
+    def test_score_coding_single_it_no_solution_step(self, mock_dataset_item):
+        request = AutofixRequest(
+            organization_id=1,
+            project_id=2,
+            repos=[
+                RepoDefinition(provider="github", owner="test", name="test-repo", external_id="1")
+            ],
+            issue=IssueDetails(id=1, title="Test Issue", short_id="1", events=[]),
+            invoking_user=AutofixUserDetails(id=1, display_name="Test User"),
+            instruction="Fix the bug",
+            options=AutofixRequestOptions(),
+        )
+        final_state = AutofixContinuation(request=request)
+        result = score_coding_single_it(mock_dataset_item, final_state, model="test_model")
+        assert result is None
+
+    def test_score_coding_single_it_no_changes_step(self, mock_dataset_item):
+        request = AutofixRequest(
+            organization_id=1,
+            project_id=2,
+            repos=[
+                RepoDefinition(provider="github", owner="test", name="test-repo", external_id="1")
+            ],
+            issue=IssueDetails(id=1, title="Test Issue", short_id="1", events=[]),
+            invoking_user=AutofixUserDetails(id=1, display_name="Test User"),
+            instruction="Fix the bug",
+            options=AutofixRequestOptions(),
+        )
+        final_state = AutofixContinuation(request=request)
+        solution_step = SolutionStep(
+            id="solution",
+            key="solution",
+            title="Solution",
+            solution=[
+                SolutionTimelineEvent(
+                    title="Test Solution",
+                    code_snippet_and_analysis="This is a test solution",
+                    relevant_code_file=None,
+                )
+            ],
+        )
+        final_state.steps.append(solution_step)
+        result = score_coding_single_it(mock_dataset_item, final_state, model="test_model")
+        assert result is None
+
+
+class TestScoreCoding:
+    @pytest.fixture
+    def mock_dataset_item(self):
+        return Mock(spec=DatasetItemClient)
+
+    @pytest.fixture
+    def mock_final_state(self):
+        request = AutofixRequest(
+            organization_id=1,
+            project_id=2,
+            repos=[
+                RepoDefinition(provider="github", owner="test", name="test-repo", external_id="1")
+            ],
+            issue=IssueDetails(id=1, title="Test Issue", short_id="1", events=[]),
+            invoking_user=AutofixUserDetails(id=1, display_name="Test User"),
+            instruction="Fix the bug",
+            options=AutofixRequestOptions(),
+        )
+        final_state = AutofixContinuation(request=request)
+
+        # Add solution step
+        solution_step = SolutionStep(
+            id="solution",
+            key="solution",
+            title="Solution",
+            solution=[
+                SolutionTimelineEvent(
+                    title="Test Solution",
+                    code_snippet_and_analysis="This is a test solution",
+                    relevant_code_file=None,
+                )
+            ],
+        )
+        final_state.steps.append(solution_step)
+
+        # Add changes step
+        changes_step = ChangesStep(
+            id="changes",
+            key="changes",
+            title="Changes",
+            changes=[
+                CodebaseChange(
+                    repo_external_id="1",
+                    repo_name="test",
+                    title="Test Change",
+                    description="This is a test change",
+                    diff=[],
+                    diff_str="diff --git a/test.py b/test.py\nindex 123..456 789\n--- a/test.py\n+++ b/test.py\n@@ -1,1 +1,1 @@\n-old code\n+new code",
+                )
+            ],
+        )
+        final_state.steps.append(changes_step)
+
+        return final_state
+
+    @patch("seer.automation.autofix.evaluations.score_coding_single_it")
+    def test_score_coding(self, mock_score_coding_single_it, mock_dataset_item, mock_final_state):
+        mock_score_coding_single_it.side_effect = [
+            (0.7, 0.8),
+            (0.8, 0.7),
+            (0.9, 0.9),
+        ]
+
+        result = score_coding(mock_dataset_item, mock_final_state, n_panel=3, model="test_model")
+
+        assert result == (0.8, 0.8)  # Average scores
+        assert mock_score_coding_single_it.call_count == 3
+
+    @patch("seer.automation.autofix.evaluations.score_coding_single_it")
+    def test_score_coding_custom_n_panel(
+        self, mock_score_coding_single_it, mock_dataset_item, mock_final_state
+    ):
+        mock_score_coding_single_it.side_effect = [(0.6, 0.9), (0.8, 0.7)]
+
+        result = score_coding(mock_dataset_item, mock_final_state, n_panel=2, model="test_model")
+
+        assert result == (0.7, 0.8)  # Average scores
+        assert mock_score_coding_single_it.call_count == 2
+
+    @patch("seer.automation.autofix.evaluations.score_coding_single_it")
+    def test_score_coding_no_solution_step(self, mock_score_coding_single_it, mock_dataset_item):
+        # Set the mock to return None to simulate no solution
+        mock_score_coding_single_it.return_value = None
+
+        request = AutofixRequest(
+            organization_id=1,
+            project_id=2,
+            repos=[
+                RepoDefinition(provider="github", owner="test", name="test-repo", external_id="1")
+            ],
+            issue=IssueDetails(id=1, title="Test Issue", short_id="1", events=[]),
+            invoking_user=AutofixUserDetails(id=1, display_name="Test User"),
+            instruction="Fix the bug",
+            options=AutofixRequestOptions(),
+        )
+        final_state = AutofixContinuation(request=request)
+
+        # Patch the solution_step property to always return None
+        with patch.object(
+            AutofixContinuation, "solution_step", new_callable=PropertyMock, return_value=None
+        ):
+            result = score_coding(mock_dataset_item, final_state, n_panel=3, model="test_model")
+            assert result is None

--- a/tests/automation/autofix/test_autofix_evaluations.py
+++ b/tests/automation/autofix/test_autofix_evaluations.py
@@ -204,8 +204,6 @@ class TestSyncRunEvaluationOnItem:
         # Setup mock to raise exception
         self.mock_root_cause_step_instance.apply.side_effect = Exception("Test exception")
 
-        # Mock AutofixContinuation return value to simulate what happens after an exception
-        AutofixContinuation(request=self.autofix_request)
         # We need to patch the AutofixEventManager to return our empty state
         with patch(
             "seer.automation.autofix.evaluations.create_initial_autofix_run",


### PR DESCRIPTION
The solution eval now tests the fix on the solution step, while the coding step we have a new `correctness_score` and a `conciseness_score` that just tests how well it takes its instructions and writes code for it.

This also removes the `run_type` field from the evaluation call and the individual root cause and coding evals, this is because we weren't using the other ones. They were outdated deadcode. We can just quickly write them up again when we were using it.