### PR TITLE
chore(seer): Use Migration URL

### DIFF
--- a/gocd/templates/bash/run-migrations.sh
+++ b/gocd/templates/bash/run-migrations.sh
@@ -6,9 +6,9 @@ echo "running flask db upgrade" \
   && /devinfra/scripts/k8s/k8s-spawn-job.py \
   --container-name="seer" \
   --label-selector="service=seer" \
+  --env="IS_DB_MIGRATION=true" \
   "seer-run-migrations" \
   "us-central1-docker.pkg.dev/sentryio/seer/image:${GO_REVISION_SEER_REPO}" \
-  -- \
   flask \
   db \
   upgrade

--- a/src/seer/configuration.py
+++ b/src/seer/configuration.py
@@ -46,6 +46,8 @@ class AppConfig(BaseModel):
     SENTRY_ENVIRONMENT: str = "production"
 
     DATABASE_URL: str
+    DATABASE_MIGRATIONS_URL: str | None = None
+    IS_DB_MIGRATION: ParseBool = False
     CELERY_BROKER_URL: str
     GITHUB_TOKEN: str | None = None
     GITHUB_APP_ID: str = ""

--- a/src/seer/db.py
+++ b/src/seer/db.py
@@ -41,7 +41,14 @@ def initialize_database(
     config: AppConfig = injected,
     app: Flask = injected,
 ):
-    app.config["SQLALCHEMY_DATABASE_URI"] = config.DATABASE_URL
+    # Get the database URL based on whether we're in migration mode
+    database_url = (
+        config.DATABASE_MIGRATIONS_URL
+        if config.IS_DB_MIGRATION and config.DATABASE_MIGRATIONS_URL
+        else config.DATABASE_URL
+    )
+
+    app.config["SQLALCHEMY_DATABASE_URI"] = database_url
     app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {
         "connect_args": {"prepare_threshold": None},
         "pool_pre_ping": True,


### PR DESCRIPTION
- Uses `DATABASE_MIGRATION_URL` if present which includes the proper permissions for creating migrations
- Defaults to the standard `DATABASE_URL` otherwise