### PR TITLE
fix(anomaly detection): Change Store Query to Upsert

### DIFF
--- a/src/seer/anomaly_detection/tasks.py
+++ b/src/seer/anomaly_detection/tasks.py
@@ -256,10 +256,6 @@ def _store_prophet_predictions(alert: DbDynamicAlert, predictions: ProphetPredic
             }
             for i in range(len(predictions.timestamps))
         ]
-
-        if not prediction_values:
-            return
-
         stmt = insert(DbProphetAlertTimeSeries).values(prediction_values)
 
         update_stmt = stmt.on_conflict_do_update(

--- a/tests/seer/anomaly_detection/test_cleanup_and_predict_tasks.py
+++ b/tests/seer/anomaly_detection/test_cleanup_and_predict_tasks.py
@@ -38,6 +38,10 @@ class TestCleanupTasks(unittest.TestCase):
         cur_ts = datetime.now().timestamp()
         past_ts = (datetime.now() - timedelta(days=200)).timestamp()
 
+        # Strip the timestamp to the minute
+        cur_ts = int(cur_ts / 60) * 60
+        past_ts = int(past_ts / 60) * 60
+
         config = AnomalyDetectionConfig(
             time_period=15, sensitivity="high", direction="both", expected_seasonality="auto"
         )
@@ -97,6 +101,10 @@ class TestCleanupTasks(unittest.TestCase):
 
         cur_ts = datetime.now().timestamp()
         past_ts = (datetime.now() - timedelta(days=200)).timestamp()
+
+        # Strip the timestamp to the minute
+        cur_ts = int(cur_ts / 60) * 60
+        past_ts = int(past_ts / 60) * 60
 
         timestamps_old = [past_ts + (i * 3600) for i in range(num_points_old)]
         timestamps_new = [cur_ts + (i * 3600) for i in range(num_points_new)]
@@ -267,7 +275,7 @@ class TestCleanupTasks(unittest.TestCase):
             new_predictions = [
                 prediction.timestamp
                 for prediction in alert.prophet_predictions
-                if prediction.timestamp >= datetime.fromtimestamp(cur_timestamp)
+                if prediction.timestamp > datetime.fromtimestamp(cur_timestamp)
             ]
 
             assert len(new_predictions) == (24 * (60 // config.time_period))


### PR DESCRIPTION
- Changes the store query to be an upsert so we can include all the new predictions
- Update test to ensure timestamps do not include seconds as in production