### PR TITLE
feat(autofix): Add tools for commit history

### DIFF
--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -162,6 +162,30 @@ class AutofixContext(PipelineContext):
 
         return file_contents
 
+    def get_commit_history_for_file(
+        self, path: str, repo_name: str | None = None, max_commits: int = 10
+    ) -> list[str]:
+        repo_name = self.autocorrect_repo_name(repo_name) if repo_name else None
+        if not repo_name:
+            raise AgentError() from ValueError(
+                f"Repo '{repo_name}' not found. Available repos: {', '.join([repo.full_name for repo in self.repos])}"
+            )
+
+        repo_client = self.get_repo_client(repo_name)
+        return repo_client.get_commit_history(path, autocorrect=True, max_commits=max_commits)
+
+    def get_commit_patch_for_file(
+        self, path: str, repo_name: str | None = None, commit_sha: str | None = None
+    ) -> str | None:
+        repo_name = self.autocorrect_repo_name(repo_name) if repo_name else None
+        if not repo_name:
+            raise AgentError() from ValueError(
+                f"Repo '{repo_name}' not found. Available repos: {', '.join([repo.full_name for repo in self.repos])}"
+            )
+
+        repo_client = self.get_repo_client(repo_name)
+        return repo_client.get_commit_patch_for_file(path, commit_sha, autocorrect=True)
+
     def _process_stacktrace_paths(self, stacktrace: Stacktrace):
         """
         Annotate a stacktrace with the correct repo each frame is pointing to and fix the filenames

--- a/src/seer/automation/autofix/evaluations.py
+++ b/src/seer/automation/autofix/evaluations.py
@@ -67,7 +67,7 @@ class DatasetItemDict(TypedDict):
     expected_output: ExpectedOutputDict
 
 
-@observe(name="Sync run evaluation on item (JENN)")
+@observe(name="Sync run evaluation on item")
 def sync_run_evaluation_on_item(item: DatasetItemClient) -> AutofixContinuation:
     run_id = None
 

--- a/src/seer/automation/autofix/tools.py
+++ b/src/seer/automation/autofix/tools.py
@@ -63,7 +63,11 @@ class BaseTools:
                 repo_name=repo_name, type=self.repo_client_type
             )
             valid_file_paths = repo_client.get_valid_file_paths(files_only=True)
-            files_per_repo[repo_name] = "\n".join(sorted(valid_file_paths))
+
+            # Convert the list of file paths to a tree structure
+            files_with_status = [{"path": path, "status": ""} for path in valid_file_paths]
+            tree_representation = repo_client._build_file_tree_string(files_with_status)
+            files_per_repo[repo_name] = tree_representation
 
         self.context.event_manager.add_log(f'Searching for "{query}"...')
 
@@ -116,6 +120,36 @@ class BaseTools:
         # show potential corrected paths if nothing was found here
         other_paths = self._get_potential_abs_paths(file_path, repo_name)
         return f"<document with the provided path not found/>\n{other_paths}".strip()
+
+    @observe(name="View Diff")
+    @ai_track(description="View Diff")
+    def view_diff(self, file_path: str, repo_name: str, commit_sha: str):
+        """
+        Given a file path, repository name, and commit SHA, returns the diff for the file in the given commit.
+        """
+        self.context.event_manager.add_log(
+            f"Studying commit `{commit_sha}` in `{file_path}` in `{repo_name}`..."
+        )
+        patch = self.context.get_commit_patch_for_file(
+            path=file_path, repo_name=repo_name, commit_sha=commit_sha
+        )
+        if patch is None:
+            return "Could not find the file in the given commit. Either your hash is incorrect or the file does not exist in the given commit."
+        return patch
+
+    @observe(name="Explain File")
+    @ai_track(description="Explain File")
+    def explain_file(self, file_path: str, repo_name: str):
+        """
+        Given a file path and repository name, returns recent commits and related files.
+        """
+        num_commits = 30
+        commit_history = self.context.get_commit_history_for_file(
+            file_path, repo_name, max_commits=num_commits
+        )
+        if commit_history:
+            return "COMMIT HISTORY:\n" + "\n".join(commit_history)
+        return "No commit history found for the given file. Either the file path or repo name is incorrect, or it is just unavailable right now."
 
     @observe(name="List Directory")
     @ai_track(description="List Directory")
@@ -348,7 +382,7 @@ class BaseTools:
     @observe(name="Search Google")
     @ai_track(description="Search Google")
     @inject
-    def search_google(self, question: str, llm_client: LlmClient = injected):
+    def google_search(self, question: str, llm_client: LlmClient = injected):
         """
         Searches Google to answer a question.
         """
@@ -361,8 +395,8 @@ class BaseTools:
 
         tools = [
             FunctionTool(
-                name="search_google",
-                fn=self.search_google,
+                name="google_search",
+                fn=self.google_search,
                 description="Searches the web with Google and returns the answer to a question.",
                 parameters=[
                     {
@@ -481,6 +515,47 @@ class BaseTools:
                             },
                         ],
                         required=["query"],
+                    ),
+                    FunctionTool(
+                        name="explain_file",
+                        fn=self.explain_file,
+                        description="Given a file path and repository name, describes recent commits and suggests related files.",
+                        parameters=[
+                            {
+                                "name": "file_path",
+                                "type": "string",
+                                "description": "The file to get more context on.",
+                            },
+                            {
+                                "name": "repo_name",
+                                "type": "string",
+                                "description": "Name of the repository containing the file.",
+                            },
+                        ],
+                        required=["file_path", "repo_name"],
+                    ),
+                    FunctionTool(
+                        name="view_diff",
+                        fn=self.view_diff,
+                        description="Given a file path, repository name, and 7 character commit SHA, returns the diff of what changed in the file in the given commit.",
+                        parameters=[
+                            {
+                                "name": "file_path",
+                                "type": "string",
+                                "description": "The file path to view the diff for.",
+                            },
+                            {
+                                "name": "repo_name",
+                                "type": "string",
+                                "description": "Name of the repository containing the file.",
+                            },
+                            {
+                                "name": "commit_sha",
+                                "type": "string",
+                                "description": "The 7 character commit SHA to view the diff for.",
+                            },
+                        ],
+                        required=["file_path", "repo_name", "commit_sha"],
                     ),
                 ]
             )

--- a/src/seer/automation/autofix/tools.py
+++ b/src/seer/automation/autofix/tools.py
@@ -127,6 +127,8 @@ class BaseTools:
         """
         Given a file path, repository name, and commit SHA, returns the diff for the file in the given commit.
         """
+        if not isinstance(self.context, AutofixContext):
+            return None
         self.context.event_manager.add_log(
             f"Studying commit `{commit_sha}` in `{file_path}` in `{repo_name}`..."
         )
@@ -143,6 +145,8 @@ class BaseTools:
         """
         Given a file path and repository name, returns recent commits and related files.
         """
+        if not isinstance(self.context, AutofixContext):
+            return None
         num_commits = 30
         commit_history = self.context.get_commit_history_for_file(
             file_path, repo_name, max_commits=num_commits
@@ -516,6 +520,12 @@ class BaseTools:
                         ],
                         required=["query"],
                     ),
+                ]
+            )
+
+        if isinstance(self.context, AutofixContext):
+            tools.extend(
+                [
                     FunctionTool(
                         name="explain_file",
                         fn=self.explain_file,

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -4,6 +4,8 @@ import os
 import shutil
 import tarfile
 import tempfile
+import textwrap
+from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from typing import Literal
 
@@ -309,6 +311,45 @@ class RepoClient:
 
         return tmp_dir, tmp_repo_dir
 
+    def _autocorrect_path(self, path: str, sha: str | None = None) -> tuple[str, bool]:
+        """
+        Attempts to autocorrect a file path by finding the closest match in the repository.
+
+        Args:
+            path: The path to autocorrect
+            sha: The commit SHA to use for finding valid paths
+
+        Returns:
+            A tuple of (corrected_path, was_autocorrected)
+        """
+        if sha is None:
+            sha = self.base_commit_sha
+
+        path = path.lstrip("/")
+        valid_paths = self.get_valid_file_paths(sha)
+
+        # If path is valid, return it unchanged
+        if path in valid_paths:
+            return path, False
+
+        # Check for partial matches if no exact match and path is long enough
+        if len(path) > 3:
+            path_lower = path.lower()
+            partial_matches = [
+                valid_path for valid_path in valid_paths if path_lower in valid_path.lower()
+            ]
+            if partial_matches:
+                # Sort by length to get closest match (shortest containing path)
+                closest_match = sorted(partial_matches, key=len)[0]
+                logger.warning(
+                    f"Path '{path}' not found exactly, using closest match: '{closest_match}'"
+                )
+                return closest_match, True
+
+        # No match found
+        logger.warning("No matching file found for provided file path", extra={"path": path})
+        return path, False
+
     def get_file_content(
         self, path: str, sha: str | None = None, autocorrect: bool = False
     ) -> tuple[str | None, str]:
@@ -318,27 +359,9 @@ class RepoClient:
 
         autocorrected_path = False
         if autocorrect:
-            path = path.lstrip("/")
-            valid_paths = self.get_valid_file_paths(sha)
-
-            # Check for partial matches if no exact match
-            if path not in valid_paths and len(path) > 3:
-                path_lower = path.lower()
-                partial_matches = [
-                    valid_path for valid_path in valid_paths if path_lower in valid_path.lower()
-                ]
-                if partial_matches:
-                    # Sort by length to get closest match (shortest containing path)
-                    closest_match = sorted(partial_matches, key=len)[0]
-                    logger.warning(
-                        f"Path '{path}' not found exactly, using closest match: '{closest_match}'"
-                    )
-                    path = closest_match
-                else:
-                    logger.exception(
-                        "No matching file found for provided file path", extra={"path": path}
-                    )
-                    return None, "utf-8"
+            path, autocorrected_path = self._autocorrect_path(path, sha)
+            if not autocorrected_path and path not in self.get_valid_file_paths(sha):
+                return None, "utf-8"
 
         try:
             contents = self.repo.get_contents(path, ref=sha)
@@ -377,6 +400,149 @@ class RepoClient:
                 valid_file_paths.add(file.path)
 
         return valid_file_paths
+
+    @functools.lru_cache(maxsize=16)
+    def get_commit_history(
+        self, path: str, sha: str | None = None, autocorrect: bool = False, max_commits: int = 10
+    ) -> list[str]:
+        if sha is None:
+            sha = self.base_commit_sha
+
+        if autocorrect:
+            path, was_autocorrected = self._autocorrect_path(path, sha)
+            if not was_autocorrected and path not in self.get_valid_file_paths(sha):
+                return []
+
+        commits = self.repo.get_commits(sha=sha, path=path)
+        commit_list = list(commits[:max_commits])
+        commit_strs = []
+
+        def process_commit(commit):
+            short_sha = commit.sha[:7]
+            message = commit.commit.message
+            files_touched = [
+                {"path": file.filename, "status": file.status} for file in commit.files[:20]
+            ]
+
+            # Build a file tree representation instead of a flat list
+            file_tree_str = self._build_file_tree_string(files_touched)
+
+            # Add a note about additional files if needed
+            additional_files_note = ""
+            if len(files_touched) < len(commit.files):
+                additional_files_note = (
+                    f"\n[and {len(commit.files) - len(files_touched)} more files were changed...]"
+                )
+
+            string = textwrap.dedent(
+                """\
+                ----------------
+                {short_sha} - {message}
+                Files touched:
+                {file_tree}{additional_files}
+                """
+            ).format(
+                short_sha=short_sha,
+                message=message,
+                file_tree=file_tree_str,
+                additional_files=additional_files_note,
+            )
+            return string
+
+        with ThreadPoolExecutor() as executor:
+            results = list(executor.map(process_commit, commit_list))
+
+        for result in results:
+            commit_strs.append(result)
+
+        return commit_strs
+
+    def _build_file_tree_string(self, files: list[dict]) -> str:
+        """
+        Builds a tree representation of files to save tokens when many files share the same directories.
+        The output is similar to the 'tree' command in terminal.
+
+        Args:
+            files: List of dictionaries with 'path' and 'status' keys
+
+        Returns:
+            A string representation of the file tree
+        """
+        if not files:
+            return "No files changed"
+
+        # First, build a nested dictionary structure representing the file tree
+        tree = {}
+        for file in files:
+            path = file["path"]
+            status = file["status"]
+
+            # Split the path into components
+            parts = path.split("/")
+
+            # Navigate through the tree, creating nodes as needed
+            current = tree
+            for i, part in enumerate(parts):
+                # If this is the last part (the filename)
+                if i == len(parts) - 1:
+                    current[part] = {"__status__": status}
+                else:
+                    if part not in current:
+                        current[part] = {}
+                    current = current[part]
+
+        # Now build the tree string recursively
+        lines = []
+
+        def _build_tree(node, prefix="", is_last=True, is_root=True):
+            items = list(node.items())
+
+            # Process each item
+            for i, (key, value) in enumerate(sorted(items)):
+                if key == "__status__":
+                    continue
+
+                # Determine if this is the last item at this level
+                is_last_item = i == len(items) - 1 or (i == len(items) - 2 and "__status__" in node)
+
+                # Create the appropriate prefix for this line
+                if is_root:
+                    current_prefix = ""
+                    next_prefix = ""
+                else:
+                    current_prefix = prefix + ("└── " if is_last else "├── ")
+                    next_prefix = prefix + ("    " if is_last else "│   ")
+
+                # If this is a file (has a status)
+                if "__status__" in value:
+                    status = value["__status__"]
+                    status_str = f" ({status})" if status else ""
+                    lines.append(f"{current_prefix}{key}{status_str}")
+                # If this is a directory
+                else:
+                    lines.append(f"{current_prefix}{key}/")
+                    _build_tree(value, next_prefix, is_last_item, False)
+
+        # Start building the tree from the root
+        _build_tree(tree)
+
+        return "\n".join(lines)
+
+    @functools.lru_cache(maxsize=16)
+    def get_commit_patch_for_file(
+        self, path: str, commit_sha: str, autocorrect: bool = False
+    ) -> str | None:
+        if autocorrect:
+            path, was_autocorrected = self._autocorrect_path(path, commit_sha)
+            if not was_autocorrected and path not in self.get_valid_file_paths(commit_sha):
+                return None
+
+        commit = self.repo.get_commit(commit_sha)
+        matching_file = next((file for file in commit.files if file.filename == path), None)
+        if not matching_file:
+            return None
+
+        return matching_file.patch
 
     def _create_branch(self, branch_name):
         ref = self.repo.create_git_ref(

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -472,7 +472,7 @@ class RepoClient:
             return "No files changed"
 
         # First, build a nested dictionary structure representing the file tree
-        tree = {}
+        tree: dict = {}
         for file in files:
             path = file["path"]
             status = file["status"]

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -590,7 +590,7 @@ class TestRepoClient:
         # Test with a path that needs correction (wrong case)
         content, _ = repo_client.get_file_content("SRC/test_file.py", autocorrect=True)
 
-        assert content == "test content"
+        assert content == "Showing results instead for src/test_file.py\n=====\ntest content"
 
         # Verify get_contents was called with corrected path
         mock_github.get_repo.return_value.get_contents.assert_called_once_with(


### PR DESCRIPTION
Adds two new tools:
- Explain File: given a file, show the descriptions of the 30 most recent commits as well as a tree of what other files were touched in the same commit.
- View Diff: given a 7-char commit sha and a specific file, view the diff of the change made.

Both tools typically complete in 2-5s. I think the latency increase in the evals is because the agent decides to explore more files after seeing the connected files, which also leads to better solutions.

Eval results:
- Root cause stable
- Solution correctness: 55% -> 62%
- Code conciseness: 91% -> 95%
- Code correctness: 86% -> 88%