### PR TITLE
fix(relevant-warnings) Add raw provider field

### DIFF
--- a/src/seer/automation/codegen/relevant_warnings_component.py
+++ b/src/seer/automation/codegen/relevant_warnings_component.py
@@ -68,10 +68,6 @@ class FetchIssuesComponent(BaseComponent[CodeFetchIssuesRequest, CodeFetchIssues
             logger.info("No eligible files in PR.")
             return {}
 
-        if not provider.startswith("integrations:"):
-            # TODO(kddubey): need to come up with something more general
-            provider = f"integrations:{provider}"
-
         logger.info(f"Repo query: {organization_id=}, {provider=}, {external_id=}")
 
         pr_files_eligible = pr_files_eligible[:max_files_analyzed]
@@ -92,9 +88,14 @@ class FetchIssuesComponent(BaseComponent[CodeFetchIssuesRequest, CodeFetchIssues
     @observe(name="Codegen - Relevant Warnings - Fetch Issues Component")
     @ai_track(description="Codegen - Relevant Warnings - Fetch Issues Component")
     def invoke(self, request: CodeFetchIssuesRequest) -> CodeFetchIssuesOutput:
+        if self.context.repo.provider_raw is None:
+            raise TypeError(
+                f"provider_raw is not set for repo: {self.context.repo}. "
+                "Something went wrong during initialization of the RepoDefinition."
+            )
         filename_to_issues = self._fetch_issues(
             organization_id=request.organization_id,
-            provider=self.context.repo.provider,
+            provider=self.context.repo.provider_raw,
             external_id=self.context.repo.external_id,
             pr_files=request.pr_files,
         )

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -15,6 +15,7 @@ from pydantic import (
     ValidationError,
     ValidationInfo,
     field_validator,
+    model_validator,
 )
 from pydantic.alias_generators import to_camel, to_snake
 from pydantic_xml import BaseXmlModel
@@ -590,10 +591,18 @@ class RepoDefinition(BaseModel):
     name: str
     external_id: Annotated[str, Examples(specialized.ascii_words)]
     base_commit_sha: Optional[str] = None
+    provider_raw: Optional[str] = None
 
     @property
     def full_name(self):
         return f"{self.owner}/{self.name}"
+
+    @model_validator(mode="before")
+    @classmethod
+    def store_provider_raw(cls, data):
+        if isinstance(data, dict) and "provider" in data and "provider_raw" not in data:
+            data["provider_raw"] = data["provider"]
+        return data
 
     @field_validator("provider", mode="after")
     @classmethod

--- a/tests/automation/autofix/test_models.py
+++ b/tests/automation/autofix/test_models.py
@@ -242,7 +242,7 @@ class TestStacktraceHelpers(unittest.TestCase):
 class TestRepoDefinition(unittest.TestCase):
     def test_repo_definition_creation(self):
         repo_def = RepoDefinition(
-            provider="github", owner="seer", name="automation", external_id="123"
+            provider="integrations:github", owner="seer", name="automation", external_id="123"
         )
         self.assertEqual(repo_def.provider, "github")
         self.assertEqual(repo_def.owner, "seer")
@@ -272,6 +272,7 @@ class TestRepoDefinition(unittest.TestCase):
             provider="integrations:github", owner="seer", name="automation", external_id="123"
         )
         self.assertEqual(repo_def.provider, "github")
+        self.assertEqual(repo_def.provider_raw, "integrations:github")
         self.assertEqual(repo_def.owner, "seer")
         self.assertEqual(repo_def.name, "automation")
 

--- a/tests/automation/codegen/test_relevant_warnings.py
+++ b/tests/automation/codegen/test_relevant_warnings.py
@@ -43,12 +43,24 @@ class TestFetchIssuesComponent:
         mock_context = MagicMock(spec=CodegenContext)
         mock_context.repo = MagicMock()
         mock_context.repo.provider = "github"
+        mock_context.repo.provider_raw = "integrations:github"
         mock_context.repo.external_id = "123123"
         return FetchIssuesComponent(mock_context)
+
+    def test_bad_provider_raw(self, component: FetchIssuesComponent):
+        mock_context = MagicMock(spec=CodegenContext)
+        mock_context.repo = MagicMock()
+        mock_context.repo.provider = "github"
+        mock_context.repo.provider_raw = None
+        mock_context.repo.external_id = "123123"
+        component = FetchIssuesComponent(mock_context)
+        with pytest.raises(TypeError):
+            component.invoke(CodeFetchIssuesRequest(organization_id=1, pr_files=[]))
 
     def test_invoke_filters_files(
         self, mock_rpc_client_call: Mock, component: FetchIssuesComponent
     ):
+        assert component.context.repo.provider_raw is not None
         pr_files = [
             PrFile(filename="fine.py", patch="patch1", status="modified", changes=100),
             PrFile(filename="many_changes.py", patch="patch2", status="modified", changes=1_000),


### PR DESCRIPTION
When fetching issues matching file patches in sentry, we look up the repo (sentry object) by its uniqueness constraint. Need the raw, un[processed](https://github.com/getsentry/seer/blob/108d9a7686a43b4ff062ea322f2eb74b4e3c29cc/src/seer/automation/utils.py#L107-L110)/unstripped provider to do that.