### PR TITLE
fix(relevant-warnings) Filter warnings from files not affected by commit

### DIFF
--- a/src/seer/automation/codegen/models.py
+++ b/src/seer/automation/codegen/models.py
@@ -167,7 +167,6 @@ class PrFile(BaseModel):
 class FilterWarningsRequest(BaseComponentRequest):
     warnings: list[StaticAnalysisWarning]
     target_filenames: list[str]
-    repo_full_name: str
 
 
 class FilterWarningsOutput(BaseComponentOutput):

--- a/src/seer/automation/codegen/models.py
+++ b/src/seer/automation/codegen/models.py
@@ -164,6 +164,16 @@ class PrFile(BaseModel):
     changes: int
 
 
+class FilterWarningsRequest(BaseComponentRequest):
+    warnings: list[StaticAnalysisWarning]
+    target_filenames: list[str]
+    repo_full_name: str
+
+
+class FilterWarningsOutput(BaseComponentOutput):
+    warnings: list[StaticAnalysisWarning]
+
+
 class CodeFetchIssuesRequest(BaseComponentRequest):
     organization_id: int
     pr_files: list[PrFile]

--- a/src/seer/automation/codegen/relevant_warnings_component.py
+++ b/src/seer/automation/codegen/relevant_warnings_component.py
@@ -93,7 +93,7 @@ class FilterWarningsComponent(BaseComponent[FilterWarningsRequest, FilterWarning
                 for filename in self._left_truncated_paths(Path(filename), max_num_paths=1)
             },
         }
-        return possible_matches_from_warning & possible_matches_from_targets
+        return bool(possible_matches_from_warning & possible_matches_from_targets)
 
     @observe(name="Codegen - Relevant Warnings - Filter Warnings Component")
     @ai_track(description="Codegen - Relevant Warnings - Filter Warnings Component")

--- a/src/seer/automation/codegen/relevant_warnings_step.py
+++ b/src/seer/automation/codegen/relevant_warnings_step.py
@@ -23,12 +23,15 @@ from seer.automation.codegen.models import (
     CodegenRelevantWarningsRequest,
     CodePredictRelevantWarningsOutput,
     CodePredictRelevantWarningsRequest,
+    FilterWarningsOutput,
+    FilterWarningsRequest,
     PrFile,
 )
 from seer.automation.codegen.relevant_warnings_component import (
     AreIssuesFixableComponent,
     AssociateWarningsWithIssuesComponent,
     FetchIssuesComponent,
+    FilterWarningsComponent,
     PredictRelevantWarningsComponent,
 )
 from seer.automation.codegen.step import CodegenStep
@@ -112,12 +115,7 @@ class RelevantWarningsStep(CodegenStep):
         self.logger.info("Executing Codegen - Relevant Warnings Step")
         self.context.event_manager.mark_running()
 
-        if not self.request.warnings:
-            self.logger.info("No warnings to predict relevancy for.")
-            self._complete_run(CodePredictRelevantWarningsOutput(relevant_warning_results=[]))
-            return
-
-        # 1. Fetch issues related to the commit.
+        # 1. Read the commit.
         repo_client = self.context.get_repo_client(type=RepoClientType.READ)
         commit = repo_client.repo.get_commit(self.request.commit_sha)
         pr_files = [
@@ -127,6 +125,25 @@ class RelevantWarningsStep(CodegenStep):
             for file in commit.files
             if file.patch
         ]
+
+        # 2. Only consider warnings from files changed in the commit.
+        filter_warnings_component = FilterWarningsComponent(self.context)
+        filter_warnings_request = FilterWarningsRequest(
+            warnings=self.request.warnings,
+            target_filenames=[file.filename for file in pr_files],
+            repo_full_name=self.request.repo.full_name,
+        )
+        filter_warnings_output: FilterWarningsOutput = filter_warnings_component.invoke(
+            filter_warnings_request
+        )
+        warnings = filter_warnings_output.warnings
+
+        if not warnings:  # exit early to avoid unnecessary issue-fetching.
+            self.logger.info("No warnings to predict relevancy for.")
+            self._complete_run(CodePredictRelevantWarningsOutput(relevant_warning_results=[]))
+            return
+
+        # 3. Fetch issues related to the commit.
         fetch_issues_component = FetchIssuesComponent(self.context)
         fetch_issues_request = CodeFetchIssuesRequest(
             organization_id=self.request.organization_id, pr_files=pr_files
@@ -135,11 +152,11 @@ class RelevantWarningsStep(CodegenStep):
             fetch_issues_request
         )
 
-        # 2. Limit the number of warning-issue associations we analyze to the top
-        # max_num_associations.
+        # 4. Limit the number of warning-issue associations we analyze to the top
+        #    max_num_associations.
         association_component = AssociateWarningsWithIssuesComponent(self.context)
         associations_request = AssociateWarningsWithIssuesRequest(
-            warnings=self.request.warnings,
+            warnings=warnings,
             filename_to_issues=fetch_issues_output.filename_to_issues,
             max_num_associations=self.request.max_num_associations,
         )
@@ -148,7 +165,7 @@ class RelevantWarningsStep(CodegenStep):
         )
         associations = associations_output.candidate_associations
 
-        # 3. Filter out unfixable issues b/c our definition of "relevant" is that fixing the warning
+        # 5. Filter out unfixable issues b/c our definition of "relevant" is that fixing the warning
         #    will fix the issue.
         are_issues_fixable_component = AreIssuesFixableComponent(self.context)
         are_fixable_output: CodeAreIssuesFixableOutput = are_issues_fixable_component.invoke(
@@ -165,7 +182,7 @@ class RelevantWarningsStep(CodegenStep):
             if is_fixable
         ]
 
-        # 4. Predict which warnings are relevant to which issues.
+        # 6. Predict which warnings are relevant to which issues.
         prediction_component = PredictRelevantWarningsComponent(self.context)
         request = CodePredictRelevantWarningsRequest(
             candidate_associations=associations_with_fixable_issues
@@ -174,5 +191,5 @@ class RelevantWarningsStep(CodegenStep):
             request
         )
 
-        # 5. Save results.
+        # 7. Save results.
         self._complete_run(relevant_warnings_output)

--- a/src/seer/automation/codegen/relevant_warnings_step.py
+++ b/src/seer/automation/codegen/relevant_warnings_step.py
@@ -129,9 +129,7 @@ class RelevantWarningsStep(CodegenStep):
         # 2. Only consider warnings from files changed in the commit.
         filter_warnings_component = FilterWarningsComponent(self.context)
         filter_warnings_request = FilterWarningsRequest(
-            warnings=self.request.warnings,
-            target_filenames=[file.filename for file in pr_files],
-            repo_full_name=self.request.repo.full_name,
+            warnings=self.request.warnings, target_filenames=[file.filename for file in pr_files]
         )
         filter_warnings_output: FilterWarningsOutput = filter_warnings_component.invoke(
             filter_warnings_request

--- a/tests/automation/codegen/test_relevant_warnings.py
+++ b/tests/automation/codegen/test_relevant_warnings.py
@@ -79,8 +79,8 @@ class TestFilterWarningsComponent:
                 ],
                 encoded_locations_without_matches=[
                     "../app/getsentry/seer/src/seer/anomaly_detection/detectors/mp_boxcox_scorer.py:233",  # too far up
-                    "getsentry/seer/src/seer/anomaly_detection/mp_boxcox_scorer.py",  # missing detectors
-                    "getsentry/seer/src/seer/detectors/mp_boxcox_scorer.py",  # missing anomaly_detection
+                    "getsentry/seer/src/seer/anomaly_detection/mp_boxcox_scorer.py:1",  # missing detectors
+                    "getsentry/seer/src/seer/detectors/mp_boxcox_scorer.py:1",  # missing anomaly_detection
                 ],
             ),
             _TestInvokeTestCase(
@@ -96,10 +96,10 @@ class TestFilterWarningsComponent:
                     "app/Livewire/Actions/Logout.php:15",
                 ],
                 encoded_locations_without_matches=[
-                    "generate_signature.py",  # unknown location
-                    "app/tools/generate_signature.py",  # missing seer_signature
-                    "tests/services/test_package.py",  # wrong file
-                    "app/app/Livewire/Actions/Logout.py",  # wrong extension
+                    "generate_signature.py:1",  # unknown location
+                    "app/tools/generate_signature.py:1",  # missing seer_signature
+                    "tests/services/test_package.py:1",  # wrong file
+                    "app/app/Livewire/Actions/Logout.py:1",  # wrong extension
                 ],
             ),
         ],

--- a/tests/automation/codegen/test_relevant_warnings.py
+++ b/tests/automation/codegen/test_relevant_warnings.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, Mock, patch
 import numpy as np
 import pytest
 from johen import generate
+from pydantic import BaseModel
 
 from seer.automation.agent.embeddings import GoogleProviderEmbeddings
 from seer.automation.agent.models import LlmGenerateStructuredResponse
@@ -40,65 +41,88 @@ from seer.automation.models import IssueDetails, RepoDefinition, SentryEventData
 
 
 class TestFilterWarningsComponent:
-    def test_bad_encoded_locations_cause_errors(self):
-        repo_full_name = "getsentry/seer"
+    @pytest.fixture
+    def component(self):
+        return FilterWarningsComponent(context=MagicMock())
 
-        warning = next(generate(StaticAnalysisWarning))
-        warning.encoded_location = "missing/repo/name/file.py:1:1"
-        with pytest.raises(
-            ValueError,
-            match=(
-                f"The repo {repo_full_name} isn't in the encoded location. "
-                f"Encoded location: {warning.encoded_location}"
-            ),
-        ):
-            FilterWarningsComponent._does_warning_match_a_target_file(
-                warning, {"file1.py"}, repo_full_name=repo_full_name
-            )
-
+    def test_bad_encoded_locations_cause_errors(self, component: FilterWarningsComponent):
         warning = next(generate(StaticAnalysisWarning))
         warning.encoded_location = "../../getsentry/seer/../not/anymore.py:1:1"
         with pytest.raises(
             ValueError,
             match=f"Found `..` in the middle of path. Encoded location: {warning.encoded_location}",
         ):
-            FilterWarningsComponent._does_warning_match_a_target_file(
-                warning, {"file1.py"}, repo_full_name=repo_full_name
-            )
+            component._does_warning_match_a_target_file(warning, {"file1.py"})
 
-    @pytest.fixture
-    def component(self):
-        return FilterWarningsComponent(context=MagicMock())
+    class _TestInvokeTestCase(BaseModel):
+        id: str
 
-    def test_invoke(self, component: FilterWarningsComponent):
-        target_files = [
-            # These files are relative to the repo root b/c they're from the GitHub API.
-            "src/seer/anomaly_detection/detectors/mp_boxcox_scorer.py",
-        ]
-        encoded_locations_with_matches = [
-            # These files come from overwatch. They'll always contain the repo's full name.
-            "getsentry/seer/src/seer/anomaly_detection/detectors/mp_boxcox_scorer.py:233:234",
-            "../../../getsentry/seer/src/seer/anomaly_detection/detectors/mp_boxcox_scorer.py:233",
-            "../app/getsentry/seer/src/seer/anomaly_detection/detectors/mp_boxcox_scorer.py:233",
-        ]
-        encoded_locations_without_matches = [
-            "getsentry/seer/src/seer/mp_boxcox_scorer.py",
-            "getsentry/seer/src/seer/detectors/mp_boxcox_scorer.py",
-        ]
+        target_files: list[str]
+        "These files are relative to the repo root b/c they're from the GitHub API."
 
+        encoded_locations_with_matches: list[str]
+        "These locations come from overwatch. Currently, they may not contain the repo's full name."
+
+        encoded_locations_without_matches: list[str]
+
+    @pytest.mark.parametrize(
+        "test_case",
+        [
+            _TestInvokeTestCase(
+                id="getsentry/seer",
+                target_files=["src/seer/anomaly_detection/detectors/mp_boxcox_scorer.py"],
+                encoded_locations_with_matches=[
+                    "src/seer/anomaly_detection/detectors/mp_boxcox_scorer.py:233:234",
+                    "seer/anomaly_detection/detectors/mp_boxcox_scorer.py:233:234",
+                    "getsentry/seer/src/seer/anomaly_detection/detectors/mp_boxcox_scorer.py:233:234",
+                    "../../../getsentry/seer/src/seer/anomaly_detection/detectors/mp_boxcox_scorer.py:233",
+                ],
+                encoded_locations_without_matches=[
+                    "../app/getsentry/seer/src/seer/anomaly_detection/detectors/mp_boxcox_scorer.py:233",  # too far up
+                    "getsentry/seer/src/seer/anomaly_detection/mp_boxcox_scorer.py",  # missing detectors
+                    "getsentry/seer/src/seer/detectors/mp_boxcox_scorer.py",  # missing anomaly_detection
+                ],
+            ),
+            _TestInvokeTestCase(
+                id="codecov/overwatch",
+                target_files=[
+                    "app/tools/seer_signature/generate_signature.py",
+                    "processor/tests/services/test_envelope.py",
+                    "app/app/Livewire/Actions/Logout.php",
+                ],
+                encoded_locations_with_matches=[
+                    "app/tools/seer_signature/generate_signature.py:20",
+                    "tests/services/test_envelope.py:4",
+                    "app/Livewire/Actions/Logout.php:15",
+                ],
+                encoded_locations_without_matches=[
+                    "generate_signature.py",  # unknown location
+                    "app/tools/generate_signature.py",  # missing seer_signature
+                    "tests/services/test_package.py",  # wrong file
+                    "app/app/Livewire/Actions/Logout.py",  # wrong extension
+                ],
+            ),
+        ],
+        ids=lambda test_case: test_case.id,
+    )
+    def test_invoke(self, test_case: _TestInvokeTestCase, component: FilterWarningsComponent):
         warnings = []
-        for encoded_location in encoded_locations_with_matches + encoded_locations_without_matches:
+        for encoded_location in (
+            test_case.encoded_locations_with_matches + test_case.encoded_locations_without_matches
+        ):
             warning = next(generate(StaticAnalysisWarning))
             warning.encoded_location = encoded_location
             warnings.append(warning)
 
         request = FilterWarningsRequest(
-            warnings=warnings, target_filenames=target_files, repo_full_name="getsentry/seer"
+            warnings=warnings,
+            target_filenames=test_case.target_files,
+            repo_full_name="getsentry/seer",
         )
         output: FilterWarningsOutput = component.invoke(request)
         output_encoded_locations = [warning.encoded_location for warning in output.warnings]
-        assert output_encoded_locations == encoded_locations_with_matches
-        assert output.warnings == warnings[: len(encoded_locations_with_matches)]
+        assert output_encoded_locations == test_case.encoded_locations_with_matches
+        assert output.warnings == warnings[: len(test_case.encoded_locations_with_matches)]
 
 
 @patch("seer.rpc.DummyRpcClient.call")
@@ -446,7 +470,6 @@ def test_relevant_warnings_step_invoke(
     mock_invoke_filter_warnings_component.call_args[0][0].target_filenames = [
         file.filename for file in mock_pr_files
     ]
-    mock_invoke_filter_warnings_component.call_args[0][0].repo_full_name = request.repo.full_name
 
     mock_invoke_fetch_issues_component.assert_called_once()
     mock_invoke_fetch_issues_component.call_args[0][0].organization_id = request.organization_id


### PR DESCRIPTION
Overwatch runs static analysis on the whole project every commit and sends these warnings to seer. Currently, the warning paths may not be normalized to the repo root. So need to do some fuzzy matching for now