### PR TITLE
chore(anomaly_detection): avoid NaNs in scores

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt --strip-extras requirements-constraints.txt
 #
-aiohappyeyeballs==2.4.6
+aiohappyeyeballs==2.4.8
     # via aiohttp
 aiohttp==3.11.13
     # via
@@ -13,7 +13,7 @@ aiohttp==3.11.13
     #   fsspec
 aiosignal==1.3.2
     # via aiohttp
-alembic==1.14.1
+alembic==1.15.1
     # via
     #   flask-migrate
     #   pytest-alembic
@@ -21,7 +21,7 @@ amqp==5.3.1
     # via kombu
 annotated-types==0.7.0
     # via pydantic
-anthropic==0.47.2
+anthropic==0.49.0
     # via -r requirements-constraints.txt
 anyio==4.8.0
     # via
@@ -42,7 +42,7 @@ backoff==2.2.1
     # via
     #   langfuse
     #   posthog
-bcrypt==4.2.1
+bcrypt==4.3.0
     # via chromadb
 billiard==4.2.1
     # via celery
@@ -136,13 +136,14 @@ distro==1.9.0
     # via
     #   anthropic
     #   openai
+    #   posthog
 docstring-parser==0.16
     # via google-cloud-aiplatform
 ephem==4.1.4
     # via
     #   -r requirements-constraints.txt
     #   lunarcalendar
-fastapi==0.115.8
+fastapi==0.115.11
     # via chromadb
 filelock==3.12.2
     # via
@@ -200,9 +201,9 @@ google-auth==2.38.0
     #   google-cloud-secret-manager
     #   google-cloud-storage
     #   google-genai
-google-cloud-aiplatform==1.81.0
+google-cloud-aiplatform==1.82.0
     # via -r requirements-constraints.txt
-google-cloud-bigquery==3.29.0
+google-cloud-bigquery==3.30.0
     # via google-cloud-aiplatform
 google-cloud-core==2.4.2
     # via
@@ -226,12 +227,12 @@ google-resumable-media==2.7.2
     # via
     #   google-cloud-bigquery
     #   google-cloud-storage
-googleapis-common-protos==1.68.0
+googleapis-common-protos==1.69.0
     # via
     #   google-api-core
     #   grpc-google-iam-v1
     #   grpcio-status
-grpc-google-iam-v1==0.14.0
+grpc-google-iam-v1==0.14.1
     # via
     #   google-cloud-resource-manager
     #   google-cloud-secret-manager
@@ -274,7 +275,7 @@ httpx==0.27.2
     #   anthropic
     #   langfuse
     #   openai
-huggingface-hub==0.29.1
+huggingface-hub==0.29.2
     # via
     #   datasets
     #   optimum
@@ -358,7 +359,7 @@ markupsafe==2.1.3
     #   mako
     #   sentry-sdk
     #   werkzeug
-matplotlib==3.10.0
+matplotlib==3.10.1
     # via
     #   prophet
     #   seaborn
@@ -427,7 +428,7 @@ onnx==1.16.0
     # via -r requirements-constraints.txt
 onnxruntime==1.20.1
     # via chromadb
-openai==1.64.0
+openai==1.65.3
     # via -r requirements-constraints.txt
 openapi-core==0.18.2
     # via -r requirements-constraints.txt
@@ -488,7 +489,7 @@ pip-tools==7.4.1
     # via -r requirements-constraints.txt
 pluggy==1.5.0
     # via pytest
-posthog==3.15.1
+posthog==3.18.1
     # via chromadb
 prompt-toolkit==3.0.50
     # via click-repl
@@ -524,7 +525,7 @@ protobuf==5.29.3
     #   transformers
 psycopg==3.1.18
     # via -r requirements-constraints.txt
-pulsar-client==3.6.0
+pulsar-client==3.6.1
     # via chromadb
 pyarrow==19.0.1
     # via datasets
@@ -659,7 +660,7 @@ rpds-py==0.23.1
     #   referencing
 rsa==4.9
     # via google-auth
-safetensors==0.5.2
+safetensors==0.5.3
     # via transformers
 scikit-learn==1.3.0
     # via
@@ -681,7 +682,7 @@ sentencepiece==0.2.0
     # via
     #   sentence-transformers
     #   transformers
-sentry-protos==0.1.61
+sentry-protos==0.1.62
     # via -r requirements-constraints.txt
 sentry-sdk==2.18.0
     # via -r requirements-constraints.txt
@@ -714,7 +715,7 @@ sqlalchemy==2.0.25
     #   pytest-alembic
 stanio==0.5.1
     # via cmdstanpy
-starlette==0.45.3
+starlette==0.46.0
     # via fastapi
 statsmodels==0.14.0
     # via -r requirements-constraints.txt
@@ -766,7 +767,7 @@ tree-sitter-languages==1.10.2
     # via -r requirements-constraints.txt
 tsmoothie==1.0.5
     # via -r requirements-constraints.txt
-typer==0.15.1
+typer==0.15.2
     # via chromadb
 types-colorama==0.4.15.12
     # via -r requirements-constraints.txt


### PR DESCRIPTION
Storing NaN in DB results in redash issues. So switching to a low float value instead.