### PR TITLE
fix(anomaly detection): Coordinate Prophet Test Timestamps

### DIFF
--- a/tests/seer/anomaly_detection/test_cleanup_and_predict_tasks.py
+++ b/tests/seer/anomaly_detection/test_cleanup_and_predict_tasks.py
@@ -272,6 +272,9 @@ class TestCleanupTasks(unittest.TestCase):
             )
             assert alert is not None
 
+            for prediction in prophet_predictions:
+                print(prediction.timestamp)
+
             new_predictions = [
                 prediction.timestamp
                 for prediction in alert.prophet_predictions
@@ -279,6 +282,7 @@ class TestCleanupTasks(unittest.TestCase):
             ]
 
             assert len(new_predictions) == (36 * (60 // config.time_period))
+            assert 1 / 0
 
     def test_cleanup_disabled_alerts(self):
         # Create and save alerts with old points

--- a/tests/seer/anomaly_detection/test_cleanup_and_predict_tasks.py
+++ b/tests/seer/anomaly_detection/test_cleanup_and_predict_tasks.py
@@ -94,11 +94,15 @@ class TestCleanupTasks(unittest.TestCase):
         return external_alert_id, config, points, anomalies, cur_ts
 
     def _save_prophet_predictions(
-        self, external_alert_id: int, num_points_old: int, num_points_new: int
+        self,
+        external_alert_id: int,
+        num_points_old: int,
+        num_points_new: int,
+        first_timestamp: float = None,
     ):
 
-        cur_ts = datetime.now().timestamp()
-        past_ts = (datetime.now() - timedelta(days=200)).timestamp()
+        cur_ts = first_timestamp if first_timestamp else datetime.now().timestamp()
+        past_ts = (datetime.fromtimestamp(first_timestamp) - timedelta(days=200)).timestamp()
 
         # Strip the timestamp to the minute
         cur_ts = int(cur_ts / 60) * 60
@@ -178,7 +182,11 @@ class TestCleanupTasks(unittest.TestCase):
         # Create and save alert with 2000 points (1000 old, 1000 new)
         external_alert_id, config, points, anomalies, _ = self._save_alert(0, 1000, 1000)
 
-        external_alert_id, prophet_predictions = self._save_prophet_predictions(0, 1000, 0)
+        first_timestamp = points[0].timestamp
+
+        external_alert_id, prophet_predictions = self._save_prophet_predictions(
+            0, 1000, 0, first_timestamp
+        )
 
         points_new = points[1000:]
         ts_new = TimeSeries(
@@ -259,7 +267,10 @@ class TestCleanupTasks(unittest.TestCase):
     def test_make_prophet_predictions(self):
         # Create and save alert with 6 points (3 old, 3 new)
         external_alert_id, config, points, anomalies, cur_timestamp = self._save_alert(777, 4800, 1)
-        external_alert_id, prophet_predictions = self._save_prophet_predictions(777, 0, 6)
+        first_timestamp = points[0].timestamp
+        external_alert_id, prophet_predictions = self._save_prophet_predictions(
+            777, 0, 6, first_timestamp
+        )
 
         date_threshold = (datetime.now() - timedelta(days=28)).timestamp()
         cleanup_timeseries_and_predict(external_alert_id, date_threshold)
@@ -289,7 +300,6 @@ class TestCleanupTasks(unittest.TestCase):
             ]
 
             assert len(new_predictions) == (36 * (60 // config.time_period))
-            assert 1 / 0
 
     def test_cleanup_disabled_alerts(self):
         # Create and save alerts with old points

--- a/tests/seer/anomaly_detection/test_cleanup_and_predict_tasks.py
+++ b/tests/seer/anomaly_detection/test_cleanup_and_predict_tasks.py
@@ -258,8 +258,8 @@ class TestCleanupTasks(unittest.TestCase):
 
     def test_make_prophet_predictions(self):
         # Create and save alert with 6 points (3 old, 3 new)
-        external_alert_id, config, points, anomalies, cur_timestamp = self._save_alert(0, 4800, 1)
-        external_alert_id, prophet_predictions = self._save_prophet_predictions(0, 0, 6)
+        external_alert_id, config, points, anomalies, cur_timestamp = self._save_alert(777, 4800, 1)
+        external_alert_id, prophet_predictions = self._save_prophet_predictions(777, 0, 6)
 
         date_threshold = (datetime.now() - timedelta(days=28)).timestamp()
         cleanup_timeseries_and_predict(external_alert_id, date_threshold)

--- a/tests/seer/anomaly_detection/test_cleanup_and_predict_tasks.py
+++ b/tests/seer/anomaly_detection/test_cleanup_and_predict_tasks.py
@@ -272,8 +272,15 @@ class TestCleanupTasks(unittest.TestCase):
             )
             assert alert is not None
 
+            print("------------ prophet predictions ------------")
             for prediction in prophet_predictions:
                 print(prediction.timestamp)
+            print("---------------------------------------------")
+
+            print("------------ alert prophet predictions ------------")
+            for prediction in alert.prophet_predictions:
+                print(prediction.timestamp)
+            print("---------------------------------------------")
 
             new_predictions = [
                 prediction.timestamp

--- a/tests/seer/anomaly_detection/test_cleanup_and_predict_tasks.py
+++ b/tests/seer/anomaly_detection/test_cleanup_and_predict_tasks.py
@@ -283,16 +283,6 @@ class TestCleanupTasks(unittest.TestCase):
             )
             assert alert is not None
 
-            print("------------ prophet predictions ------------")
-            for prediction in prophet_predictions:
-                print(prediction.timestamp)
-            print("---------------------------------------------")
-
-            print("------------ alert prophet predictions ------------")
-            for prediction in alert.prophet_predictions:
-                print(prediction.timestamp)
-            print("---------------------------------------------")
-
             new_predictions = [
                 prediction.timestamp
                 for prediction in alert.prophet_predictions


### PR DESCRIPTION
- Coordinate timestamps so that predictions and what is in the database are aligned and do not desync when predictions are being upserted into db
- Previously, test would flake because timestamps created right near the end of the minute would not be synced with values being pushed into the table right after the minute. Therefore, records would be off by 1 minute and would insert all the new values rather than updating because of the time desync