### PR TITLE
fix(autofix): Stricter fuzzy matcher for more reliable diff application

### DIFF
--- a/src/seer/automation/autofix/components/coding/utils.py
+++ b/src/seer/automation/autofix/components/coding/utils.py
@@ -162,7 +162,7 @@ def task_to_file_change(
         result = find_original_snippet(
             chunk.original_chunk,
             file_content,
-            threshold=0.75,
+            threshold=0.90,
             initial_line_threshold=0.95,
         )
 

--- a/src/seer/automation/autofix/utils.py
+++ b/src/seer/automation/autofix/utils.py
@@ -76,18 +76,35 @@ def find_original_snippet(
             snippet_index = 0
 
             while actual_end < len(file_lines) and snippet_index < len(snippet_lines):
+                # Skip empty lines in the file but don't increment snippet_index
                 if not file_lines[actual_end].strip():
                     actual_end += 1
                     continue
 
-                if snippet_index == len(snippet_lines):
-                    break
+                # Skip empty lines in the snippet but don't increment actual_end
+                if not snippet_lines[snippet_index].strip():
+                    snippet_index += 1
+                    continue
 
-                actual_end += 1
-                snippet_index += 1
+                # Compare current lines
+                line_score = (
+                    fuzz.ratio(snippet_lines[snippet_index], file_lines[actual_end]) / 100.0
+                )
+                if line_score >= threshold:
+                    actual_end += 1
+                    snippet_index += 1
+                else:
+                    # If this line doesn't match well, try the next file line
+                    actual_end += 1
 
-            best_score = full_score
-            best_match = ("\n".join(file_lines[start_index:actual_end]), start_index, actual_end)
+            # Make sure we've matched all snippet lines
+            if snippet_index >= len(snippet_lines):
+                best_score = full_score
+                best_match = (
+                    "\n".join(file_lines[start_index:actual_end]),
+                    start_index,
+                    actual_end,
+                )
 
     return best_match
 

--- a/tests/automation/autofix/test_autofix_utils.py
+++ b/tests/automation/autofix/test_autofix_utils.py
@@ -68,14 +68,14 @@ class TestFindOriginalSnippet(unittest.TestCase):
         file_contents = textwrap.dedent(
             """\
             def example_function():
-                print('Hello world!')  # Missing comma
+                print('Hello world!')
 
             def unrelated_function():
                 pass
             """
-        )
+        )  # missing comma
         expected_result = (
-            "def example_function():\n    print('Hello world!')  # Missing comma",
+            "def example_function():\n    print('Hello world!')",
             0,
             2,
         )


### PR DESCRIPTION
This hopefully fixes the issue where the diff application looks completely glitched. My hypothesis from the examples I looked at was that it was replacing snippets in the wrong location, so a stricter matching process should fix it. This is also ok because our diff output from the coding step is nearly perfect in accuracy, so we don't need to be as "fuzzy" as we used to.