### PR TITLE
feat(anomaly detection): MP Override

### DIFF
--- a/src/seer/anomaly_detection/accessors.py
+++ b/src/seer/anomaly_detection/accessors.py
@@ -191,7 +191,6 @@ class DbAlertDataAccessor(AlertDataAccessor):
             if prophet_timestamp > cur_ts:
                 num_predictions_remaining += 1
 
-        # print(confidence_levels)
         anomalies = MPTimeSeriesAnomalies(
             flags=flags,
             scores=scores,

--- a/src/seer/anomaly_detection/accessors.py
+++ b/src/seer/anomaly_detection/accessors.py
@@ -169,8 +169,9 @@ class DbAlertDataAccessor(AlertDataAccessor):
                         ]
                     )
 
-                if i >= n_points - len(algo_data.get("original_flags", [])):
-                    original_flags[i] = algo_data["original_flag"]
+                point_original_flag = algo_data.get("original_flag")
+                if point_original_flag is not None and i >= n_points - len(point_original_flag):
+                    original_flags[i] = point_original_flag
                     use_suss[i] = algo_data["use_suss"]
                     confidence_levels[i] = algo_data["confidence_level"]
             if ts[i] < timestamp_threshold:

--- a/src/seer/anomaly_detection/accessors.py
+++ b/src/seer/anomaly_detection/accessors.py
@@ -173,7 +173,9 @@ class DbAlertDataAccessor(AlertDataAccessor):
                 if point_original_flag is not None and i >= n_points - len(point_original_flag):
                     original_flags[i] = point_original_flag
                     use_suss[i] = algo_data["use_suss"]
-                    confidence_levels[i] = algo_data["confidence_level"]
+                    confidence_levels[i] = (
+                        algo_data.get("confidence_level") or ConfidenceLevel.MEDIUM
+                    )  # Default to medium for backwards compatibility
             if ts[i] < timestamp_threshold:
                 num_old_points += 1
 
@@ -189,6 +191,7 @@ class DbAlertDataAccessor(AlertDataAccessor):
             if prophet_timestamp > cur_ts:
                 num_predictions_remaining += 1
 
+        # print(confidence_levels)
         anomalies = MPTimeSeriesAnomalies(
             flags=flags,
             scores=scores,

--- a/src/seer/anomaly_detection/anomaly_detection.py
+++ b/src/seer/anomaly_detection/anomaly_detection.py
@@ -408,6 +408,7 @@ class AnomalyDetection(BaseModel):
             matrix_profile=np.array([]),
             window_size=100,
             original_flags=[],
+            confidence_levels=[],
         )
         initial_history = True
         while len(current.values) > 0:
@@ -434,6 +435,7 @@ class AnomalyDetection(BaseModel):
                     matrix_profile=historic_anomalies.matrix_profile[-trim_current_by:],
                     window_size=historic_anomalies.window_size,
                     original_flags=historic_anomalies.original_flags[-trim_current_by:],
+                    confidence_levels=historic_anomalies.confidence_levels[-trim_current_by:],
                 )
                 initial_history = False
 
@@ -477,6 +479,7 @@ class AnomalyDetection(BaseModel):
             matrix_profile=agg_streamed_anomalies.matrix_profile[-orig_curr_len:],
             window_size=agg_streamed_anomalies.window_size,
             original_flags=agg_streamed_anomalies.original_flags[-orig_curr_len:],
+            confidence_levels=agg_streamed_anomalies.confidence_levels[-orig_curr_len:],
         )
 
         converted_anomalies = DbAlertDataAccessor().combine_anomalies(

--- a/src/seer/anomaly_detection/detectors/anomaly_detectors.py
+++ b/src/seer/anomaly_detection/detectors/anomaly_detectors.py
@@ -166,6 +166,7 @@ class MPBatchAnomalyDetector(AnomalyDetector):
             window_size=window_size,
             thresholds=flags_and_scores.thresholds if algo_config.return_thresholds else None,
             original_flags=original_flags,
+            confidence_levels=flags_and_scores.confidence_levels,
         )
 
 
@@ -313,4 +314,5 @@ class MPStreamAnomalyDetector(AnomalyDetector):
                 window_size=self.window_size,
                 thresholds=thresholds if algo_config.return_thresholds else None,
                 original_flags=self.original_flags,
+                confidence_levels=flags_and_scores.confidence_levels,
             )

--- a/src/seer/anomaly_detection/detectors/anomaly_scorer.py
+++ b/src/seer/anomaly_detection/detectors/anomaly_scorer.py
@@ -16,6 +16,7 @@ from seer.anomaly_detection.models import (
     AlgoConfig,
     AnomalyDetectionConfig,
     AnomalyFlags,
+    ConfidenceLevel,
     Directions,
 )
 from seer.dependency_injection import inject, injected
@@ -256,7 +257,7 @@ class CombinedAnomalyScorer(AnomalyScorer):
                         flags.append("anomaly_higher_confidence")
                     elif prophet_score >= 2.0:
                         flags.append(prophet_flag)
-                    elif mp_confidence_level == "high":
+                    elif mp_confidence_level == ConfidenceLevel.HIGH:
                         flags.append(mp_flag)
                     else:
                         flags.append("none")

--- a/src/seer/anomaly_detection/detectors/anomaly_scorer.py
+++ b/src/seer/anomaly_detection/detectors/anomaly_scorer.py
@@ -125,7 +125,6 @@ class CombinedAnomalyScorer(AnomalyScorer):
         df_prophet_scores = self.prophet_scorer.batch_score(prophet_df)
         combined = self._merge_prophet_mp_results(
             timestamps=timestamps,
-            mp_distances=mp_dist,
             mp_flags_and_scores=mp_flags_and_scores,
             prophet_predictions=df_prophet_scores,
             ad_config=ad_config,
@@ -185,7 +184,6 @@ class CombinedAnomalyScorer(AnomalyScorer):
 
         combined = self._merge_prophet_mp_results(
             timestamps=np.array([np.float64(streamed_timestamp)]),
-            mp_distances=np.array([np.float64(streamed_mp_dist)]),
             mp_flags_and_scores=mp_flags_and_scores,
             prophet_predictions=df_prophet_scores,
             ad_config=ad_config,
@@ -219,28 +217,22 @@ class CombinedAnomalyScorer(AnomalyScorer):
     def _merge_prophet_mp_results(
         self,
         timestamps: np.ndarray,
-        mp_distances: np.ndarray,
         mp_flags_and_scores: FlagsAndScores,
         prophet_predictions: pd.DataFrame,
         ad_config: AnomalyDetectionConfig,
     ) -> FlagsAndScores:
 
         # todo: return prophet thresholds
-        def merge(timestamps, mp_distances, mp_flags_and_scores, prophet_map):
+        def merge(timestamps, mp_flags_and_scores, prophet_map):
             mp_flags = mp_flags_and_scores.flags
-            mp_thresholds = [thresh.upper for thresh in mp_flags_and_scores.thresholds[0]]
+            mp_confidence_levels = mp_flags_and_scores.confidence_levels
             flags = []
             missing = 0
             found = 0
             previous_mp_flag: AnomalyFlags = "none"
             missing_timestamps = []
-
-            # In the batch case, we only get 1 threshold so we need to ensure we have correct sizing
-            if len(mp_thresholds) < len(mp_distances):
-                mp_thresholds.extend([mp_thresholds[-1]] * (len(mp_distances) - len(mp_thresholds)))
-
-            for timestamp, mp_flag, mp_threshold, mp_distance in zip(
-                timestamps, mp_flags, mp_thresholds, mp_distances
+            for timestamp, mp_flag, mp_confidence_level in zip(
+                timestamps, mp_flags, mp_confidence_levels
             ):
                 pd_dt = float(timestamp)
                 if pd_dt in prophet_map["flag"]:
@@ -264,7 +256,7 @@ class CombinedAnomalyScorer(AnomalyScorer):
                         flags.append("anomaly_higher_confidence")
                     elif prophet_score >= 2.0:
                         flags.append(prophet_flag)
-                    elif mp_distance >= mp_threshold * 2.0:
+                    elif mp_confidence_level == "high":
                         flags.append(mp_flag)
                     else:
                         flags.append("none")
@@ -298,10 +290,11 @@ class CombinedAnomalyScorer(AnomalyScorer):
         prophet_predictions_map = prophet_predictions.set_index("ds")[
             ["flag", "score", "y", "yhat", "yhat_lower", "yhat_upper"]
         ].to_dict()
-        flags = merge(timestamps, mp_distances, mp_flags_and_scores, prophet_predictions_map)
+        flags = merge(timestamps, mp_flags_and_scores, prophet_predictions_map)
 
         return FlagsAndScores(
             flags=flags,
             scores=mp_flags_and_scores.scores,
             thresholds=mp_flags_and_scores.thresholds,
+            confidence_levels=mp_flags_and_scores.confidence_levels,
         )

--- a/src/seer/anomaly_detection/detectors/mp_boxcox_scorer.py
+++ b/src/seer/anomaly_detection/detectors/mp_boxcox_scorer.py
@@ -13,6 +13,7 @@ from seer.anomaly_detection.models import (
     AlgoConfig,
     AnomalyDetectionConfig,
     AnomalyFlags,
+    ConfidenceLevel,
     Sensitivities,
     Threshold,
     ThresholdType,
@@ -160,7 +161,9 @@ class MPBoxCoxScorer(MPScorer):
             if std != 0 and not np.isnan(score) and score > threshold:
                 flag = "anomaly_higher_confidence"
 
-            confidence_level = "high" if score >= threshold * 2 else "medium"
+            confidence_level = (
+                ConfidenceLevel.HIGH if score >= threshold * 2 else ConfidenceLevel.MEDIUM
+            )
             cur_thresholds = [
                 Threshold(
                     type=ThresholdType.BOX_COX_THRESHOLD,
@@ -208,7 +211,9 @@ class MPBoxCoxScorer(MPScorer):
             if std == 0 or np.isnan(score) or score <= threshold
             else "anomaly_higher_confidence"
         )
-        confidence_level = "high" if score >= threshold * 2 else "medium"
+        confidence_level = (
+            ConfidenceLevel.HIGH if score >= threshold * 2 else ConfidenceLevel.MEDIUM
+        )
         thresholds: List[Threshold] = [
             Threshold(
                 type=ThresholdType.BOX_COX_THRESHOLD,

--- a/src/seer/anomaly_detection/detectors/mp_boxcox_scorer.py
+++ b/src/seer/anomaly_detection/detectors/mp_boxcox_scorer.py
@@ -139,6 +139,7 @@ class MPBoxCoxScorer(MPScorer):
         scores = []
         flags = []
         thresholds = []
+        confidence_levels = []
         time_allocated = datetime.timedelta(milliseconds=time_budget_ms) if time_budget_ms else None
         time_start = datetime.datetime.now()
         batch_size = 10 if len(mp_dist) > 10 else 1
@@ -158,6 +159,8 @@ class MPBoxCoxScorer(MPScorer):
 
             if std != 0 and not np.isnan(score) and score > threshold:
                 flag = "anomaly_higher_confidence"
+
+            confidence_level = "high" if score >= threshold * 2 else "medium"
             cur_thresholds = [
                 Threshold(
                     type=ThresholdType.BOX_COX_THRESHOLD,
@@ -173,8 +176,10 @@ class MPBoxCoxScorer(MPScorer):
             flags.append(flag)
             cur_thresholds.extend(location_thresholds)
             thresholds.append(cur_thresholds)
-
-        return FlagsAndScores(flags=flags, scores=scores, thresholds=thresholds)
+            confidence_levels.append(confidence_level)
+        return FlagsAndScores(
+            flags=flags, scores=scores, thresholds=thresholds, confidence_levels=confidence_levels
+        )
 
     @inject
     def stream_score(
@@ -203,6 +208,7 @@ class MPBoxCoxScorer(MPScorer):
             if std == 0 or np.isnan(score) or score <= threshold
             else "anomaly_higher_confidence"
         )
+        confidence_level = "high" if score >= threshold * 2 else "medium"
         thresholds: List[Threshold] = [
             Threshold(
                 type=ThresholdType.BOX_COX_THRESHOLD,
@@ -217,4 +223,5 @@ class MPBoxCoxScorer(MPScorer):
             flags=[flag],
             scores=[score],
             thresholds=[thresholds],
+            confidence_levels=[confidence_level],
         )

--- a/src/seer/anomaly_detection/detectors/mp_scorers.py
+++ b/src/seer/anomaly_detection/detectors/mp_scorers.py
@@ -11,6 +11,7 @@ from seer.anomaly_detection.models import (
     AlgoConfig,
     AnomalyDetectionConfig,
     AnomalyFlags,
+    ConfidenceLevel,
     Sensitivities,
     Threshold,
     ThresholdType,
@@ -26,7 +27,7 @@ class FlagsAndScores(BaseModel):
     flags: List[AnomalyFlags]
     scores: List[float]
     thresholds: List[List[Threshold]]
-    confidence_levels: List[str]
+    confidence_levels: List[ConfidenceLevel]
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -154,7 +155,9 @@ class MPLowVarianceScorer(MPScorer):
                     )
                 ]
             )
-            confidence_levels.append("medium")  # Default to medium confidence for low variance
+            confidence_levels.append(
+                ConfidenceLevel.MEDIUM
+            )  # Default to medium confidence for low variance
         return FlagsAndScores(
             flags=flags, scores=scores, thresholds=thresholds, confidence_levels=confidence_levels
         )
@@ -189,5 +192,5 @@ class MPLowVarianceScorer(MPScorer):
             flags=[flag],
             scores=[score],
             thresholds=[[threshold]],
-            confidence_levels=["medium"],  # Default to medium for low variance
+            confidence_levels=[ConfidenceLevel.MEDIUM],  # Default to medium for low variance
         )

--- a/src/seer/anomaly_detection/detectors/mp_scorers.py
+++ b/src/seer/anomaly_detection/detectors/mp_scorers.py
@@ -26,6 +26,7 @@ class FlagsAndScores(BaseModel):
     flags: List[AnomalyFlags]
     scores: List[float]
     thresholds: List[List[Threshold]]
+    confidence_levels: List[str]
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -133,6 +134,7 @@ class MPLowVarianceScorer(MPScorer):
         scores = []
         flags = []
         thresholds = []
+        confidence_levels = []
         if values.std() > self.std_threshold:
             sentry_sdk.set_tag(AnomalyDetectionTags.LOW_VARIATION_TS, 0)
             return None
@@ -152,7 +154,10 @@ class MPLowVarianceScorer(MPScorer):
                     )
                 ]
             )
-        return FlagsAndScores(flags=flags, scores=scores, thresholds=thresholds)
+            confidence_levels.append("medium")  # Default to medium confidence for low variance
+        return FlagsAndScores(
+            flags=flags, scores=scores, thresholds=thresholds, confidence_levels=confidence_levels
+        )
 
     @inject
     def stream_score(
@@ -184,4 +189,5 @@ class MPLowVarianceScorer(MPScorer):
             flags=[flag],
             scores=[score],
             thresholds=[[threshold]],
+            confidence_levels=["medium"],  # Default to medium for low variance
         )

--- a/src/seer/anomaly_detection/models/__init__.py
+++ b/src/seer/anomaly_detection/models/__init__.py
@@ -23,3 +23,4 @@ Seasonalities = external.Seasonalities
 Threshold = timeseries_anomalies.Threshold
 ThresholdType = timeseries_anomalies.ThresholdType
 ProphetPrediction = timeseries.ProphetPrediction
+ConfidenceLevel = timeseries_anomalies.ConfidenceLevel

--- a/src/seer/anomaly_detection/models/timeseries_anomalies.py
+++ b/src/seer/anomaly_detection/models/timeseries_anomalies.py
@@ -10,6 +10,12 @@ from pydantic import BaseModel, ConfigDict, Field
 logger = logging.getLogger(__name__)
 
 
+class ConfidenceLevel(Enum):
+    LOW = 1
+    MEDIUM = 2
+    HIGH = 3
+
+
 class ThresholdType(Enum):
     TREND = 1
     PREDICTION = 2

--- a/src/seer/anomaly_detection/models/timeseries_anomalies.py
+++ b/src/seer/anomaly_detection/models/timeseries_anomalies.py
@@ -206,7 +206,7 @@ class MPTimeSeriesAnomalies(TimeSeriesAnomalies):
                     "r_idx": r_index_fixed,
                 }
             original_flag = self.original_flags[i] if i < len(self.original_flags) else "none"
-            use_suss = self.use_suss[len(self.use_suss) - front_pad_to_len + i]
+            use_suss = True  # Default to true since we are only using SuSS window
             confidence_level = (
                 self.confidence_levels[i]
                 if i < len(self.confidence_levels)

--- a/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
+++ b/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
@@ -13,7 +13,11 @@ from seer.anomaly_detection.detectors.anomaly_detectors import (
     MPBatchAnomalyDetector,
     MPStreamAnomalyDetector,
 )
-from seer.anomaly_detection.models import AlgoConfig, MPTimeSeriesAnomaliesSingleWindow
+from seer.anomaly_detection.models import (
+    AlgoConfig,
+    ConfidenceLevel,
+    MPTimeSeriesAnomaliesSingleWindow,
+)
 from seer.anomaly_detection.models.external import AnomalyDetectionConfig
 from seer.anomaly_detection.models.timeseries import TimeSeries
 from seer.exceptions import ServerError
@@ -52,7 +56,12 @@ class TestMPBatchAnomalyDetector(unittest.TestCase):
                 scores=[0.1, 6.5, 4.8, 0.2],
                 flags=["none", "anomaly_higher_confidence", "anomaly_higher_confidence", "none"],
                 thresholds=[],
-                confidence_levels=["medium", "medium", "medium", "medium"],
+                confidence_levels=[
+                    ConfidenceLevel.MEDIUM,
+                    ConfidenceLevel.MEDIUM,
+                    ConfidenceLevel.MEDIUM,
+                    ConfidenceLevel.MEDIUM,
+                ],
             )
         )
 
@@ -182,7 +191,7 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
         mock_utils.get_mp_dist_from_mp.return_value = np.array([0.1, 0.2])
 
         mock_scorer.stream_score.return_value = FlagsAndScores(
-            scores=[0.5], flags=["none"], thresholds=[], confidence_levels=["medium"]
+            scores=[0.5], flags=["none"], thresholds=[], confidence_levels=[ConfidenceLevel.MEDIUM]
         )
 
         anomalies = self.detector.detect(

--- a/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
+++ b/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
@@ -52,6 +52,7 @@ class TestMPBatchAnomalyDetector(unittest.TestCase):
                 scores=[0.1, 6.5, 4.8, 0.2],
                 flags=["none", "anomaly_higher_confidence", "anomaly_higher_confidence", "none"],
                 thresholds=[],
+                confidence_levels=["medium", "medium", "medium", "medium"],
             )
         )
 
@@ -181,7 +182,7 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
         mock_utils.get_mp_dist_from_mp.return_value = np.array([0.1, 0.2])
 
         mock_scorer.stream_score.return_value = FlagsAndScores(
-            scores=[0.5], flags=["none"], thresholds=[]
+            scores=[0.5], flags=["none"], thresholds=[], confidence_levels=["medium"]
         )
 
         anomalies = self.detector.detect(

--- a/tests/seer/anomaly_detection/detectors/test_anomaly_scorer.py
+++ b/tests/seer/anomaly_detection/detectors/test_anomaly_scorer.py
@@ -32,6 +32,7 @@ class TestCombinedAnomalyScorer:
                 ]
                 * 3
             ],
+            confidence_levels=["medium", "medium", "medium"],
         )
 
     @pytest.fixture
@@ -393,6 +394,7 @@ class TestCombinedAnomalyScorer:
                 ]
                 * 3
             ],
+            confidence_levels=["medium", "high", "medium"],
         )
         # Test merging MP and Prophet results
         timestamps = np.array(
@@ -417,7 +419,6 @@ class TestCombinedAnomalyScorer:
 
         result = scorer._merge_prophet_mp_results(
             timestamps=timestamps,
-            mp_distances=np.array([0.0, 2.0, 0.0]),
             mp_flags_and_scores=mp_flags_and_scores,
             prophet_predictions=prophet_predictions,
             ad_config=ad_config,
@@ -449,6 +450,7 @@ class TestCombinedAnomalyScorer:
                 ]
                 * 3
             ],
+            confidence_levels=["medium", "medium", "medium"],
         )
         # Test merging MP and Prophet results
         timestamps = np.array(
@@ -473,7 +475,6 @@ class TestCombinedAnomalyScorer:
 
         result = scorer._merge_prophet_mp_results(
             timestamps=timestamps,
-            mp_distances=np.array([0.0, 0.0, 0.0]),
             mp_flags_and_scores=mp_flags_and_scores,
             prophet_predictions=prophet_predictions,
             ad_config=ad_config,
@@ -505,6 +506,7 @@ class TestCombinedAnomalyScorer:
                 ]
                 * 3
             ],
+            confidence_levels=["high", "high", "high"],
         )
         # Test merging MP and Prophet results
         timestamps = np.array(
@@ -529,7 +531,6 @@ class TestCombinedAnomalyScorer:
 
         result = scorer._merge_prophet_mp_results(
             timestamps=timestamps,
-            mp_distances=np.array([0.0, 0.0, 0.0]),
             mp_flags_and_scores=mp_flags_and_scores,
             prophet_predictions=prophet_predictions,
             ad_config=ad_config,
@@ -561,6 +562,7 @@ class TestCombinedAnomalyScorer:
                 ]
                 * 3
             ],
+            confidence_levels=["medium", "high", "medium"],
         )
 
         # Test merging MP and Prophet results
@@ -586,7 +588,6 @@ class TestCombinedAnomalyScorer:
 
         result = scorer._merge_prophet_mp_results(
             timestamps=timestamps,
-            mp_distances=np.array([0.0, 0.0, 0.0]),
             mp_flags_and_scores=mp_flags_and_scores,
             prophet_predictions=prophet_predictions,
             ad_config=ad_config,

--- a/tests/seer/anomaly_detection/detectors/test_anomaly_scorer.py
+++ b/tests/seer/anomaly_detection/detectors/test_anomaly_scorer.py
@@ -417,6 +417,7 @@ class TestCombinedAnomalyScorer:
 
         result = scorer._merge_prophet_mp_results(
             timestamps=timestamps,
+            mp_distances=np.array([0.0, 0.0, 0.0]),
             mp_flags_and_scores=mp_flags_and_scores,
             prophet_predictions=prophet_predictions,
             ad_config=ad_config,
@@ -472,6 +473,7 @@ class TestCombinedAnomalyScorer:
 
         result = scorer._merge_prophet_mp_results(
             timestamps=timestamps,
+            mp_distances=np.array([0.0, 0.0, 0.0]),
             mp_flags_and_scores=mp_flags_and_scores,
             prophet_predictions=prophet_predictions,
             ad_config=ad_config,
@@ -528,6 +530,7 @@ class TestCombinedAnomalyScorer:
 
         result = scorer._merge_prophet_mp_results(
             timestamps=timestamps,
+            mp_distances=np.array([0.0, 0.0, 0.0]),
             mp_flags_and_scores=mp_flags_and_scores,
             prophet_predictions=prophet_predictions,
             ad_config=ad_config,

--- a/tests/seer/anomaly_detection/detectors/test_anomaly_scorer.py
+++ b/tests/seer/anomaly_detection/detectors/test_anomaly_scorer.py
@@ -9,6 +9,7 @@ from seer.anomaly_detection.detectors.mp_scorers import FlagsAndScores
 from seer.anomaly_detection.models import (
     AlgoConfig,
     AnomalyDetectionConfig,
+    ConfidenceLevel,
     Threshold,
     ThresholdType,
 )
@@ -32,7 +33,11 @@ class TestCombinedAnomalyScorer:
                 ]
                 * 3
             ],
-            confidence_levels=["medium", "medium", "medium"],
+            confidence_levels=[
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+            ],
         )
 
     @pytest.fixture
@@ -394,7 +399,11 @@ class TestCombinedAnomalyScorer:
                 ]
                 * 3
             ],
-            confidence_levels=["medium", "high", "medium"],
+            confidence_levels=[
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.HIGH,
+                ConfidenceLevel.MEDIUM,
+            ],
         )
         # Test merging MP and Prophet results
         timestamps = np.array(
@@ -450,7 +459,11 @@ class TestCombinedAnomalyScorer:
                 ]
                 * 3
             ],
-            confidence_levels=["medium", "medium", "medium"],
+            confidence_levels=[
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+            ],
         )
         # Test merging MP and Prophet results
         timestamps = np.array(
@@ -506,7 +519,11 @@ class TestCombinedAnomalyScorer:
                 ]
                 * 3
             ],
-            confidence_levels=["high", "high", "high"],
+            confidence_levels=[
+                ConfidenceLevel.HIGH,
+                ConfidenceLevel.HIGH,
+                ConfidenceLevel.HIGH,
+            ],
         )
         # Test merging MP and Prophet results
         timestamps = np.array(
@@ -562,7 +579,11 @@ class TestCombinedAnomalyScorer:
                 ]
                 * 3
             ],
-            confidence_levels=["medium", "high", "medium"],
+            confidence_levels=[
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.HIGH,
+                ConfidenceLevel.MEDIUM,
+            ],
         )
 
         # Test merging MP and Prophet results

--- a/tests/seer/anomaly_detection/detectors/test_anomaly_scorer.py
+++ b/tests/seer/anomaly_detection/detectors/test_anomaly_scorer.py
@@ -403,7 +403,7 @@ class TestCombinedAnomalyScorer:
             {
                 "ds": timestamps,
                 "flag": ["none", "none", "none"],
-                "score": [0.5, 2.5, 0.3],
+                "score": [0.5, 0.2, 0.3],
                 "y": [10.0, 10.0, 15.0],
                 "yhat": [11.0, 12.0, 14.0],
                 "yhat_lower": [9.0, 10.0, 12.0],
@@ -427,8 +427,8 @@ class TestCombinedAnomalyScorer:
         assert isinstance(result, FlagsAndScores)
         assert len(result.flags) == 3
 
-        # For the second point, both MP and Prophet have high confidence anomalies
-        assert result.flags[1] == "none"
+        # For the seconde point, MP should override Prophet
+        assert result.flags[1] == "anomaly_higher_confidence"
 
     def test_prophet_negative_overrides_mp(
         self,

--- a/tests/seer/anomaly_detection/models/test_timeseries.py
+++ b/tests/seer/anomaly_detection/models/test_timeseries.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy as np
 
+from seer.anomaly_detection.models import ConfidenceLevel
 from seer.anomaly_detection.models.timeseries import MPTimeSeries
 from seer.anomaly_detection.models.timeseries_anomalies import MPTimeSeriesAnomalies
 
@@ -21,6 +22,9 @@ class TestTimeSeries(unittest.TestCase):
                 thresholds=[],
                 original_flags=["none"],
                 use_suss=[True],
+                confidence_levels=[
+                    ConfidenceLevel.MEDIUM,
+                ],
             ),
         )
 

--- a/tests/seer/anomaly_detection/models/test_timeseries_anomalies.py
+++ b/tests/seer/anomaly_detection/models/test_timeseries_anomalies.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy as np
 
+from seer.anomaly_detection.models import ConfidenceLevel
 from seer.anomaly_detection.models.timeseries_anomalies import MPTimeSeriesAnomalies
 
 
@@ -17,6 +18,10 @@ class TestConverters(unittest.TestCase):
             thresholds=[],
             original_flags=["none", "none"],
             use_suss=[True, True],
+            confidence_levels=[
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+            ],
         )
 
     def test_get_anomaly_algo_data_with_padding(self):
@@ -31,12 +36,14 @@ class TestConverters(unittest.TestCase):
                 "mp_fixed": {"dist": 0.2, "idx": 1, "l_idx": 2, "r_idx": 3},
                 "original_flag": "none",
                 "use_suss": True,
+                "confidence_level": ConfidenceLevel.MEDIUM,
             },
             {
                 "mp_suss": {"dist": 0.3, "idx": 1, "l_idx": 2, "r_idx": 3},
                 "mp_fixed": {"dist": 0.4, "idx": 2, "l_idx": 3, "r_idx": 4},
                 "original_flag": "none",
                 "use_suss": True,
+                "confidence_level": ConfidenceLevel.MEDIUM,
             },
         ]
 
@@ -53,12 +60,14 @@ class TestConverters(unittest.TestCase):
                 "mp_fixed": {"dist": 0.2, "idx": 1, "l_idx": 2, "r_idx": 3},
                 "original_flag": "none",
                 "use_suss": True,
+                "confidence_level": ConfidenceLevel.MEDIUM,
             },
             {
                 "mp_suss": {"dist": 0.3, "idx": 1, "l_idx": 2, "r_idx": 3},
                 "mp_fixed": {"dist": 0.4, "idx": 2, "l_idx": 3, "r_idx": 4},
                 "original_flag": "none",
                 "use_suss": True,
+                "confidence_level": ConfidenceLevel.MEDIUM,
             },
         ]
 

--- a/tests/seer/anomaly_detection/test_accessors.py
+++ b/tests/seer/anomaly_detection/test_accessors.py
@@ -1,5 +1,6 @@
 import unittest
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 
@@ -13,7 +14,13 @@ from seer.anomaly_detection.models import (
     ThresholdType,
 )
 from seer.anomaly_detection.models.external import AnomalyDetectionConfig, TimeSeriesPoint
-from seer.db import DbDynamicAlert, DbProphetAlertTimeSeries, Session, TaskStatus
+from seer.db import (
+    DbDynamicAlert,
+    DbDynamicAlertTimeSeries,
+    DbProphetAlertTimeSeries,
+    Session,
+    TaskStatus,
+)
 
 
 class TestDbAlertDataAccessor(unittest.TestCase):
@@ -36,8 +43,6 @@ class TestDbAlertDataAccessor(unittest.TestCase):
             original_flags=["none", "none"],
             use_suss=[True, True],
             confidence_levels=[
-                ConfidenceLevel.MEDIUM,
-                ConfidenceLevel.MEDIUM,
                 ConfidenceLevel.MEDIUM,
                 ConfidenceLevel.MEDIUM,
             ],
@@ -721,3 +726,69 @@ class TestDbAlertDataAccessor(unittest.TestCase):
             "none",
         ]
         assert combined_anomalies.use_suss == [True, True, False, True]
+
+    @patch("seer.anomaly_detection.accessors.stumpy.mparray.mparray")
+    def test_hydrate_alert_sets_flags_from_algo_data(self, mock_mparray):
+        mock_mparray.return_value = np.array([])
+
+        db_alert = DbDynamicAlert(
+            organization_id=1,
+            project_id=2,
+            external_alert_id=3,
+            config={
+                "time_period": 15,
+                "sensitivity": "medium",
+                "direction": "both",
+                "expected_seasonality": "auto",
+            },
+            anomaly_algo_data={"window_size": 10},
+            prophet_predictions=[],
+            data_purge_flag="not_queued",
+            last_queued_at=None,
+        )
+
+        ts1 = DbDynamicAlertTimeSeries(
+            timestamp=datetime.now(),
+            value=1.0,
+            anomaly_type="none",
+            anomaly_score=0.0,
+            anomaly_algo_data=None,
+        )
+
+        ts2 = DbDynamicAlertTimeSeries(
+            timestamp=datetime.now(),
+            value=2.0,
+            anomaly_type="none",
+            anomaly_score=0.0,
+            anomaly_algo_data=None,
+        )
+
+        ts3 = DbDynamicAlertTimeSeries(
+            timestamp=datetime.now(),
+            value=3.0,
+            anomaly_type="spike",
+            anomaly_score=0.8,
+            anomaly_algo_data={
+                "mp_suss": {"dist": 0.2, "idx": 2, "l_idx": 1, "r_idx": 3},
+                "original_flag": "none",
+                "use_suss": True,
+                "confidence_level": ConfidenceLevel.HIGH,
+            },
+        )
+
+        db_alert.timeseries = [ts1, ts2, ts3]
+
+        mock_algo_config = MagicMock()
+
+        accessor = DbAlertDataAccessor()
+        result = accessor._hydrate_alert(db_alert, algo_config=mock_algo_config)
+
+        assert result.anomalies.original_flags[0] == "none"
+        assert result.anomalies.original_flags[1] == "none"
+        assert result.anomalies.use_suss[0]
+        assert result.anomalies.use_suss[1]
+        assert result.anomalies.confidence_levels[0] == ConfidenceLevel.MEDIUM
+        assert result.anomalies.confidence_levels[1] == ConfidenceLevel.MEDIUM
+
+        assert result.anomalies.use_suss[2]
+        assert result.anomalies.confidence_levels[2] == ConfidenceLevel.HIGH

--- a/tests/seer/anomaly_detection/test_accessors.py
+++ b/tests/seer/anomaly_detection/test_accessors.py
@@ -6,6 +6,7 @@ import numpy as np
 from seer.anomaly_detection.accessors import DbAlertDataAccessor
 from seer.anomaly_detection.models import (
     Anomaly,
+    ConfidenceLevel,
     MPTimeSeriesAnomalies,
     MPTimeSeriesAnomaliesSingleWindow,
     Threshold,
@@ -34,6 +35,12 @@ class TestDbAlertDataAccessor(unittest.TestCase):
             thresholds=[],
             original_flags=["none", "none"],
             use_suss=[True, True],
+            confidence_levels=[
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+            ],
         )
         # Verify saving
         alert_data_accessor = DbAlertDataAccessor()
@@ -186,6 +193,12 @@ class TestDbAlertDataAccessor(unittest.TestCase):
                 thresholds=[],
                 original_flags=["none"],
                 use_suss=[True],
+                confidence_levels=[
+                    ConfidenceLevel.MEDIUM,
+                    ConfidenceLevel.MEDIUM,
+                    ConfidenceLevel.MEDIUM,
+                    ConfidenceLevel.MEDIUM,
+                ],
             ),
             anomaly_algo_data={
                 "mp_suss": {"dist": 1.0, "idx": 10, "l_idx": -1, "r_idx": -1},
@@ -223,6 +236,12 @@ class TestDbAlertDataAccessor(unittest.TestCase):
                 thresholds=[],
                 original_flags=["none"],
                 use_suss=[True],
+                confidence_levels=[
+                    ConfidenceLevel.MEDIUM,
+                    ConfidenceLevel.MEDIUM,
+                    ConfidenceLevel.MEDIUM,
+                    ConfidenceLevel.MEDIUM,
+                ],
             ),
             anomaly_algo_data={"window_size": 1},
             data_purge_flag=TaskStatus.NOT_QUEUED,
@@ -305,6 +324,10 @@ class TestDbAlertDataAccessor(unittest.TestCase):
             thresholds=[],
             original_flags=["none"] * 700,
             use_suss=[True] * 700,
+            confidence_levels=[
+                ConfidenceLevel.MEDIUM,
+            ]
+            * 700,
         )
 
         alert_data_accessor = DbAlertDataAccessor()
@@ -358,6 +381,13 @@ class TestDbAlertDataAccessor(unittest.TestCase):
             thresholds=[],
             original_flags=["none", "none"],
             use_suss=[True, True],
+            confidence_levels=[
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+            ],
         )
 
         alert_data_accessor = DbAlertDataAccessor()
@@ -415,6 +445,10 @@ class TestDbAlertDataAccessor(unittest.TestCase):
             thresholds=[],
             original_flags=["none", "none"],
             use_suss=[True, True],
+            confidence_levels=[
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+            ],
         )
         alert_data_accessor = DbAlertDataAccessor()
         alert_data_accessor.save_alert(
@@ -467,6 +501,10 @@ class TestDbAlertDataAccessor(unittest.TestCase):
             thresholds=[],
             original_flags=["none", "none"],
             use_suss=[True, True],
+            confidence_levels=[
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+            ],
         )
         alert_data_accessor = DbAlertDataAccessor()
         alert_data_accessor.save_alert(
@@ -520,6 +558,10 @@ class TestDbAlertDataAccessor(unittest.TestCase):
             thresholds=[],
             original_flags=["none", "none"],
             use_suss=[True, True],
+            confidence_levels=[
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+            ],
         )
         alert_data_accessor = DbAlertDataAccessor()
         alert_data_accessor.save_alert(
@@ -566,6 +608,10 @@ class TestDbAlertDataAccessor(unittest.TestCase):
             thresholds=[],
             original_flags=["none", "none"],
             use_suss=[True, True],
+            confidence_levels=[
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+            ],
         )
         alert_data_accessor = DbAlertDataAccessor()
         alert_data_accessor.save_alert(
@@ -616,6 +662,12 @@ class TestDbAlertDataAccessor(unittest.TestCase):
                 "anomaly_higher_confidence",
                 "none",
             ],
+            confidence_levels=[
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+            ],
         )
         fixed_thresholds = [
             Threshold(type=ThresholdType.MP_DIST_IQR, timestamp=10.0, upper=1.0, lower=1.0),
@@ -633,6 +685,12 @@ class TestDbAlertDataAccessor(unittest.TestCase):
             window_size=10,
             thresholds=[fixed_thresholds],
             original_flags=["none", "none", "none", "none"],
+            confidence_levels=[
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+                ConfidenceLevel.MEDIUM,
+            ],
         )
 
         accessor = DbAlertDataAccessor()

--- a/tests/seer/anomaly_detection/test_anomaly_detection.py
+++ b/tests/seer/anomaly_detection/test_anomaly_detection.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 from seer.anomaly_detection.anomaly_detection import AnomalyDetection
 from seer.anomaly_detection.models import (
+    ConfidenceLevel,
     DynamicAlert,
     MPTimeSeries,
     MPTimeSeriesAnomaliesSingleWindow,
@@ -101,6 +102,7 @@ class TestAnomalyDetection(unittest.TestCase):
                     thresholds=[],
                     original_flags=[],
                     use_suss=[],
+                    confidence_levels=[],
                 ),
                 pd.DataFrame(
                     {
@@ -209,6 +211,10 @@ class TestAnomalyDetection(unittest.TestCase):
                 thresholds=[],
                 original_flags=np.array(["none"] * len(ts_timestamps)),
                 use_suss=np.array([True] * len(ts_timestamps)),
+                confidence_levels=[
+                    ConfidenceLevel.MEDIUM,
+                ]
+                * len(ts_timestamps),
             ),
             prophet_predictions=ProphetPrediction(
                 timestamps=np.array([]),
@@ -262,6 +268,10 @@ class TestAnomalyDetection(unittest.TestCase):
                 thresholds=[],
                 original_flags=np.array(["none"] * len(ts_timestamps[:100])),
                 use_suss=np.array([True] * len(ts_timestamps[:100])),
+                confidence_levels=[
+                    ConfidenceLevel.MEDIUM,
+                ]
+                * len(ts_timestamps[:100]),
             ),
             prophet_predictions=ProphetPrediction(
                 timestamps=np.array([]),
@@ -316,6 +326,10 @@ class TestAnomalyDetection(unittest.TestCase):
                 thresholds=[],
                 original_flags=["none"] * (len(ts_timestamps) - 1),  # One less than timestamps
                 use_suss=[True] * len(ts_timestamps),
+                confidence_levels=[
+                    ConfidenceLevel.MEDIUM,
+                ]
+                * len(ts_timestamps),
             ),
             prophet_predictions=ProphetPrediction(
                 timestamps=np.array([]),
@@ -384,6 +398,10 @@ class TestAnomalyDetection(unittest.TestCase):
                 thresholds=[],
                 original_flags=np.array(["none"] * len(ts_timestamps)),
                 use_suss=np.array([True] * len(ts_timestamps)),
+                confidence_levels=[
+                    ConfidenceLevel.MEDIUM,
+                ]
+                * len(ts_timestamps),
             ),
             prophet_predictions=ProphetPrediction(
                 timestamps=np.array([]),
@@ -410,6 +428,10 @@ class TestAnomalyDetection(unittest.TestCase):
             window_size=window_size,
             thresholds=[],
             original_flags=["none"] * len(ts_timestamps),
+            confidence_levels=[
+                ConfidenceLevel.MEDIUM,
+            ]
+            * len(ts_timestamps),
         )
 
         new_timestamp = len(ts_values) + datetime.now().timestamp() + 1
@@ -447,6 +469,10 @@ class TestAnomalyDetection(unittest.TestCase):
                 thresholds=[],
                 original_flags=np.array(["none"] * len(ts_timestamps)),
                 use_suss=np.array([True] * len(ts_timestamps)),
+                confidence_levels=[
+                    ConfidenceLevel.MEDIUM,
+                ]
+                * len(ts_timestamps),
             ),
             prophet_predictions=ProphetPrediction(
                 timestamps=np.array([]),

--- a/tests/seer/anomaly_detection/test_cleanup_and_predict_tasks.py
+++ b/tests/seer/anomaly_detection/test_cleanup_and_predict_tasks.py
@@ -67,6 +67,7 @@ class TestCleanupTasks(unittest.TestCase):
                 thresholds=np.array([]),
                 original_flags=np.array([]),
                 use_suss=np.array([]),
+                confidence_levels=[],
             )
         else:
             anomalies = MPBatchAnomalyDetector().detect(ts, config)


### PR DESCRIPTION
- Adjusts the scoring algorithm to use the MP Flags if there is strong confidence (mp_dist > 2 * threshold) even if prophet does not indicate an anomaly. This is an incremental change.

Before MP Override:
![Screenshot 2025-03-05 at 9 31 41 PM](https://github.com/user-attachments/assets/768c1322-e051-4280-b416-6fa9cac8cd69)

After MP Override:
<img width="1414" alt="Screenshot 2025-03-05 at 9 54 36 PM" src="https://github.com/user-attachments/assets/185583b2-cbab-4a5f-bd35-5889c45172f9" />

If we look at the end of the big spike in this example, because the Prophet CI begins to widen after, originally we stop the alert earlier than we should (not good in stream case where we are not sure how the timeseries will behave next). By adding the override, we extend the anomaly just a little more and ensure we are fully confident before marking it as resolved. 

Overall in the other examples, only 1 of them produced a 1 timestep false positive while the rest remained the same as intended.

**CAVEAT:**
An example like this still needs to be dug deeper into because this spike at Nov 15th should be called out, but the matrix profile does not go high enough for it to trigger and Prophet scores are not high enough for it to override either due to the confidence intervals being so large. On `high` sensitivity though this should be captured due to confidence intervals shrinking.
![image](https://github.com/user-attachments/assets/ccdbc44c-1dab-4cb7-9fd8-e15fbc9ac574)
