### PR TITLE
feat(autofix): Receive trace tree in request payload

### DIFF
--- a/src/seer/automation/autofix/components/root_cause/models.py
+++ b/src/seer/automation/autofix/components/root_cause/models.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 from seer.automation.agent.models import Message
 from seer.automation.component import BaseComponentOutput, BaseComponentRequest
-from seer.automation.models import EventDetails, Profile
+from seer.automation.models import EventDetails, Profile, TraceTree
 from seer.automation.summarize.issue import IssueSummary
 
 
@@ -69,6 +69,7 @@ class RootCauseAnalysisRequest(BaseComponentRequest):
     summary: Optional[IssueSummary] = None
     initial_memory: list[Message] = []
     profile: Profile | None = None
+    trace_tree: TraceTree | None = None
 
 
 class RootCauseAnalysisOutput(BaseComponentOutput):

--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -20,6 +20,7 @@ from seer.automation.models import (
     Line,
     Profile,
     RepoDefinition,
+    TraceTree,
 )
 from seer.automation.summarize.issue import IssueSummary
 from seer.automation.utils import make_kill_signal
@@ -318,10 +319,11 @@ class AutofixRequest(BaseModel):
     project_id: Annotated[int, Examples(specialized.unsigned_ints)]
     repos: list[RepoDefinition]
     issue: IssueDetails
-    invoking_user: Optional[AutofixUserDetails] = None
-    instruction: Optional[str] = Field(default=None, validation_alias="additional_context")
-    issue_summary: Optional[IssueSummary] = None
+    invoking_user: AutofixUserDetails | None = None
+    instruction: str | None = Field(default=None, validation_alias="additional_context")
+    issue_summary: IssueSummary | None = None
     profile: Profile | None = None
+    trace_tree: TraceTree | None = None
 
     options: AutofixRequestOptions = Field(default_factory=AutofixRequestOptions)
 

--- a/src/seer/automation/autofix/steps/root_cause_step.py
+++ b/src/seer/automation/autofix/steps/root_cause_step.py
@@ -86,6 +86,7 @@ class RootCauseStep(AutofixPipelineStep):
                 summary=summary,
                 initial_memory=self.request.initial_memory,
                 profile=state.request.profile,
+                trace_tree=state.request.trace_tree,
             )
         )
 

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -255,7 +255,7 @@ class SentryExceptionEntry(BaseModel):
 class SentryEventData(TypedDict):
     title: str
     entries: list[dict]
-    tags: list[dict[str, str]] | None
+    tags: NotRequired[list[dict[str, str]]]
 
 
 class ExceptionMechanism(TypedDict):

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -255,7 +255,7 @@ class SentryExceptionEntry(BaseModel):
 class SentryEventData(TypedDict):
     title: str
     entries: list[dict]
-    tags: list[dict[str, str]]
+    tags: list[dict[str, str]] = Field(default_factory=list)
 
 
 class ExceptionMechanism(TypedDict):

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -255,7 +255,7 @@ class SentryExceptionEntry(BaseModel):
 class SentryEventData(TypedDict):
     title: str
     entries: list[dict]
-    tags: list[dict[str, str]] = Field(default_factory=list)
+    tags: list[dict[str, str]] | None
 
 
 class ExceptionMechanism(TypedDict):

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -255,6 +255,7 @@ class SentryExceptionEntry(BaseModel):
 class SentryEventData(TypedDict):
     title: str
     entries: list[dict]
+    tags: list[dict[str, str]]
 
 
 class ExceptionMechanism(TypedDict):
@@ -308,6 +309,7 @@ class BreadcrumbsDetails(BaseModel):
 
 class EventDetails(BaseModel):
     title: str
+    transaction_name: str | None = None
     exceptions: list[ExceptionDetails] = Field(default_factory=list, exclude=False)
     threads: list[ThreadDetails] = Field(default_factory=list, exclude=False)
     breadcrumbs: list[BreadcrumbsDetails] = Field(default_factory=list, exclude=False)
@@ -319,6 +321,12 @@ class EventDetails(BaseModel):
         exceptions: list[ExceptionDetails] = []
         threads: list[ThreadDetails] = []
         breadcrumbs: list[BreadcrumbsDetails] = []
+        transaction_name: str | None = None
+
+        for tag in error_event.get("tags", []):
+            if tag.get("key") == "transaction":
+                transaction_name = tag.get("value")
+
         for entry in error_event.get("entries", []):
             if entry.get("type") == "exception":
                 for exception in entry.get("data", {}).get("values", []):
@@ -345,6 +353,7 @@ class EventDetails(BaseModel):
 
         return cls(
             title=error_event.get("title"),
+            transaction_name=transaction_name,
             exceptions=exceptions,
             threads=threads,
             breadcrumbs=breadcrumbs,
@@ -353,7 +362,7 @@ class EventDetails(BaseModel):
     def format_event(self):
         return textwrap.dedent(
             """\
-            {title}
+            {title} {transaction}
             <exceptions>
             {exceptions}
             </exceptions>
@@ -363,6 +372,7 @@ class EventDetails(BaseModel):
             """
         ).format(
             title=self.title,
+            transaction=f"(occurred in: {self.transaction_name})" if self.transaction_name else "",
             exceptions=self.format_exceptions(),
             breadcrumbs=self.format_breadcrumbs(),
         )

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -595,6 +595,23 @@ class Profile(BaseModel):
         return "\n".join(result)
 
 
+class TraceEvent(BaseModel):
+    event_id: str | None = None
+    title: str | None = None
+    is_transaction: bool = False
+    is_error: bool = False
+    platform: str | None = None
+    is_current_project: bool = True
+    duration: str | None = None
+    profile_id: str | None = None
+    children: list["TraceEvent"] = Field(default_factory=list)
+
+
+class TraceTree(BaseModel):
+    trace_id: str | None = None
+    events: list[TraceEvent] = Field(default_factory=list)  # only expecting transactions and errors
+
+
 class RepoDefinition(BaseModel):
     provider: Annotated[str, Examples(("github", "integrations:github"))]
     owner: str


### PR DESCRIPTION
Creates a model for trace data for the `sentry` backend to send. Also passes it into the root cause request, but doesn't use it, so I can inspect Langfuse logs to see the data looks right in prod before putting it in a prompt. It does include the transaction name in the event details that go in our prompts though.

Once I can confirm this is working in prod, my plan is to follow up with using this in our prompts and adding related tools.