### PR TITLE
chore(ci): try overwatch without libssl

### DIFF
--- a/.github/workflows/relevant-warnings.yml
+++ b/.github/workflows/relevant-warnings.yml
@@ -30,12 +30,6 @@ jobs:
           pip install mypy==1.15.0
           pip install ruff==0.3.3
 
-      - name: Install Build Dependencies
-        run: |
-          sudo apt-get update
-          wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
-          sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
-
       - name: Install Overwatch CLI
         run: |
           curl -o overwatch-cli https://overwatch.codecov.io/linux/cli


### PR DESCRIPTION
Technically on https://github.com/codecov/overwatch/commit/ee056fa94dbc219331ae64103f38fc61e56c6dfa we shouldn't have to explicitly download OpenSSL anymore.

The overwatch CLI should be able to use a rust library that, hopefully, goes with it.

I've seen it work locally and for the overwatch project itself, but I'm not yet confident the requirement can be dropped. So I'm testing it out :E