### PR TITLE
feat(autofix): New testing flow

### DIFF
--- a/src/seer/automation/autofix/components/coding/prompts.py
+++ b/src/seer/automation/autofix/components/coding/prompts.py
@@ -76,6 +76,7 @@ class CodingPrompts:
         custom_solution: str | None = None,
         auto_solution: list[SolutionTimelineEvent] | None = None,
         mode: Literal["all", "fix", "test"] = "fix",
+        has_test: bool = False,
         event_details: EventDetails | None = None,
         root_cause: RootCauseAnalysisItem | str | None = None,
     ):
@@ -128,7 +129,7 @@ class CodingPrompts:
             ),
             has_test_guidelines=(
                 "- Examine any existing tests to determine existing testing patterns in the codebase and if there is an appropriate test suite to add your test to. If not, create a new test. Make sure that your test case fits in well with the codebase."
-                if mode == "test" or mode == "all"
+                if mode == "test" or mode == "all" or has_test
                 else ""
             ),
             steps_example_str=CodeChangesPromptXml.get_example().to_prompt_str(),

--- a/src/seer/automation/autofix/components/solution/models.py
+++ b/src/seer/automation/autofix/components/solution/models.py
@@ -19,7 +19,9 @@ class SolutionTimelineEvent(BaseModel):
     code_snippet_and_analysis: str | None = None
     relevant_code_file: RelevantCodeFile | None = None
     is_most_important_event: bool = False
-    timeline_item_type: Literal["internal_code", "human_instruction"] = "internal_code"
+    timeline_item_type: Literal["internal_code", "human_instruction", "repro_test"] = (
+        "internal_code"
+    )
     is_active: bool = True
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -34,6 +36,7 @@ class SolutionTimelineEvent(BaseModel):
             and "timeline_item_type" in data
             and data["timeline_item_type"] != "internal_code"
             and data["timeline_item_type"] != "human_instruction"
+            and data["timeline_item_type"] != "repro_test"
         ):
             data["timeline_item_type"] = "internal_code"
         return data

--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -193,7 +193,7 @@ class AutofixEventManager:
                 )
                 for solution_step in solution_output.solution_steps
             ]
-            solution_step.solution.append(
+            solution_step.solution.append(  # type: ignore[union-attr]
                 SolutionTimelineEvent(
                     title="Add a unit test that reproduces the issue.",
                     code_snippet_and_analysis=None,

--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -193,6 +193,16 @@ class AutofixEventManager:
                 )
                 for solution_step in solution_output.solution_steps
             ]
+            solution_step.solution.append(
+                SolutionTimelineEvent(
+                    title="Add a unit test that reproduces the issue.",
+                    code_snippet_and_analysis=None,
+                    relevant_code_file=None,
+                    is_most_important_event=False,
+                    is_active=False,
+                    timeline_item_type="repro_test",
+                )
+            )
             solution_step.description = solution_output.summary
             cur.status = AutofixStatus.NEED_MORE_INFORMATION
 


### PR DESCRIPTION
Always adds a step to add a unit test at the end of the solution timeline, but disables it by default. Adds support for triggering "testing mode" if that event is present in the solution sent in the payload. I tested it and it follows instructions nicely.