### PR TITLE
bugfix(anomaly detection): fix for combined detection call from UI timing out

### DIFF
--- a/src/seer/anomaly_detection/accessors.py
+++ b/src/seer/anomaly_detection/accessors.py
@@ -418,6 +418,7 @@ class DbAlertDataAccessor(AlertDataAccessor):
             dynamic_alert.data_purge_flag = TaskStatus.NOT_QUEUED
             session.commit()
 
+    @sentry_sdk.trace
     def combine_anomalies(
         self,
         anomalies_suss: MPTimeSeriesAnomaliesSingleWindow,

--- a/src/seer/anomaly_detection/detectors/anomaly_scorer.py
+++ b/src/seer/anomaly_detection/detectors/anomaly_scorer.py
@@ -4,6 +4,7 @@ import logging
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
+import sentry_sdk
 from pydantic import BaseModel, Field
 
 from seer.anomaly_detection.detectors.mp_cascading_scorer import MPCascadingScorer
@@ -74,6 +75,7 @@ class CombinedAnomalyScorer(AnomalyScorer):
         description="The ProphetScorer to use for scoring against the prophet model",
     )
 
+    @sentry_sdk.trace
     @inject
     def batch_score(
         self,

--- a/src/seer/anomaly_detection/detectors/prophet_anomaly_detector.py
+++ b/src/seer/anomaly_detection/detectors/prophet_anomaly_detector.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
+import sentry_sdk
 from prophet import Prophet  # type: ignore
 from pydantic import BaseModel
 from scipy import special, stats  # type: ignore
@@ -24,6 +25,7 @@ class ProphetAnomalyDetector(BaseModel):
     """
 
     @inject
+    @sentry_sdk.trace
     def predict(
         self,
         timestamps: npt.NDArray[np.float64],

--- a/src/seer/anomaly_detection/detectors/smoothers.py
+++ b/src/seer/anomaly_detection/detectors/smoothers.py
@@ -149,7 +149,6 @@ class MajorityVoteStreamFlagSmoother(FlagSmoother):
 
         return new_flag
 
-    @sentry_sdk.trace
     def smooth(
         self,
         original_flags: list,

--- a/src/seer/anomaly_detection/models/algo_config.py
+++ b/src/seer/anomaly_detection/models/algo_config.py
@@ -164,12 +164,12 @@ class AlgoConfig(BaseModel):
     )
 
     max_stream_days_for_combo_detection: int = Field(
-        5,
+        3,
         description="Limit on the number of days we apply streaming to during combo detection",
     )
 
     combo_detection_prophet_batching_interval_days: float = Field(
-        1.5,
+        3,
         description="Number of days to batch prophet predictions for combo detection",
     )
 


### PR DESCRIPTION
This PR includes:
* reducing the number of days use stream prediction to 3 days
* changes the number of prophet predictions to cover all 3 days to reduce the number of times we run Prophet prediction
* removes trace on methods that are called for each point in the dataset to avoid huge traces