### PR TITLE
:alien: add code snippet to StaticAnalysisWarning

### DIFF
--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -22,7 +22,7 @@ from seer.automation.codebase.utils import potential_frame_match
 from seer.automation.models import EventDetails, FileChange, FilePatch, RepoDefinition, Stacktrace
 from seer.automation.pipeline import PipelineContext
 from seer.automation.state import State
-from seer.automation.summarize.issue import IssueSummary, IssueSummaryWithScores
+from seer.automation.summarize.issue import IssueSummaryWithScores
 from seer.automation.utils import AgentError
 from seer.db import DbIssueSummary, DbPrIdToAutofixRunIdMapping, DbRunMemory, Session
 from seer.dependency_injection import inject, injected

--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -128,19 +128,40 @@ class StaticAnalysisWarning(BaseModel):
     encoded_location: str
     rule_id: int | None = None
     rule: StaticAnalysisRule | None = None
+    code_snippet: str | None = None
     # TODO: project info necessary for seer?
+
+    def _try_get_language(self) -> str | None:
+        if ".py" in self.encoded_location:
+            return "python"
+        if ".js" in self.encoded_location or ".ts" in self.encoded_location:
+            return "javascript"
+        if ".php" in self.encoded_location:
+            return "php"
+        return None
 
     def format_warning(self) -> str:
         location = Location.from_encoded(self.encoded_location)
-        return textwrap.dedent(
-            f"""\
+        return (
+            textwrap.dedent(
+                f"""\
             Warning message: {self.message}
             ----------
             Location:
                 filename: {location.filename}
                 start_line: {location.start_line}
                 end_line: {location.end_line}
+            Code Snippet:
+            ```{self._try_get_language() or ""}
+            CODE_SNIPPET
+            ```
             ----------
-            {self.rule.format_rule() if self.rule else ""}
+            FORMATTED_RULE
             """
+            )
+            # Multiline strings being substituted inside textwrap.dedent would mess with the formatting.
+            # So we substitute afterwards.
+            .replace("CODE_SNIPPET", textwrap.dedent(self.code_snippet or "").strip()).replace(
+                "FORMATTED_RULE", self.rule.format_rule() if self.rule else ""
+            )
         )

--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -128,7 +128,7 @@ class StaticAnalysisWarning(BaseModel):
     encoded_location: str
     rule_id: int | None = None
     rule: StaticAnalysisRule | None = None
-    code_snippet: str | None = None
+    encoded_code_snippet: str | None = None
     # TODO: project info necessary for seer?
 
     def _try_get_language(self) -> str | None:
@@ -161,7 +161,7 @@ class StaticAnalysisWarning(BaseModel):
             )
             # Multiline strings being substituted inside textwrap.dedent would mess with the formatting.
             # So we substitute afterwards.
-            .replace("CODE_SNIPPET", textwrap.dedent(self.code_snippet or "").strip()).replace(
-                "FORMATTED_RULE", self.rule.format_rule() if self.rule else ""
-            )
+            .replace(
+                "CODE_SNIPPET", textwrap.dedent(self.encoded_code_snippet or "").strip()
+            ).replace("FORMATTED_RULE", self.rule.format_rule() if self.rule else "")
         )

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -716,7 +716,7 @@ class RepoClient:
                     draft=False,
                 )
             else:
-                logger.exception(f"Error creating PR")
+                logger.exception("Error creating PR")
                 raise e
 
     def get_index_file_set(

--- a/src/seer/automation/summarize/issue.py
+++ b/src/seer/automation/summarize/issue.py
@@ -2,8 +2,6 @@ import textwrap
 
 from langfuse.decorators import observe
 from pydantic import BaseModel
-from scipy.spatial.distance import cosine
-from scipy.special import softmax
 
 from seer.automation.agent.client import GeminiProvider, LlmClient
 from seer.automation.agent.embeddings import GoogleProviderEmbeddings, cosine_similarity

--- a/src/seer/automation/utils.py
+++ b/src/seer/automation/utils.py
@@ -8,7 +8,6 @@ from xml.etree import ElementTree as ET
 
 import billiard  # type: ignore[import-untyped]
 import chardet
-import numpy as np
 import torch
 from openai.types.chat import ParsedChatCompletion
 from sentence_transformers import SentenceTransformer

--- a/tests/automation/autofix/test_autofix_context.py
+++ b/tests/automation/autofix/test_autofix_context.py
@@ -29,7 +29,7 @@ from seer.automation.models import (
     ThreadDetails,
 )
 from seer.automation.state import DbStateRunTypes
-from seer.automation.summarize.issue import IssueSummary, IssueSummaryWithScores
+from seer.automation.summarize.issue import IssueSummaryWithScores
 from seer.automation.summarize.models import SummarizeIssueScores
 from seer.db import DbIssueSummary, DbPrIdToAutofixRunIdMapping, DbRunMemory, Session
 

--- a/tests/automation/codegen/test_relevant_warnings.py
+++ b/tests/automation/codegen/test_relevant_warnings.py
@@ -1,3 +1,4 @@
+import textwrap
 from collections import defaultdict
 from typing import Generic, TypeVar
 from unittest.mock import MagicMock, Mock, patch
@@ -9,7 +10,7 @@ from pydantic import BaseModel
 
 from seer.automation.agent.embeddings import GoogleProviderEmbeddings
 from seer.automation.agent.models import LlmGenerateStructuredResponse
-from seer.automation.codebase.models import StaticAnalysisWarning
+from seer.automation.codebase.models import StaticAnalysisRule, StaticAnalysisWarning
 from seer.automation.codegen.codegen_context import CodegenContext
 from seer.automation.codegen.models import (
     AssociateWarningsWithIssuesOutput,
@@ -38,6 +39,96 @@ from seer.automation.codegen.relevant_warnings_step import (
     RelevantWarningsStepRequest,
 )
 from seer.automation.models import IssueDetails, RepoDefinition, SentryEventData
+
+
+@pytest.mark.parametrize(
+    "warning, expected",
+    [
+        pytest.param(
+            StaticAnalysisWarning(
+                id=1,
+                code="unused-variable",
+                encoded_location="path/to/file.py:1~2",
+                message="Warning message",
+                rule=StaticAnalysisRule(
+                    id=1,
+                    tool="mypy",
+                    code="unused-variable",
+                    category="style",
+                    is_autofixable=False,
+                    is_stable=None,
+                ),
+                code_snippet="    def test_format_code_snippet(self):\n        pass\n",
+            ),
+            textwrap.dedent(
+                """\
+                Warning message: Warning message
+                ----------
+                Location:
+                    filename: path/to/file.py
+                    start_line: 1
+                    end_line: 2
+                Code Snippet:
+                ```python
+                def test_format_code_snippet(self):
+                    pass
+                ```
+                ----------
+                Static Analysis Rule:
+                    Rule: unused-variable
+                    Tool: mypy
+                    Is auto-fixable: False
+                    Is stable: None
+                    Category: style
+
+                """
+            ),
+            id="python-warning",
+        ),
+        pytest.param(
+            StaticAnalysisWarning(
+                id=2,
+                code="unused-variable",
+                encoded_location="path/to/file.js:1~2",
+                message="Warning message",
+                rule=StaticAnalysisRule(
+                    id=2,
+                    tool="eslint",
+                    code="unused-variable",
+                    category="style",
+                    is_autofixable=False,
+                    is_stable=False,
+                ),
+                code_snippet="",
+            ),
+            textwrap.dedent(
+                """\
+                Warning message: Warning message
+                ----------
+                Location:
+                    filename: path/to/file.js
+                    start_line: 1
+                    end_line: 2
+                Code Snippet:
+                ```javascript
+
+                ```
+                ----------
+                Static Analysis Rule:
+                    Rule: unused-variable
+                    Tool: eslint
+                    Is auto-fixable: False
+                    Is stable: False
+                    Category: style
+
+                """
+            ),
+            id="javascript-warning-no-snippet",
+        ),
+    ],
+)
+def test_format_code_snippet(warning: StaticAnalysisWarning, expected: str):
+    assert warning.format_warning() == expected
 
 
 class TestFilterWarningsComponent:

--- a/tests/automation/codegen/test_relevant_warnings.py
+++ b/tests/automation/codegen/test_relevant_warnings.py
@@ -58,7 +58,7 @@ from seer.automation.models import IssueDetails, RepoDefinition, SentryEventData
                     is_autofixable=False,
                     is_stable=None,
                 ),
-                code_snippet="    def test_format_code_snippet(self):\n        pass\n",
+                encoded_code_snippet="    def test_format_code_snippet(self):\n        pass\n",
             ),
             textwrap.dedent(
                 """\
@@ -99,7 +99,7 @@ from seer.automation.models import IssueDetails, RepoDefinition, SentryEventData
                     is_autofixable=False,
                     is_stable=False,
                 ),
-                code_snippet="",
+                encoded_code_snippet="",
             ),
             textwrap.dedent(
                 """\

--- a/tests/automation/summarize/test_issue.py
+++ b/tests/automation/summarize/test_issue.py
@@ -9,7 +9,6 @@ from seer.automation.agent.client import LlmGenerateStructuredResponse, LlmRespo
 from seer.automation.agent.models import LlmProviderType, Usage
 from seer.automation.models import IssueDetails
 from seer.automation.summarize.issue import (
-    IssueSummary,
     IssueSummaryForLlmToGenerate,
     IssueSummaryWithScores,
     evaluate_autofixability,
@@ -87,11 +86,11 @@ class TestSummarizeIssue:
         assert (
             result.title == expected_result.title
         ), f"Title mismatch: {result.title} != {expected_result.title}"
-        assert result.whats_wrong == expected_result.whats_wrong, f"whats_wrong mismatch"
+        assert result.whats_wrong == expected_result.whats_wrong, "whats_wrong mismatch"
         assert (
             result.session_related_issues == expected_result.session_related_issues
-        ), f"session_related_issues mismatch"
-        assert result.possible_cause == expected_result.possible_cause, f"possible_cause mismatch"
+        ), "session_related_issues mismatch"
+        assert result.possible_cause == expected_result.possible_cause, "possible_cause mismatch"
         assert (
             result.scores.possible_cause_confidence
             == expected_result.scores.possible_cause_confidence


### PR DESCRIPTION
From https://github.com/codecov/overwatch/pull/239 we will be able to have code snippets for the warnings. The hope is that they will help provide better suggestions from the LLMs.

Obviously depends on that PR being merged.
I did spent more time than I expected fixing the formatting, not sure if it was all that worth it. Do LLMs even care?