### PR TITLE
fix(autofix): Return existing PR + logging

### DIFF
--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -21,8 +21,8 @@ from github import (
     UnknownObjectException,
 )
 from github.GitRef import GitRef
-from github.Repository import Repository
 from github.PullRequest import PullRequest
+from github.Repository import Repository
 
 from seer.automation.autofix.utils import generate_random_string, sanitize_branch_name
 from seer.automation.codebase.models import GithubPrReviewComment

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -22,6 +22,7 @@ from github import (
 )
 from github.GitRef import GitRef
 from github.Repository import Repository
+from github.PullRequest import PullRequest
 
 from seer.automation.autofix.utils import generate_random_string, sanitize_branch_name
 from seer.automation.codebase.models import GithubPrReviewComment
@@ -680,7 +681,20 @@ class RepoClient:
         title: str,
         description: str,
         provided_base: str | None = None,
-    ):
+    ) -> PullRequest:
+        if pulls := self.repo.get_pulls(state="open", head=branch.ref):
+            logger.error(
+                f"Branch {branch.ref} already has an open PR.",
+                extra={
+                    "branch_ref": branch.ref,
+                    "title": title,
+                    "description": description,
+                    "provided_base": provided_base,
+                },
+            )
+
+            return pulls[0]
+
         try:
             return self.repo.create_pull(
                 title=title,
@@ -690,7 +704,7 @@ class RepoClient:
                 draft=True,
             )
         except GithubException as e:
-            if e.status == 422:
+            if e.status == 422 and "Draft pull requests are not supported" in str(e):
                 # fallback to creating a regular PR if draft PR is not supported
                 return self.repo.create_pull(
                     title=title,
@@ -700,6 +714,7 @@ class RepoClient:
                     draft=False,
                 )
             else:
+                logger.exception(f"Error creating PR")
                 raise e
 
     def get_index_file_set(


### PR DESCRIPTION
After looking at the trace of a lot of the errors, [a lot of them are coming from the non-draft pr line](https://sentry.sentry.io/issues/6361334163/events/f3e7f38368fa449aba774b4fa940d9fa/?project=6178942&sort=date&statsPeriod=14d). And apart from that the errors don't have a stacktrace, this attempts to better logging there so we can debug what the actual issue is.

Also, if a PR already exists for a branch, we should just return it and link to it on Autofix cuz u can only have 1 PR for a branch...