### PR TITLE
fix(autofix): Fix get pulls

### DIFF
--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -682,7 +682,7 @@ class RepoClient:
         description: str,
         provided_base: str | None = None,
     ) -> PullRequest:
-        if pulls := self.repo.get_pulls(state="open", head=branch.ref):
+        if pulls := self.repo.get_pulls(state="open", head=f"{self.repo_owner}:{branch.ref}"):
             logger.error(
                 f"Branch {branch.ref} already has an open PR.",
                 extra={


### PR DESCRIPTION
When getting pull requests, github expects a wildly different ref format

https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests
![CleanShot 2025-03-17 at 15 11 42](https://github.com/user-attachments/assets/717e19b0-8810-4486-87ce-5c562cfba04d)
