### PR TITLE
fix(relevant-warnings): Filter warnings by pr diff instead of by files

### DIFF
--- a/.github/workflows/relevant-warnings.yml
+++ b/.github/workflows/relevant-warnings.yml
@@ -30,12 +30,6 @@ jobs:
           pip install mypy==1.15.0
           pip install ruff==0.3.3
 
-      - name: Install Build Dependencies
-        run: |
-          sudo apt-get update
-          wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
-          sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
-
       - name: Install Overwatch CLI
         run: |
           curl -o overwatch-cli https://overwatch.codecov.io/linux/cli

--- a/src/seer/automation/codegen/models.py
+++ b/src/seer/automation/codegen/models.py
@@ -159,7 +159,7 @@ class PrFile(BaseModel):
 
 class FilterWarningsRequest(BaseComponentRequest):
     warnings: list[StaticAnalysisWarning]
-    target_filenames: list[str]
+    pr_files: list[PrFile]
 
 
 class FilterWarningsOutput(BaseComponentOutput):

--- a/src/seer/automation/codegen/models.py
+++ b/src/seer/automation/codegen/models.py
@@ -156,6 +156,7 @@ class PrFile(BaseModel):
     changes: int
     sha: str
 
+
 class FilterWarningsRequest(BaseComponentRequest):
     warnings: list[StaticAnalysisWarning]
     pr_files: list[PrFile]

--- a/src/seer/automation/codegen/models.py
+++ b/src/seer/automation/codegen/models.py
@@ -156,7 +156,6 @@ class PrFile(BaseModel):
     changes: int
     sha: str
 
-
 class FilterWarningsRequest(BaseComponentRequest):
     warnings: list[StaticAnalysisWarning]
     pr_files: list[PrFile]

--- a/src/seer/automation/codegen/relevant_warnings_step.py
+++ b/src/seer/automation/codegen/relevant_warnings_step.py
@@ -130,10 +130,10 @@ class RelevantWarningsStep(CodegenStep):
             if file.patch
         ]
 
-        # 2. Only consider warnings from files changed in the PR.
+        # 2. Only consider warnings from lines changed in the PR.
         filter_warnings_component = FilterWarningsComponent(self.context)
         filter_warnings_request = FilterWarningsRequest(
-            warnings=self.request.warnings, target_filenames=[file.filename for file in pr_files]
+            warnings=self.request.warnings, pr_files=pr_files
         )
         filter_warnings_output: FilterWarningsOutput = filter_warnings_component.invoke(
             filter_warnings_request

--- a/tests/automation/codegen/test_relevant_warnings.py
+++ b/tests/automation/codegen/test_relevant_warnings.py
@@ -69,7 +69,7 @@ class TestFilterWarningsComponent:
             changes=10,
             sha="sha1",
         )
-        assert component._get_changed_lines(pr_file) == [1, 2, 3, 4]
+        assert component._get_pr_changed_lines(pr_file) == [1, 2, 3, 4]
 
         pr_file = PrFile(
             filename="test.py",
@@ -84,7 +84,7 @@ class TestFilterWarningsComponent:
             changes=15,
             sha="sha2",
         )
-        assert component._get_changed_lines(pr_file) == [10, 11, 12, 13, 14, 15]
+        assert component._get_pr_changed_lines(pr_file) == [10, 11, 12, 13, 14, 15]
 
     class _TestInvokeTestCase(BaseModel):
         id: str

--- a/tests/automation/codegen/test_relevant_warnings.py
+++ b/tests/automation/codegen/test_relevant_warnings.py
@@ -135,7 +135,7 @@ class TestFilterWarningsComponent:
                             print("generating")
                             return True
                         +    print("done")""",
-                        status="modified", 
+                        status="modified",
                         changes=1,
                         sha="sha1",
                     ),


### PR DESCRIPTION
Filter warnings based on those that have a line number in the modified file line numbers in the PR diff. Previously we allowed the warning to exist anywhere in the same file, which turned out to be too loose.

Closes https://github.com/codecov/overwatch/issues/242