### PR TITLE
fix(relevant-warnings): Fix github actions ruff version

### DIFF
--- a/.github/workflows/relevant-warnings.yml
+++ b/.github/workflows/relevant-warnings.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Static Analysis Tools
         run: |
           pip install mypy==1.15.0
-          pip install ruff==0.3.3
+          pip install ruff==0.11.1
 
       - name: Install Overwatch CLI
         run: |


### PR DESCRIPTION
There was a job failure [here](https://github.com/getsentry/seer/actions/runs/13973962300/job/39122801681) because the latest release of overwatch CLI required a version beyond that supported here.