### PR TITLE
Add GH app logic to unit test endpoint

### DIFF
--- a/src/seer/app.py
+++ b/src/seer/app.py
@@ -333,7 +333,7 @@ def codecov_request_endpoint(
     if data.request_type == "pr-review":
         return codegen_pr_review_endpoint(data.data)
     elif data.request_type == "unit-tests":
-        return codegen_unit_tests_endpoint(data.data)
+        return codegen_unittest(data.data, is_codecov_request=True)
     elif data.request_type == "retry-unit-tests":
         return codegen_retry_unittest(data.data)
 

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -820,17 +820,6 @@ class RepoClient:
         data.raise_for_status()  # Raise an exception for HTTP errors
         return data.json()["head"]["sha"]
 
-    def post_unit_test_confirmation_message_to_pr(self, pr_url: str):
-        original_pr_id = int(original_pr_url.split("/")[-1])
-        repo_name = original_pr_url.split("github.com/")[1].split("/pull")[0]
-        url = f"https://api.github.com/repos/{repo_name}/issues/{original_pr_id}/comments"
-        comment = f"Sentry has generated a new [PR]({unit_test_pr_url}) with unit tests for this PR. View the new PR({unit_test_pr_url}) to review the changes."
-        params = {"body": comment}
-        headers = self._get_auth_headers()
-        response = requests.post(url, headers=headers, json=params)
-        response.raise_for_status()
-        return response.json()["html_url"]
-
     def post_unit_test_reference_to_original_pr(self, original_pr_url: str, unit_test_pr_url: str):
         original_pr_id = int(original_pr_url.split("/")[-1])
         repo_name = original_pr_url.split("github.com/")[1].split("/pull")[0]

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -820,6 +820,17 @@ class RepoClient:
         data.raise_for_status()  # Raise an exception for HTTP errors
         return data.json()["head"]["sha"]
 
+    def post_unit_test_confirmation_message_to_pr(self, pr_url: str):
+        original_pr_id = int(original_pr_url.split("/")[-1])
+        repo_name = original_pr_url.split("github.com/")[1].split("/pull")[0]
+        url = f"https://api.github.com/repos/{repo_name}/issues/{original_pr_id}/comments"
+        comment = f"Sentry has generated a new [PR]({unit_test_pr_url}) with unit tests for this PR. View the new PR({unit_test_pr_url}) to review the changes."
+        params = {"body": comment}
+        headers = self._get_auth_headers()
+        response = requests.post(url, headers=headers, json=params)
+        response.raise_for_status()
+        return response.json()["html_url"]
+
     def post_unit_test_reference_to_original_pr(self, original_pr_url: str, unit_test_pr_url: str):
         original_pr_id = int(original_pr_url.split("/")[-1])
         repo_name = original_pr_url.split("github.com/")[1].split("/pull")[0]

--- a/src/seer/automation/codegen/tasks.py
+++ b/src/seer/automation/codegen/tasks.py
@@ -80,7 +80,9 @@ def create_subsequent_unittest_run(request: CodegenBaseRequest) -> DbState[Codeg
 
 
 @inject
-def codegen_unittest(request: CodegenBaseRequest, app_config: AppConfig = injected):
+def codegen_unittest(
+    request: CodegenBaseRequest, app_config: AppConfig = injected, is_codecov_request: bool = False
+):
     state = create_initial_unittest_run(request)
 
     cur_state = state.get()
@@ -93,6 +95,7 @@ def codegen_unittest(request: CodegenBaseRequest, app_config: AppConfig = inject
         run_id=cur_state.run_id,
         pr_id=request.pr_id,
         repo_definition=request.repo,
+        is_codecov_request=is_codecov_request,
     )
     UnittestStep.get_signature(unittest_request, queue=app_config.CELERY_WORKER_QUEUE).apply_async()
 

--- a/src/seer/automation/codegen/unit_test_coding_component.py
+++ b/src/seer/automation/codegen/unit_test_coding_component.py
@@ -99,7 +99,9 @@ class UnitTestCodingComponent(BaseComponent[CodeUnitTestRequest, CodeUnitTestOut
             raise ValueError("No tasks found in coding output")
         file_changes: list[FileChange] = []
         client_type = (
-            RepoClientType.PR_REVIEW if is_codecov_request else RepoClientType.CODECOV_UNIT_TEST
+            RepoClientType.CODECOV_PR_REVIEW
+            if is_codecov_request
+            else RepoClientType.CODECOV_UNIT_TEST
         )
         repo_client = self.context.get_repo_client(task.repo_name, type=client_type)
         for task in coding_output.tasks:

--- a/src/seer/automation/codegen/unit_test_coding_component.py
+++ b/src/seer/automation/codegen/unit_test_coding_component.py
@@ -103,8 +103,8 @@ class UnitTestCodingComponent(BaseComponent[CodeUnitTestRequest, CodeUnitTestOut
             if is_codecov_request
             else RepoClientType.CODECOV_UNIT_TEST
         )
-        repo_client = self.context.get_repo_client(task.repo_name, type=client_type)
         for task in coding_output.tasks:
+            repo_client = self.context.get_repo_client(task.repo_name, type=client_type)
             if task.type == "file_change":
                 file_content, _ = repo_client.get_file_content(task.file_path)
                 if not file_content:

--- a/src/seer/automation/codegen/unit_test_coding_component.py
+++ b/src/seer/automation/codegen/unit_test_coding_component.py
@@ -32,7 +32,10 @@ class UnitTestCodingComponent(BaseComponent[CodeUnitTestRequest, CodeUnitTestOut
     @ai_track(description="Generate unit tests")
     @inject
     def invoke(
-        self, request: CodeUnitTestRequest, llm_client: LlmClient = injected
+        self,
+        request: CodeUnitTestRequest,
+        is_codecov_request: bool,
+        llm_client: LlmClient = injected,
     ) -> CodeUnitTestOutput | None:
         with BaseTools(self.context, repo_client_type=RepoClientType.CODECOV_UNIT_TEST) as tools:
             agent = LlmAgent(
@@ -95,10 +98,11 @@ class UnitTestCodingComponent(BaseComponent[CodeUnitTestRequest, CodeUnitTestOut
         if not coding_output.tasks:
             raise ValueError("No tasks found in coding output")
         file_changes: list[FileChange] = []
+        client_type = (
+            RepoClientType.PR_REVIEW if is_codecov_request else RepoClientType.CODECOV_UNIT_TEST
+        )
+        repo_client = self.context.get_repo_client(task.repo_name, type=client_type)
         for task in coding_output.tasks:
-            repo_client = self.context.get_repo_client(
-                task.repo_name, type=RepoClientType.CODECOV_UNIT_TEST
-            )
             if task.type == "file_change":
                 file_content, _ = repo_client.get_file_content(task.file_path)
                 if not file_content:

--- a/src/seer/automation/codegen/unittest_step.py
+++ b/src/seer/automation/codegen/unittest_step.py
@@ -71,13 +71,24 @@ class UnittestStep(CodegenStep):
             "owner_username": self.request.repo_definition.owner,
             "head_sha": latest_commit_sha,
         }
+        is_codecov_request = self.request.is_codecov_request
+
+        if is_codecov_request:
+            repo_client.post_issue_comment(
+                pr.url, "On it! Codecov is generating unit tests for this PR."
+            )
+        else:
+            repo_client.post_issue_comment(
+                pr.url, "On it! Sentry is generating unit tests for this PR."
+            )
+
         try:
             unittest_output = UnitTestCodingComponent(self.context).invoke(
                 CodeUnitTestRequest(
                     diff=diff_content,
                     codecov_client_params=codecov_client_params,
                 ),
-                is_codecov_request=self.request.is_codecov_request,
+                is_codecov_request=is_codecov_request,
             )
 
             if unittest_output:


### PR DESCRIPTION
If the invocation is from a Codecov service, use the codecov GH app to post unit tests to a PR. This will enable the `retry-unit-test` flow automatically going forward for codecov unit test requests. 