### PR TITLE
fix(anomaly detection): Fix Ghost Alerts

### DIFF
--- a/src/seer/anomaly_detection/accessors.py
+++ b/src/seer/anomaly_detection/accessors.py
@@ -180,7 +180,7 @@ class DbAlertDataAccessor(AlertDataAccessor):
                     confidence_levels[i] = (
                         algo_data.get("confidence_level") or ConfidenceLevel.MEDIUM
                     )  # Default to medium for backwards compatibility
-                algo_types[i] = algo_data.get("alert_algorithm_type") or AlertAlgorithmType.NONE
+                    algo_types[i] = algo_data.get("algorithm_type") or AlertAlgorithmType.NONE
             if ts[i] < timestamp_threshold:
                 num_old_points += 1
 

--- a/src/seer/anomaly_detection/detectors/anomaly_detectors.py
+++ b/src/seer/anomaly_detection/detectors/anomaly_detectors.py
@@ -193,8 +193,12 @@ class MPStreamAnomalyDetector(AnomalyDetector):
     )
     window_size: int = Field(..., description="Window size to use for stream computation")
     original_flags: list[AnomalyFlags | None] = Field(
-        ..., description="Original flags of the baseline timeseries."
+        ..., description="Original MP flags of the baseline timeseries."
     )
+    original_combined_flags: list[AnomalyFlags | None] = Field(
+        ..., description="Original combined flags of the baseline timeseries."
+    )
+
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
     )
@@ -287,11 +291,13 @@ class MPStreamAnomalyDetector(AnomalyDetector):
                     raise ServerError("Failed to score the matrix profile distance")
 
                 self.original_flags.append(flags_and_scores.flags[-1])
+                self.original_combined_flags.append(flags_and_scores.flags[-1])
+
                 stream_flag_smoother = MajorityVoteStreamFlagSmoother()
 
                 # Apply stream smoothing to the newest flag based on the previous original flags
                 smoothed_flags = stream_flag_smoother.smooth(
-                    original_flags=self.original_flags,
+                    original_flags=self.original_combined_flags,
                     ad_config=ad_config,
                     algo_config=algo_config,
                     vote_threshold=0.3,

--- a/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
+++ b/tests/seer/anomaly_detection/detectors/test_anomaly_detectors.py
@@ -164,6 +164,7 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
             history_mp=np.array([[0.3, 0.3, 0.3, 0.3], [0.4, 0.5, 0.6, 0.7]]),
             window_size=3,
             original_flags=["none", "none", "none"],
+            original_combined_flags=["none", "none", "none"],
         )
         self.timeseries = TimeSeries(
             timestamps=np.array([1, 2, 3]), values=np.array([1.1, 2.1, 3.1])
@@ -253,6 +254,7 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
             history_mp=history_mp,
             window_size=window_size,
             original_flags=["none", "none", "none"],
+            original_combined_flags=["none", "none", "none"],
         )
         stream_ts_timestamps = np.array(list(range(1, len(stream_ts) + 1))) + len(history_ts)
         stream_anomalies = stream_detector.detect(
@@ -383,6 +385,7 @@ class TestMPStreamAnomalyDetector(unittest.TestCase):
                 history_mp=np.array([0.1, 0.2, 0.3, 0.4]),
                 window_size=3,
                 original_flags=original_flags,
+                original_combined_flags=original_flags,
             )
             stream_detector.detect(
                 timeseries=TimeSeries(


### PR DESCRIPTION
- There could be cases when MP in the past said there is an alert (but not high confidence enough to force an alert) and prophet does not agree, so no alert fires.
  -  However, due to smoothing incorrectly being applied to the MP original flags, an alert could still be fired on non-anomalous data (neither algorithm agreeing), because there would be a majority of the MP original flag, not the `combined original flags`

- Uses the `algorithm_type` (the enum which indicates which combination of the two algorithms cause the alert) to determine the `combined_original_flag`