### PR TITLE
Add logs to investigate Sentry errors for PR reviews

### DIFF
--- a/src/seer/automation/codegen/pr_review_coding_component.py
+++ b/src/seer/automation/codegen/pr_review_coding_component.py
@@ -58,7 +58,7 @@ class PrReviewCodingComponent(BaseComponent[CodePrReviewRequest, CodePrReviewOut
         try:
             comments_data = json.loads(comments_json)
         except json.JSONDecodeError as e:
-            raise ValueError(f"Invalid JSON format inside <comments>: {e}")
+            raise ValueError(f"Invalid JSON format inside <comments>: {comments_json}. Error: {e}")
 
         if not isinstance(comments_data, list):
             raise ValueError("Expected a list of JSON objects inside <comments>")


### PR DESCRIPTION
We are seeing a lot of [Sentry](https://sentry.sentry.io/issues/6358241639/events/?project=6178942&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&stream_index=0) errors that have an `Error generating pr review`. 

This is due to an un-parsable response from Claude. This PR will log the responses so we can investigate where the formatting errors occur and tweak prompts/parsing logic as a follow up. 