### PR TITLE
ref(gocd): Cutting over to check_cloudbuild.py

### DIFF
--- a/gocd/pipelines/seer-experimental.yaml
+++ b/gocd/pipelines/seer-experimental.yaml
@@ -36,10 +36,12 @@ pipelines:
                 - script: |
                     ##!/bin/bash
 
-                    /devinfra/scripts/checks/googlecloud/checkcloudbuild.py \
-                      "${GO_REVISION_SEER_REPO}" \
+                    /devinfra/scripts/checks/googlecloud/check_cloudbuild.py \
                       sentryio \
-                      "us-central1-docker.pkg.dev/sentryio/seer/image"
+                      seer \
+                      seer-builder \
+                      "${GO_REVISION_SEER_REPO}" \
+                      main
               timeout: 1200
       - deploy-experimental:
           environment_variables:

--- a/gocd/templates/bash/check-cloudbuild.sh
+++ b/gocd/templates/bash/check-cloudbuild.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-/devinfra/scripts/checks/googlecloud/checkcloudbuild.py \
-  "${GO_REVISION_SEER_REPO}" \
+/devinfra/scripts/checks/googlecloud/check_cloudbuild.py \
   sentryio \
-  "us-central1-docker.pkg.dev/sentryio/seer/image"
+  seer \
+  seer-builder \
+  "${GO_REVISION_SEER_REPO}" \
+  main


### PR DESCRIPTION
Cutting over to the new check_cloudbuild script that doesn't rely on images anymore and instead relies on repo_name, trigger_name, sha, and branch_name.
https://linear.app/getsentry/issue/DI-632/update-getsentryseer-to-use-new-script