### PR TITLE
fix(issue-summary) Keep scores when scoring autofixability

### DIFF
--- a/src/seer/automation/summarize/issue.py
+++ b/src/seer/automation/summarize/issue.py
@@ -207,11 +207,9 @@ def run_fixability_score(
     fixability_score, is_fixable = evaluate_autofixability(issue_summary, autofixability_model)
 
     with Session() as session:
-        issue_summary.scores = SummarizeIssueScores(
-            fixability_score=fixability_score,
-            fixability_score_version=2,
-            is_fixable=is_fixable,
-        )
+        issue_summary.scores.fixability_score = fixability_score
+        issue_summary.scores.fixability_score_version = 2
+        issue_summary.scores.is_fixable = is_fixable
         session.merge(issue_summary.to_db_state(request.group_id))
         session.commit()
 

--- a/tests/automation/summarize/test_issue.py
+++ b/tests/automation/summarize/test_issue.py
@@ -265,6 +265,11 @@ class TestFixabilityScore:
         mock_db_session = Mock()
         mock_session.return_value.__enter__.return_value = mock_db_session
 
+        scores_current = {
+            "possible_cause_confidence": 0.8,
+            "possible_cause_novelty": 0.6,
+        }
+
         # Create a proper mock of DbIssueSummary with all required attributes
         mock_db_summary = Mock(spec=DbIssueSummary)
         mock_db_summary.summary = {
@@ -272,10 +277,7 @@ class TestFixabilityScore:
             "whats_wrong": "Something is broken",
             "session_related_issues": "No related issues",
             "possible_cause": "Bad code",
-            "scores": {
-                "possible_cause_confidence": 0.8,
-                "possible_cause_novelty": 0.6,
-            },
+            "scores": scores_current,
         }
         # Add the new fixability-related fields
         mock_db_summary.fixability_score = None
@@ -304,6 +306,10 @@ class TestFixabilityScore:
         assert result.scores.fixability_score == 0.75
         assert result.scores.fixability_score_version == 2
         assert result.scores.is_fixable is True
+        assert (
+            result.scores.possible_cause_confidence == scores_current["possible_cause_confidence"]
+        )
+        assert result.scores.possible_cause_novelty == scores_current["possible_cause_novelty"]
 
     @patch("seer.automation.summarize.issue.Session")
     def test_run_fixability_score_no_summary(self, mock_session, autofixability_model):

--- a/tests/automation/summarize/test_issue.py
+++ b/tests/automation/summarize/test_issue.py
@@ -306,10 +306,8 @@ class TestFixabilityScore:
         assert result.scores.fixability_score == 0.75
         assert result.scores.fixability_score_version == 2
         assert result.scores.is_fixable is True
-        assert (
-            result.scores.possible_cause_confidence == scores_current["possible_cause_confidence"]
-        )
-        assert result.scores.possible_cause_novelty == scores_current["possible_cause_novelty"]
+        for score_name, score_value in scores_current.items():
+            assert getattr(result.scores, score_name) == score_value
 
     @patch("seer.automation.summarize.issue.Session")
     def test_run_fixability_score_no_summary(self, mock_session, autofixability_model):


### PR DESCRIPTION
possible causes aren't showing up b/c the confidence and novelty scores are nullified, and the [thresholding logic in the frontend](https://github.com/getsentry/sentry/blob/6094a746573f63cb425f2c6bb70500a5b729188f/static/app/components/group/groupSummary.tsx#L196-L201) defaults to not showing the cause if either are null