### PR TITLE
fix(issue summary): Retry issue summary with less context if crosses limit

### DIFF
--- a/src/seer/automation/summarize/issue.py
+++ b/src/seer/automation/summarize/issue.py
@@ -88,82 +88,98 @@ def summarize_issue(
         else []
     )
 
-    connected_issues_input = ""
-    if connected_event_details:
-        connected_issues = "\n----\n".join(
-            [
-                f"Issue from the same session:\n{event.format_event()}"
-                for _, event in enumerate(connected_event_details)
-            ]
+    def _generate_summary(full_context: bool = True) -> IssueSummaryWithScores | None:
+        connected_issues_input = ""
+        if connected_event_details:
+            connected_issues = "\n----\n".join(
+                [
+                    f"Issue from the same session:\n{event.format_event() if full_context else event.format_event_without_breadcrumbs(include_context=False, include_var_values=False)}"
+                    for _, event in enumerate(connected_event_details)
+                ]
+            )
+            connected_issues_input = f"""
+            Also, we know about some other issues that occurred in the same application session, listed below. The issue above occurred somewhere alongside these:
+            {connected_issues}
+            """
+        else:
+            connected_issues_input = "Issues from the same session: none"
+
+        prompt = textwrap.dedent(
+            f"""Our code is broken! Please summarize the issue below in a few short bullet points so our engineers can immediately understand what's wrong.
+
+            The issue: {event_details.format_event()}
+
+            {connected_issues_input}
+
+            Your #1 goal is to help our engineers immediately understand what's going on in the main issue.
+
+            Write a concise report that sets the scene for the issue. Know that our engineers can already see all the same details on the issue that were provided to you, so DO NOT repeat them. Instead extract the holistic insights that would take time to figure out otherwise.
+            Please write under 15 words per section, while cramming as much detail as possible, to make the report super easy to skim. Please bold important insights and unique terms by surrounding them with double asterisks (**like this**). The structure you should follow is:
+
+            ###### What's wrong? [not optional]
+            Summary of the stacktrace, breadcrumbs, and other context
+
+            ###### Session related issues [optional]
+            Insights from the application session issues, if relevant to this issue [you must return an empty string here if there are no relevant session related issues]
+
+            ###### Possible cause [optional]
+            Guess as to the cause, maybe show if there's clear smoking bullet. [return empty string if none]
+            The guess should be somewhat novel compared to the `whats_wrong` section.
+            If you're not sure about the guess, express this uncertainty subtly in your guess, e.g., by using words like "possible", "perhaps", "may be", etc.
+
+            ###### Possible cause novelty score [optional]
+            If you filled out the `possible_cause`, return a float score between 0 and 1 for how much new, insightful information is in the `possible_cause` section compared to the `whats_wrong` section.
+            A `possible_cause` that is mostly a rephrasing of the `whats_wrong` section should score low.
+            A `possible_cause` whose information is obviously implied by the `whats_wrong` section should score low.
+            A `possible_cause` that contains new and insightful information that isn't mentioned in the `whats_wrong` section should score high.
+
+            ###### Possible cause confidence score [optional]
+            If you filled out the `possible_cause`, return a float score between 0 and 1 for how certain you are that this `possible_cause` is the true, upstream source of the issue. This score should be granular, e.g., 0.432.
+            A guess that may contain erroneous information should score very low.
+            A guess that contains a shred of speculation or vagueness should score low.
+            A guess that only contains verifiably correct, specific, and unspeculative information should score high.
+            Be hypercritical of your guess.
+            If you didn't make a guess for the possible cause, return none here.
+
+            ###### Title [not optional]
+            Provide a concise title for the report that summarizes the `whats_wrong`, `session_related_issues`, and `possible_cause` sections.
+
+            IMPORTANT: each section should be unique and not repeat the information in another section."""
         )
-        connected_issues_input = f"""
-        Also, we know about some other issues that occurred in the same application session, listed below. The issue above occurred somewhere alongside these:
-        {connected_issues}
-        """
-    else:
-        connected_issues_input = "Issues from the same session: none"
 
-    prompt = textwrap.dedent(
-        f"""Our code is broken! Please summarize the issue below in a few short bullet points so our engineers can immediately understand what's wrong.
+        try:
+            completion = llm_client.generate_structured(
+                model=GeminiProvider.model("gemini-2.0-flash-lite"),
+                prompt=prompt,
+                response_format=IssueSummaryForLlmToGenerate,
+                temperature=0.0,
+                max_tokens=512,
+            )
 
-        The issue: {event_details.format_event()}
+            issue_summary = completion.parsed
+            return IssueSummaryWithScores(
+                **issue_summary.model_dump(),
+                scores=SummarizeIssueScores(
+                    possible_cause_confidence=issue_summary.possible_cause_confidence_score,
+                    possible_cause_novelty=issue_summary.possible_cause_novelty_score,
+                ),
+            )
+        except Exception as e:
+            # Only retry if the error is context-limit-related
+            if "token" in str(e).lower():
+                return None
+            raise
 
-        {connected_issues_input}
+    result = _generate_summary(full_context=True)
+    if result is None:
+        # If failed with token error, retry with less context
+        result = _generate_summary(full_context=False)
+        if result is None:
+            raise Exception(
+                "Failed to generate issue summary even after retrying without breadcrumbs"
+            )
 
-        Your #1 goal is to help our engineers immediately understand what's going on in the main issue.
-
-        Write a concise report that sets the scene for the issue. Know that our engineers can already see all the same details on the issue that were provided to you, so DO NOT repeat them. Instead extract the holistic insights that would take time to figure out otherwise.
-        Please write under 15 words per section, while cramming as much detail as possible, to make the report super easy to skim. Please bold important insights and unique terms by surrounding them with double asterisks (**like this**). The structure you should follow is:
-
-        ###### What's wrong? [not optional]
-        Summary of the stacktrace, breadcrumbs, and other context
-
-        ###### Session related issues [optional]
-        Insights from the application session issues, if relevant to this issue [you must return an empty string here if there are no relevant session related issues]
-
-        ###### Possible cause [optional]
-        Guess as to the cause, maybe show if there's clear smoking bullet. [return empty string if none]
-        The guess should be somewhat novel compared to the `whats_wrong` section.
-        If you're not sure about the guess, express this uncertainty subtly in your guess, e.g., by using words like "possible", "perhaps", "may be", etc.
-
-        ###### Possible cause novelty score [optional]
-        If you filled out the `possible_cause`, return a float score between 0 and 1 for how much new, insightful information is in the `possible_cause` section compared to the `whats_wrong` section.
-        A `possible_cause` that is mostly a rephrasing of the `whats_wrong` section should score low.
-        A `possible_cause` whose information is obviously implied by the `whats_wrong` section should score low.
-        A `possible_cause` that contains new and insightful information that isn't mentioned in the `whats_wrong` section should score high.
-
-        ###### Possible cause confidence score [optional]
-        If you filled out the `possible_cause`, return a float score between 0 and 1 for how certain you are that this `possible_cause` is the true, upstream source of the issue. This score should be granular, e.g., 0.432.
-        A guess that may contain erroneous information should score very low.
-        A guess that contains a shred of speculation or vagueness should score low.
-        A guess that only contains verifiably correct, specific, and unspeculative information should score high.
-        Be hypercritical of your guess.
-        If you didn't make a guess for the possible cause, return none here.
-
-        ###### Title [not optional]
-        Provide a concise title for the report that summarizes the `whats_wrong`, `session_related_issues`, and `possible_cause` sections.
-
-        IMPORTANT: each section should be unique and not repeat the information in another section."""
-    )
-
-    completion = llm_client.generate_structured(
-        model=GeminiProvider.model("gemini-2.0-flash-lite"),
-        prompt=prompt,
-        response_format=IssueSummaryForLlmToGenerate,
-        temperature=0.0,
-        max_tokens=512,
-    )
-
-    issue_summary = completion.parsed
-    issue_summary_with_scores = IssueSummaryWithScores(
-        **issue_summary.model_dump(),
-        scores=SummarizeIssueScores(
-            possible_cause_confidence=issue_summary.possible_cause_confidence_score,
-            possible_cause_novelty=issue_summary.possible_cause_novelty_score,
-        ),
-    )
-
-    return issue_summary_with_scores
+    return result
 
 
 def run_summarize_issue(request: SummarizeIssueRequest) -> SummarizeIssueResponse:

--- a/src/seer/automation/summarize/issue.py
+++ b/src/seer/automation/summarize/issue.py
@@ -155,20 +155,20 @@ def summarize_issue(
                 temperature=0.0,
                 max_tokens=512,
             )
-
-            issue_summary = completion.parsed
-            return IssueSummaryWithScores(
-                **issue_summary.model_dump(),
-                scores=SummarizeIssueScores(
-                    possible_cause_confidence=issue_summary.possible_cause_confidence_score,
-                    possible_cause_novelty=issue_summary.possible_cause_novelty_score,
-                ),
-            )
         except Exception as e:
             # Only retry if the error is context-limit-related
             if "token" in str(e).lower():
                 return None
             raise
+
+        issue_summary = completion.parsed
+        return IssueSummaryWithScores(
+            **issue_summary.model_dump(),
+            scores=SummarizeIssueScores(
+                possible_cause_confidence=issue_summary.possible_cause_confidence_score,
+                possible_cause_novelty=issue_summary.possible_cause_novelty_score,
+            ),
+        )
 
     result = _generate_summary(full_context=True)
     if result is None:


### PR DESCRIPTION
Sometimes we're crossing the input token limit. So when we do, this retries one more time by removing the code context, variable context, and breadcrumbs from trace-connected issues.