### PR TITLE
chore(anomaly detection): Disable MP Override

### DIFF
--- a/src/seer/anomaly_detection/detectors/anomaly_scorer.py
+++ b/src/seer/anomaly_detection/detectors/anomaly_scorer.py
@@ -17,7 +17,6 @@ from seer.anomaly_detection.models import (
     AlgoConfig,
     AnomalyDetectionConfig,
     AnomalyFlags,
-    ConfidenceLevel,
     Directions,
 )
 from seer.anomaly_detection.models.timeseries_anomalies import AlertAlgorithmType
@@ -263,9 +262,9 @@ class CombinedAnomalyScorer(AnomalyScorer):
                     elif prophet_score >= 2.0:
                         algo_type = AlertAlgorithmType.PROPHET
                         flags.append(prophet_flag)
-                    elif mp_confidence_level == ConfidenceLevel.HIGH:
-                        algo_type = AlertAlgorithmType.MP
-                        flags.append(mp_flag)
+                    # elif mp_confidence_level == ConfidenceLevel.HIGH:
+                    #     algo_type = AlertAlgorithmType.MP
+                    #     flags.append(mp_flag)
                     else:
                         flags.append("none")
                 else:

--- a/tests/seer/anomaly_detection/detectors/test_anomaly_scorer.py
+++ b/tests/seer/anomaly_detection/detectors/test_anomaly_scorer.py
@@ -381,6 +381,7 @@ class TestCombinedAnomalyScorer:
         mock_mp_scorer_stream_score.assert_called_once()
         mock_prophet_scorer_stream_score.assert_not_called()
 
+    @pytest.mark.skip(reason="MP overrides Prophet is disabled for now")
     def test_mp_overrides_prophet(
         self,
     ):


### PR DESCRIPTION
- Disable MP for now as missing data can cause the MP to perform erratically and force override when not necessary