### PR TITLE
chore(seer): Disable datadog for local dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
+## Datadog
+DD_DOGSTATSD_DISABLE=True # Recommended to set as True to disable Datadog DogStatsD client for local development
+STATSD_HOST=... # Optional, defaults to 127.0.0.1
+STATSD_PORT=... # Optional, defaults to 8126
+
 ## Required for Autofix and Issue Summary
 OPENAI_API_KEY=...
 LANGFUSE_SECRET_KEY=...

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
 ## Datadog
+# STATSD_HOST=... # Optional for local development, defaults to 127.0.0.1
+# STATSD_PORT=... # Optional for local development, defaults to 8126
 DD_DOGSTATSD_DISABLE=True # Recommended to set as True to disable Datadog DogStatsD client for local development
-STATSD_HOST=... # Optional, defaults to 127.0.0.1
-STATSD_PORT=... # Optional, defaults to 8126
+
 
 ## Required for Autofix and Issue Summary
 OPENAI_API_KEY=...


### PR DESCRIPTION
- Set 'DD_DOGSTATSD_DISABLE` = `True` for local development 
- datadog initialize automatically picks this up (https://github.com/DataDog/datadogpy?tab=readme-ov-file)