### PR TITLE
[fix] Fix type error in CodegenBaseRequest

### DIFF
--- a/src/seer/automation/codegen/models.py
+++ b/src/seer/automation/codegen/models.py
@@ -47,7 +47,7 @@ class CodeUnitTestOutput(BaseComponentOutput):
 class CodegenBaseRequest(BaseModel):
     repo: RepoDefinition
     pr_id: int  # The PR number
-    codecov_status: dict[str, bool] | None = None
+    codecov_status: dict[str, str] | None = None
 
 
 class CodegenUnitTestsRequest(CodegenBaseRequest):


### PR DESCRIPTION
We send over a `str:str` key, value pair from Codecov. Tests already expect this value and so does logic in `RetryUnitTestStep`