### PR TITLE
fix(autofix): Fix missing memory on coding step comment threads

### DIFF
--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -827,7 +827,7 @@ def comment_on_thread(request: AutofixUpdateRequest):
     is_coding_step = step.key == "plan"
     is_root_cause_step = step.key == "root_cause_analysis_processing"
     memory = (
-        context.get_memory("plan_and_code")
+        context.get_memory("code")
         if is_coding_step
         else (
             context.get_memory("root_cause_analysis")


### PR DESCRIPTION
The memory key was wrong, so the memory was always missing for all comments on the plan+code step.