### PR TITLE
fix(autofix): Safely handle OSErrors when committing changes

### DIFF
--- a/tests/automation/autofix/test_autofix_tools.py
+++ b/tests/automation/autofix/test_autofix_tools.py
@@ -13,6 +13,8 @@ from seer.automation.models import FileChange
 class TestRepo:
     """A real object to replace complex mocking chains for repositories in tests."""
 
+    __test__ = False
+
     def __init__(self, name="test/repo", repo_id="123"):
         self.full_name = name
         self.external_id = repo_id
@@ -27,6 +29,8 @@ class TestRepo:
 
 class TestState:
     """A real object to replace complex mocking chains for state in tests."""
+
+    __test__ = False
 
     def __init__(self, repos=None):
         self.repos = repos or [TestRepo()]

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -52,6 +52,8 @@ def find_free_port():
 
 @dataclasses.dataclass
 class TestRpcHttpServer:
+    __test__ = False
+
     server_addr: tuple[str, int] = dataclasses.field(default_factory=lambda: ("", find_free_port()))
 
     @contextlib.contextmanager


### PR DESCRIPTION
(I don't know if this is the best solution, so pls review properly)

Fixes [SEER-TJ](https://sentry.sentry.io/issues/6416820767/)

From studying replays and our code, it seems that people click "Draft PR", it errors out randomly (sometimes instantly, sometimes after a few seconds) with this OSError, which is a connection error to RabbitMQ (or the worker itself?). The celery task continues successfully and creates a PR, but the user doesn't see that, so they click "Draft PR" again after seeing the error. That causes the duplicate PR errors we see.

So my solution is to create a wrapper that catches any connection errors when using `result.get`, ignore them, and keep waiting until our timeout.