### PR TITLE
fix(autofix): Make PR creation task pollable

### DIFF
--- a/src/seer/app.py
+++ b/src/seer/app.py
@@ -233,9 +233,9 @@ def autofix_update_endpoint(
     elif data.payload.type == AutofixUpdateType.SELECT_SOLUTION:
         run_autofix_coding(data)
     elif data.payload.type == AutofixUpdateType.CREATE_PR:
-        return run_autofix_push_changes(data)
+        run_autofix_push_changes(data)
     elif data.payload.type == AutofixUpdateType.CREATE_BRANCH:
-        return run_autofix_push_changes(data)
+        run_autofix_push_changes(data)
     elif data.payload.type == AutofixUpdateType.USER_MESSAGE:
         receive_user_message(data)
     elif data.payload.type == AutofixUpdateType.RESTART_FROM_POINT_WITH_FEEDBACK:

--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -283,6 +283,21 @@ class AutofixEventManager:
                 },
             )
 
+    def send_push_changes_start(self):
+        with self.state.update() as cur:
+            cur.mark_triggered()
+            cur.status = AutofixStatus.PROCESSING
+            changes_step = cur.changes_step
+            if changes_step:
+                changes_step.status = AutofixStatus.PROCESSING
+
+    def send_push_changes_result(self):
+        with self.state.update() as cur:
+            cur.status = AutofixStatus.COMPLETED
+            changes_step = cur.changes_step
+            if changes_step:
+                changes_step.status = AutofixStatus.COMPLETED
+
     def on_confidence_question(self, question: str):
         log_seer_event(
             SeerEventNames.AUTOFIX_ASKED_USER_QUESTION,

--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -2,7 +2,6 @@ import dataclasses
 import logging
 import time
 
-from seer.automation.autofix.components.coding.models import CodingOutput
 from seer.automation.autofix.components.insight_sharing.models import InsightSharingOutput
 from seer.automation.autofix.components.root_cause.models import RootCauseAnalysisOutput
 from seer.automation.autofix.components.solution.models import SolutionOutput, SolutionTimelineEvent

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -304,12 +304,7 @@ def commit_changes_task(run_id, repo_external_id, make_pr):
         event_manager = AutofixEventManager(state)
         context = AutofixContext(state=state, event_manager=event_manager)
 
-        with state.update() as cur:
-            cur.mark_triggered()
-            cur.status = AutofixStatus.PROCESSING
-            changes_step = cur.changes_step
-            if changes_step:
-                changes_step.status = AutofixStatus.PROCESSING
+        event_manager.send_push_changes_start()
 
         return context.commit_changes(
             repo_external_id=repo_external_id,
@@ -322,11 +317,7 @@ def commit_changes_task(run_id, repo_external_id, make_pr):
         logger.error(f"Error committing changes for run {run_id}: {e}")
         raise
     finally:
-        with state.update() as cur:
-            cur.status = AutofixStatus.COMPLETED
-            changes_step = cur.changes_step
-            if changes_step:
-                changes_step.status = AutofixStatus.COMPLETED
+        event_manager.send_push_changes_result()
 
 
 def receive_feedback(request: AutofixUpdateRequest):

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -42,7 +42,6 @@ from seer.automation.autofix.models import (
     AutofixSolutionUpdatePayload,
     AutofixStatus,
     AutofixUpdateCodeChangePayload,
-    AutofixUpdateEndpointResponse,
     AutofixUpdateRequest,
     AutofixUpdateType,
     AutofixUserMessagePayload,
@@ -274,7 +273,7 @@ def run_autofix_coding(
 def run_autofix_push_changes(
     request: AutofixUpdateRequest,
     app_config: AppConfig = injected,
-) -> AutofixUpdateEndpointResponse:
+):
     if not isinstance(request.payload, AutofixCreatePrUpdatePayload) and not isinstance(
         request.payload, AutofixCreateBranchUpdatePayload
     ):


### PR DESCRIPTION
Makes the PR creation task set the Autofix state and not wait for a timeout (the task still has a 60 second timeout). This is so the frontend can poll for it. This approach should be more stable and avoid random connection issues.