### PR TITLE
chore(autofix): Prevent auto runs from overwriting existing runs

### DIFF
--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -156,8 +156,8 @@ def run_autofix_root_cause(
     if request.options.auto_run_source:  # don't let auto-runs overwrite existing runs
         existing_run = get_autofix_state(group_id=request.issue.id)
         if existing_run:
-            state = existing_run.get()
-            return state.run_id
+            existing_state = existing_run.get()
+            return existing_state.run_id
 
     state = create_initial_autofix_run(request)
 

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -153,6 +153,11 @@ def run_autofix_root_cause(
     request: AutofixRequest,
     app_config: AppConfig = injected,
 ):
+    if request.options.auto_run_source:  # don't let auto-runs overwrite existing runs
+        existing_run = get_autofix_state(group_id=request.issue.id)
+        if existing_run:
+            return existing_run.run_id
+
     state = create_initial_autofix_run(request)
 
     cur_state = state.get()

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -156,7 +156,8 @@ def run_autofix_root_cause(
     if request.options.auto_run_source:  # don't let auto-runs overwrite existing runs
         existing_run = get_autofix_state(group_id=request.issue.id)
         if existing_run:
-            return existing_run.run_id
+            state = existing_run.get()
+            return state.run_id
 
     state = create_initial_autofix_run(request)
 


### PR DESCRIPTION
It would be really awkward if you had a manual run overwritten by an automatically-triggered run. Or if multiple auto-runs were happening at once.

The sentry-side check is already there, but it could still be bypassed with the network delay and the snuba querying delays.