### PR TITLE
fix(langfuse): Count all prompt cache tokens as prompt tokens

### DIFF
--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -717,8 +717,10 @@ class AnthropicProvider:
 
             for chunk in stream:
                 if chunk.type == "message_start" and chunk.message.usage:
-                    total_input_write_tokens += chunk.message.usage.cache_creation_input_tokens
-                    total_input_read_tokens += chunk.message.usage.cache_read_input_tokens
+                    if chunk.message.usage.cache_creation_input_tokens:
+                        total_input_write_tokens += chunk.message.usage.cache_creation_input_tokens
+                    if chunk.message.usage.cache_read_input_tokens:
+                        total_input_read_tokens += chunk.message.usage.cache_read_input_tokens
                     total_input_tokens += chunk.message.usage.input_tokens
                     total_output_tokens += chunk.message.usage.output_tokens
                 elif chunk.type == "message_delta" and chunk.usage:

--- a/src/seer/automation/agent/models.py
+++ b/src/seer/automation/agent/models.py
@@ -15,6 +15,8 @@ class Usage(BaseModel):
     completion_tokens: int = 0
     prompt_tokens: int = 0
     total_tokens: int = 0
+    prompt_cache_write_tokens: int = 0
+    prompt_cache_read_tokens: int = 0
 
     def __add__(self, other: "Usage"):
         return Usage(
@@ -29,6 +31,15 @@ class Usage(BaseModel):
             prompt_tokens=self.prompt_tokens - other.prompt_tokens,
             total_tokens=self.total_tokens - other.total_tokens,
         )
+
+    def to_langfuse_usage(self):
+        return {
+            "prompt_tokens": self.prompt_tokens
+            + self.prompt_cache_write_tokens
+            + self.prompt_cache_read_tokens,
+            "completion_tokens": self.completion_tokens,
+            "total_tokens": self.total_tokens,
+        }
 
 
 class LlmProviderType(str, Enum):


### PR DESCRIPTION
We'll need to update our langfuse instances to v3 to correctly account for cached tokens, which needs us to set up clickhouse.

Instead, this as an interim half-solution is to include all cached tokens as prompt tokens.

This won't fully fix it but at least it gets us in the ballpark of what the scale of what it does cost us vs not including any of those tokens at all.