### PR TITLE
fix(ci): Use pytest-split's least-duration algo

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -154,7 +154,7 @@ jobs:
           docker compose up -d test-db
           docker compose run ${{ env.EXTRA_COMPOSE_TEST_OPTIONS }} app bash -c "\
             pip install pytest-split && \
-            pytest --splits 10 --group ${{ matrix.group }} --cov . --cov-report=\"xml:.artifacts/coverage.xml\" -vv"
+            pytest --splits 10 --group ${{ matrix.group }} --splitting-algorithm least_duration --cov . --cov-report=\"xml:.artifacts/coverage.xml\" -vv"
 
       - name: Upload to codecov
         if: ${{ always() }}


### PR DESCRIPTION
`pytest-split` was creating a split with an empty group, causing our CI to fail in PR #2329 

Fix as mentioned in the issue on `pytest-split`'s repo: https://github.com/jerry-git/pytest-split/issues/95 is to change the splitting algorithm.