### PR TITLE
fix(issue-summary) Fixability more finetuned

### DIFF
--- a/src/seer/automation/summarize/issue.py
+++ b/src/seer/automation/summarize/issue.py
@@ -224,7 +224,7 @@ def run_fixability_score(
 
     with Session() as session:
         issue_summary.scores.fixability_score = fixability_score
-        issue_summary.scores.fixability_score_version = 2
+        issue_summary.scores.fixability_score_version = 3
         issue_summary.scores.is_fixable = is_fixable
         session.merge(issue_summary.to_db_state(request.group_id))
         session.commit()
@@ -243,5 +243,5 @@ def evaluate_autofixability(
         f"Possible cause: {issue_summary.possible_cause}"
     )
     score = autofixability_model.score(issue_summary_input)
-    is_fixable = score > 0.64727825  # 80th percentile
+    is_fixable = score > 0.724  # 80th percentile
     return score, is_fixable

--- a/src/seer/inference_models.py
+++ b/src/seer/inference_models.py
@@ -56,7 +56,7 @@ def grouping_lookup() -> GroupingLookup:
 
 @deferred_loading("AUTOFIXABILITY_SCORING_ENABLED")
 def autofixability_model() -> AutofixabilityModel:
-    return AutofixabilityModel(model_path("autofixability_v0/embeddings"))
+    return AutofixabilityModel(model_path("autofixability_v3/embeddings"))
 
 
 @deferred_loading("ANOMALY_DETECTION_ENABLED")

--- a/tests/automation/autofix/test_autofix_context.py
+++ b/tests/automation/autofix/test_autofix_context.py
@@ -120,7 +120,7 @@ class TestAutofixContext(unittest.TestCase):
                     possible_cause_novelty=0.8,
                     is_fixable=True,
                     fixability_score=0.9,
-                    fixability_score_version=1,
+                    fixability_score_version=3,
                 ),
             )
             session.add(original.to_db_state(0))
@@ -141,7 +141,7 @@ class TestAutofixContext(unittest.TestCase):
             self.assertEqual(result.scores.possible_cause_novelty, 0.8)
             self.assertEqual(result.scores.is_fixable, True)
             self.assertEqual(result.scores.fixability_score, 0.9)
-            self.assertEqual(result.scores.fixability_score_version, 1)
+            self.assertEqual(result.scores.fixability_score_version, 3)
 
         with Session() as session:
             invalid_summary_data = {"bad data": "uh oh"}

--- a/tests/automation/summarize/test_issue.py
+++ b/tests/automation/summarize/test_issue.py
@@ -254,7 +254,7 @@ class TestFixabilityScore:
 
     @pytest.fixture
     def autofixability_model(self):
-        return AutofixabilityModel("models/autofixability_v0/embeddings")
+        return AutofixabilityModel("models/autofixability_v3/embeddings")
 
     @patch("seer.automation.summarize.issue.evaluate_autofixability")
     @patch("seer.automation.summarize.issue.Session")
@@ -304,7 +304,7 @@ class TestFixabilityScore:
         assert result.group_id == 123
         assert result.scores is not None
         assert result.scores.fixability_score == 0.75
-        assert result.scores.fixability_score_version == 2
+        assert result.scores.fixability_score_version == 3
         assert result.scores.is_fixable is True
         for score_name, score_value in scores_current.items():
             assert getattr(result.scores, score_name) == score_value
@@ -340,7 +340,7 @@ class TestFixabilityScore:
         assert isinstance(is_fixable, bool)
         if not can_use_model_stubs():
             assert is_fixable
-            assert score == pytest.approx(0.68511546, abs=1e-5)
+            assert score == pytest.approx(0.7751516, abs=1e-5)
 
     def test_issue_summary_db_conversions(self, sample_issue_summary):
         # Test to_db_state
@@ -355,12 +355,12 @@ class TestFixabilityScore:
         # Update with fixability scores
         sample_issue_summary.scores.fixability_score = 0.85
         sample_issue_summary.scores.is_fixable = True
-        sample_issue_summary.scores.fixability_score_version = 2
+        sample_issue_summary.scores.fixability_score_version = 3
 
         db_state = sample_issue_summary.to_db_state(456)
         assert db_state.fixability_score == 0.85
         assert db_state.is_fixable is True
-        assert db_state.fixability_score_version == 2
+        assert db_state.fixability_score_version == 3
 
         # Test from_db_state
         db_summary = DbIssueSummary(
@@ -368,7 +368,7 @@ class TestFixabilityScore:
             summary=sample_issue_summary.model_dump(mode="json"),
             fixability_score=0.65,
             is_fixable=False,
-            fixability_score_version=2,
+            fixability_score_version=3,
         )
 
         loaded_summary = IssueSummaryWithScores.from_db_state(db_summary)
@@ -376,4 +376,4 @@ class TestFixabilityScore:
         assert loaded_summary.whats_wrong == sample_issue_summary.whats_wrong
         assert loaded_summary.scores.fixability_score == 0.65
         assert loaded_summary.scores.is_fixable is False
-        assert loaded_summary.scores.fixability_score_version == 2
+        assert loaded_summary.scores.fixability_score_version == 3

--- a/tests/test_seer.py
+++ b/tests/test_seer.py
@@ -533,7 +533,7 @@ class TestSeer(unittest.TestCase):
                 possible_cause_confidence=0.8,
                 possible_cause_novelty=0.6,
                 fixability_score=0.75,
-                fixability_score_version=2,
+                fixability_score_version=3,
                 is_fixable=True,
             ),
         )
@@ -554,7 +554,7 @@ class TestSeer(unittest.TestCase):
         response_data = json.loads(response.data)
         assert response_data["group_id"] == 123
         assert response_data["scores"]["fixability_score"] == 0.75
-        assert response_data["scores"]["fixability_score_version"] == 2
+        assert response_data["scores"]["fixability_score_version"] == 3
         assert response_data["scores"]["is_fixable"] is True
 
         expected_test_data, autofixability_model = mock_run_fixability_score.call_args[0]


### PR DESCRIPTION
added quite a bit more data. see [the notebook](https://github.com/getsentry/data-analysis/blob/main/autofix/issue_summary/autofixability/train.ipynb). main difference is that precision is around +10-15% higher for the top 10% of fixability scores. also looks cleaner, qualitatively