### PR TITLE
fix(ci): Force Wheel version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-    requires = ["setuptools>=40.2.0,<64.0.0", "wheel>=0.45.1,<0.46.0"]
+    requires = ["setuptools>=61.0.0", "wheel>=0.45.1"]
     build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-    requires = ["setuptools>=40.2.0,<64.0.0", "wheel"]
+    requires = ["setuptools>=40.2.0,<64.0.0", "wheel>=0.45.1,<0.46.0"]
     build-backend = "setuptools.build_meta"
 
 [tool.black]


### PR DESCRIPTION
We were getting this issue while building:
```
× Preparing metadata (pyproject.toml) did not run successfully.
3.153   │ exit code: 1
3.153   ╰─> [11 lines of output]
3.153       running dist_info
3.153       creating /tmp/pip-modern-metadata-i8f_l1xh/seer.egg-info
3.153       writing /tmp/pip-modern-metadata-i8f_l1xh/seer.egg-info/PKG-INFO
3.153       writing dependency_links to /tmp/pip-modern-metadata-i8f_l1xh/seer.egg-info/dependency_links.txt
3.153       writing requirements to /tmp/pip-modern-metadata-i8f_l1xh/seer.egg-info/requires.txt
3.153       writing top-level names to /tmp/pip-modern-metadata-i8f_l1xh/seer.egg-info/top_level.txt
3.153       writing manifest file '/tmp/pip-modern-metadata-i8f_l1xh/seer.egg-info/SOURCES.txt'
3.153       reading manifest file '/tmp/pip-modern-metadata-i8f_l1xh/seer.egg-info/SOURCES.txt'
3.153       writing manifest file '/tmp/pip-modern-metadata-i8f_l1xh/seer.egg-info/SOURCES.txt'
3.153       creating '/tmp/pip-modern-metadata-i8f_l1xh/seer-0.1.0.dist-info'
3.153       error: invalid command 'bdist_wheel'
3.153       [end of output]
3.153   
3.153   note: This error originates from a subprocess, and is likely not a problem with pip.
3.154 error: metadata-generation-failed
3.154 
3.154 × Encountered error while generating package metadata.
3.154 ╰─> See above for output.
3.154 
3.154 note: This is an issue with the package mentioned above, not pip.
3.154 hint: See above for details.
3.223 
3.223 [notice] A new release of pip is available: 24.0 -> 25.0.1
[+] Building 0/1o update, run: pip install --upgrade pip
 ⠙ Service app  Building                                                                                                                                                               4.2s 
failed to solve: process "/bin/sh -c pip install --default-timeout=120 -e . --no-cache-dir --no-deps" did not complete successfully: exit code: 1
make: *** [update] Error 17
```
Adding this dependency requirement seems to fix it locally.

My understanding is that the caching of the wheel dependency is getting messed up somewhere along the build process and by including this line, we're forcing it to basically reinstall/reset wheel during build