### PR TITLE
change relevant warnings prediction

### DIFF
--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -148,6 +148,7 @@ class StaticAnalysisWarning(BaseModel):
         return (
             textwrap.dedent(
                 f"""\
+            Warning ID: {self.id}
             Warning message: {self.message}
             ----------
             Location:

--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -129,6 +129,7 @@ class StaticAnalysisWarning(BaseModel):
     rule_id: int | None = None
     rule: StaticAnalysisRule | None = None
     encoded_code_snippet: str | None = None
+    potentially_related_issue_titles: list[str] | None = None
     # TODO: project info necessary for seer?
 
     def _try_get_language(self) -> str | None:
@@ -142,6 +143,8 @@ class StaticAnalysisWarning(BaseModel):
 
     def format_warning(self) -> str:
         location = Location.from_encoded(self.encoded_location)
+        related_issue_titles = self.potentially_related_issue_titles or []
+        formatted_issue_titles = "\n".join([f"* {title}" for title in related_issue_titles])
         return (
             textwrap.dedent(
                 f"""\
@@ -155,6 +158,8 @@ class StaticAnalysisWarning(BaseModel):
             ```{self._try_get_language() or ""}
             CODE_SNIPPET
             ```
+            Potentially related issue titles:
+            {formatted_issue_titles}
             ----------
             FORMATTED_RULE
             """

--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -159,15 +159,16 @@ class StaticAnalysisWarning(BaseModel):
             ```{self._try_get_language() or ""}
             CODE_SNIPPET
             ```
+            ----------
             Potentially related issue titles:
-            {formatted_issue_titles}
+            FORMATTED_ISSUE_TITLES
             ----------
             FORMATTED_RULE
             """
             )
             # Multiline strings being substituted inside textwrap.dedent would mess with the formatting.
             # So we substitute afterwards.
-            .replace(
-                "CODE_SNIPPET", textwrap.dedent(self.encoded_code_snippet or "").strip()
-            ).replace("FORMATTED_RULE", self.rule.format_rule() if self.rule else "")
+            .replace("CODE_SNIPPET", textwrap.dedent(self.encoded_code_snippet or "").strip())
+            .replace("FORMATTED_RULE", self.rule.format_rule() if self.rule else "")
+            .replace("FORMATTED_ISSUE_TITLES", formatted_issue_titles)
         )

--- a/src/seer/automation/codegen/codegen_event_manager.py
+++ b/src/seer/automation/codegen/codegen_event_manager.py
@@ -2,7 +2,7 @@ import dataclasses
 from datetime import datetime
 
 from seer.automation.autofix.components.insight_sharing.models import InsightSharingOutput
-from seer.automation.codegen.models import CodegenStatus, RelevantWarningResult
+from seer.automation.codegen.models import CodegenStatus, StaticAnalysisSuggestion
 from seer.automation.codegen.state import CodegenContinuationState
 from seer.automation.models import FileChange
 
@@ -27,11 +27,11 @@ class CodegenEventManager:
         with self.state.update() as current_state:
             current_state.file_changes.append(file_change)
 
-    def mark_completed_and_extend_relevant_warning_results(
-        self, relevant_warning_results: list[RelevantWarningResult]
+    def mark_completed_and_extend_static_analysis_suggestions(
+        self, static_analysis_suggestions: list[StaticAnalysisSuggestion]
     ):
         with self.state.update() as cur:
-            cur.relevant_warning_results.extend(relevant_warning_results)
+            cur.static_analysis_suggestions.extend(static_analysis_suggestions)
             cur.completed_at = datetime.now()
             cur.status = CodegenStatus.COMPLETED
 

--- a/src/seer/automation/codegen/models.py
+++ b/src/seer/automation/codegen/models.py
@@ -30,15 +30,31 @@ class RelevantWarningResult(BaseModel):
 
 
 class StaticAnalysisSuggestion(BaseModel):
-    path: str
-    line: int
-    short_description: str
-    justification: str
-    related_warning_id: str | None = None
-    related_issue_id: str | None = None
-    severity_score: float
-    confidence_score: float
-    missing_evidence: list[str]
+    path: str = Field(description="The path to the file that contains the suggestion.")
+    line: int = Field(description="The line number of the suggestion.")
+    short_description: str = Field(
+        description="A short, fluff-free, information-dense description of the problem. Max 30 words."
+    )
+    justification: str = Field(
+        description="A short, fluff-free, information-dense summary of your analysis for why this is a problem. This justification should be at most 15 words."
+    )
+    related_warning_id: str | None = Field(
+        default=None,
+        description="If this suggestion is based on a warning, include the warning id here. Else use null.",
+    )
+    related_issue_id: str | None = Field(
+        default=None,
+        description="If this suggestion is based on an issue, include the issue id here. Else use null.",
+    )
+    severity_score: float = Field(
+        description="From 0 to 1 how serious is this potential bug? 1 being 'guaranteed exception will happen and not be caught by the code'."
+    )
+    confidence_score: float = Field(
+        description="From 0 to 1 how confident are you that this is a bug? 1 being 'I am 100% confident that this is a bug'. This should be based on the amount of evidence you had to reach your conclusion."
+    )
+    missing_evidence: list[str] = Field(
+        description="A short list of evidence that you did NOT have but would increase your confidence score. At most 5 items. Be very specific."
+    )
 
     def to_overwatch_format(self) -> RelevantWarningResult:
         """

--- a/src/seer/automation/codegen/models.py
+++ b/src/seer/automation/codegen/models.py
@@ -29,10 +29,22 @@ class RelevantWarningResult(BaseModel):
     encoded_location: str
 
 
+class StaticAnalysisSuggestion(BaseModel):
+    path: str
+    line: int
+    short_description: str
+    justification: str
+    related_warning: str | None = None
+    related_issue: str | None = None
+    severity_score: float
+    confidence_score: float
+    missing_evidence: list[str]
+
+
 class CodegenState(BaseModel):
     run_id: int = -1
     file_changes: list[FileChange] = Field(default_factory=list)
-    relevant_warning_results: list[RelevantWarningResult] = Field(default_factory=list)
+    static_analysis_suggestions: list[StaticAnalysisSuggestion] = Field(default_factory=list)
     status: CodegenStatus = CodegenStatus.PENDING
     last_triggered_at: datetime.datetime = Field(default_factory=datetime.datetime.now)
     updated_at: datetime.datetime = Field(default_factory=datetime.datetime.now)
@@ -208,6 +220,16 @@ class CodePredictRelevantWarningsRequest(BaseComponentRequest):
 
 class CodeAreIssuesFixableOutput(BaseComponentOutput):
     are_fixable: list[bool | None]  # None means the issue was not analyzed
+
+
+class CodePredictStaticAnalysisSuggestionsRequest(BaseComponentRequest):
+    warnings: list[StaticAnalysisWarning]
+    fixable_issues: list[IssueDetails]
+    pr_files: list[PrFile]
+
+
+class CodePredictStaticAnalysisSuggestionsOutput(BaseComponentOutput):
+    suggestions: list[StaticAnalysisSuggestion]
 
 
 class CodePredictRelevantWarningsOutput(BaseComponentOutput):

--- a/src/seer/automation/codegen/models.py
+++ b/src/seer/automation/codegen/models.py
@@ -19,8 +19,8 @@ class CodegenStatus(str, Enum):
 
 
 class RelevantWarningResult(BaseModel):
-    warning_id: int
-    issue_id: int
+    warning_id: int | None
+    issue_id: int | None
     does_fixing_warning_fix_issue: bool
     relevance_probability: float
     reasoning: str
@@ -48,8 +48,8 @@ class StaticAnalysisSuggestion(BaseModel):
         TODO: update Overwatch and then remove this method
         """
         return RelevantWarningResult(
-            warning_id=self.related_warning_id,
-            issue_id=self.related_issue_id,
+            warning_id=int(self.related_warning_id) if self.related_warning_id else None,
+            issue_id=int(self.related_issue_id) if self.related_issue_id else None,
             # Let's pretend our suggestions are important
             does_fixing_warning_fix_issue=True,
             # Combining both metrics means we will only surface suggestions with high confidence
@@ -59,7 +59,7 @@ class StaticAnalysisSuggestion(BaseModel):
             short_justification=self.justification,
             short_description=self.short_description,
             encoded_location=Location(
-                filename=self.path, start_line=self.line, end_line=self.line
+                filename=self.path, start_line=str(self.line), end_line=str(self.line)
             ).encode(),
         )
 

--- a/src/seer/automation/codegen/prompts.py
+++ b/src/seer/automation/codegen/prompts.py
@@ -280,6 +280,18 @@ class IsFixableIssuePrompts(_RelevantWarningsPromptPrefix):
 class StaticAnalysisSuggestionsPrompts:
 
     @staticmethod
+    def format_system_msg():
+        return textwrap.dedent(
+            """\
+            You are an expert software engineer with deep expertise in static analysis, bug detection, and code review.
+            Your role is to analyze code changes and identify potential bugs or security issues that could lead to runtime errors or exceptions.
+            You have a keen eye for subtle issues that might not be immediately obvious, and you understand how different code patterns can lead to unexpected behavior.
+            When reviewing code, you focus exclusively on actual bugs and security vulnerabilities, ignoring style issues or minor improvements that don't affect functionality.
+            You provide precise, actionable feedback with clear severity and confidence assessments to help developers prioritize fixes.
+            """
+        )
+
+    @staticmethod
     def format_prompt(diff: str, formatted_warnings: str, formatted_issues: str):
         return textwrap.dedent(
             """\

--- a/src/seer/automation/codegen/prompts.py
+++ b/src/seer/automation/codegen/prompts.py
@@ -277,6 +277,58 @@ class IsFixableIssuePrompts(_RelevantWarningsPromptPrefix):
         ).format(error_prompt=_RelevantWarningsPromptPrefix.format_prompt_error(formatted_error))
 
 
+class StaticAnalysisSuggestionsPrompts(_RelevantWarningsPromptPrefix):
+
+    @staticmethod
+    def format_prompt(diff: str, formatted_warnings: str, formatted_issues: str):
+        return textwrap.dedent(
+            """\
+            You are given a diff block:
+            {diff}
+
+            You are also given a list of static analysis warnings that exist in the codebase close to the diff:
+            {formatted_warnings}
+
+            You are also given a list of existing Sentry issues that exist in the codebase close to the diff:
+            {formatted_issues}
+
+            # Your Goal:
+            Carefully review the code changes in the diff, understand the context and surface any potential bugs that might be introduced by the changes. In your review focus on actual bugs. You should IGNORE code style, nit suggestions, and anything else that is not likely to cause a Sentry issue.
+            You SHOULD make suggestions based on the warnings and issues provided, as well as your own analysis of the code.
+            Follow ALL the guidelines!!!
+
+            # Guidelines:
+            - Return AT MOST 5 suggestions, and AT MOST 1 suggestion per line of code.
+            - Focus on bugs, performance and security issues.
+            - Do NOT propose issues if the are outside the diff.
+            - ALWAYS include the exact file path and line of the suggestion.
+            - Assign a severity score and confidence score to each suggestion, from 0 to 1.
+                - Severity score: 1 being "guaranteed an _unchaught_ exception will happen and not be caught by the code"; 0.5 being "an exception will happen but it's being caught" OR "an exception may happen depending on inputs"; 0 being "no exception will happen";
+                - Confidence score: 1 being "I am 100%% confident that this is a bug";
+            - Only surface issues that _don't_ have a warning if BOTH severity AND confidence are high.
+            - DO NOT surface issues with low severity. DO NOT surface issues that are not bugs.
+            - Before giving your final answer, think step-by-step to ensure your review is thorough. We prefer fewer suggestions with high quality over more suggestions with low quality.
+
+            # Format:
+            - Return your response as a list of JSON objects, where each object is a suggestion. Your response should be ONLY the list of objects.
+            - Each suggestion must have the following fields:
+                - `path`: The path to the file that contains the suggestion.
+                - `line`: The line number of the suggestion.
+                - `short_description`: a short, fluff-free, information-dense description of the problem. Max 30 words.
+                - `justification`: a short, fluff-free, information-dense summary of your analysis for why this is a problem. This justification should be at most 15 words.
+                - `related_warning`: If this suggestion is based on a warning, include the warning id here. Else use null.
+                - `related_issue`: If this suggestion is based on an issue, include the issue id here. Else use null.
+                - `severity_score`: From 0 to 1 how serious is this potential bug? 1 being "guaranteed exception will happen and not be caught by the code".
+                - `confidence_score`: From 0 to 1 how confident are you that this is a bug? 1 being "I am 100%% confident that this is a bug". This should be based on the amount of evidence you had to reach your conclusion.
+                - `missing_evidence`: A short list of evidence that you did NOT have but would increase your confidence score. At most 5 items. Be very specific.
+            """
+        ).format(
+            diff=diff,
+            formatted_warnings=formatted_warnings,
+            formatted_issues=formatted_issues,
+        )
+
+
 class ReleventWarningsPrompts(_RelevantWarningsPromptPrefix):
 
     class DoesFixingWarningFixIssue(BaseModel):

--- a/src/seer/automation/codegen/prompts.py
+++ b/src/seer/automation/codegen/prompts.py
@@ -277,7 +277,7 @@ class IsFixableIssuePrompts(_RelevantWarningsPromptPrefix):
         ).format(error_prompt=_RelevantWarningsPromptPrefix.format_prompt_error(formatted_error))
 
 
-class StaticAnalysisSuggestionsPrompts(_RelevantWarningsPromptPrefix):
+class StaticAnalysisSuggestionsPrompts:
 
     @staticmethod
     def format_prompt(diff: str, formatted_warnings: str, formatted_issues: str):
@@ -299,28 +299,15 @@ class StaticAnalysisSuggestionsPrompts(_RelevantWarningsPromptPrefix):
 
             # Guidelines:
             - Return AT MOST 5 suggestions, and AT MOST 1 suggestion per line of code.
-            - Focus on bugs, performance and security issues.
+            - Focus ONLY on _bugs_ and _security issues_.
+            - Only surface issues that are caused by the code changes in the diff, or directly related to a warning.
             - Do NOT propose issues if the are outside the diff.
             - ALWAYS include the exact file path and line of the suggestion.
-            - Assign a severity score and confidence score to each suggestion, from 0 to 1.
-                - Severity score: 1 being "guaranteed an _unchaught_ exception will happen and not be caught by the code"; 0.5 being "an exception will happen but it's being caught" OR "an exception may happen depending on inputs"; 0 being "no exception will happen";
+            - Assign a severity score and confidence score to each suggestion, from 0 to 1. The score should be granular, e.g., 0.432.
+                - Severity score: 1 being "guaranteed an _uncaught_ exception will happen and not be caught by the code"; 0.5 being "an exception will happen but it's being caught" OR "an exception may happen depending on inputs"; 0 being "no exception will happen";
                 - Confidence score: 1 being "I am 100%% confident that this is a bug";
-            - Only surface issues that _don't_ have a warning if BOTH severity AND confidence are high.
-            - DO NOT surface issues with low severity. DO NOT surface issues that are not bugs.
             - Before giving your final answer, think step-by-step to ensure your review is thorough. We prefer fewer suggestions with high quality over more suggestions with low quality.
-
-            # Format:
             - Return your response as a list of JSON objects, where each object is a suggestion. Your response should be ONLY the list of objects.
-            - Each suggestion must have the following fields:
-                - `path`: The path to the file that contains the suggestion.
-                - `line`: The line number of the suggestion.
-                - `short_description`: a short, fluff-free, information-dense description of the problem. Max 30 words.
-                - `justification`: a short, fluff-free, information-dense summary of your analysis for why this is a problem. This justification should be at most 15 words.
-                - `related_warning_id`: If this suggestion is based on a warning, include the warning id here. Else use null.
-                - `related_issue_id`: If this suggestion is based on an issue, include the issue id here. Else use null.
-                - `severity_score`: From 0 to 1 how serious is this potential bug? 1 being "guaranteed exception will happen and not be caught by the code".
-                - `confidence_score`: From 0 to 1 how confident are you that this is a bug? 1 being "I am 100%% confident that this is a bug". This should be based on the amount of evidence you had to reach your conclusion.
-                - `missing_evidence`: A short list of evidence that you did NOT have but would increase your confidence score. At most 5 items. Be very specific.
             """
         ).format(
             diff=diff,

--- a/src/seer/automation/codegen/prompts.py
+++ b/src/seer/automation/codegen/prompts.py
@@ -316,8 +316,8 @@ class StaticAnalysisSuggestionsPrompts(_RelevantWarningsPromptPrefix):
                 - `line`: The line number of the suggestion.
                 - `short_description`: a short, fluff-free, information-dense description of the problem. Max 30 words.
                 - `justification`: a short, fluff-free, information-dense summary of your analysis for why this is a problem. This justification should be at most 15 words.
-                - `related_warning`: If this suggestion is based on a warning, include the warning id here. Else use null.
-                - `related_issue`: If this suggestion is based on an issue, include the issue id here. Else use null.
+                - `related_warning_id`: If this suggestion is based on a warning, include the warning id here. Else use null.
+                - `related_issue_id`: If this suggestion is based on an issue, include the issue id here. Else use null.
                 - `severity_score`: From 0 to 1 how serious is this potential bug? 1 being "guaranteed exception will happen and not be caught by the code".
                 - `confidence_score`: From 0 to 1 how confident are you that this is a bug? 1 being "I am 100%% confident that this is a bug". This should be based on the amount of evidence you had to reach your conclusion.
                 - `missing_evidence`: A short list of evidence that you did NOT have but would increase your confidence score. At most 5 items. Be very specific.

--- a/src/seer/automation/codegen/relevant_warnings_component.py
+++ b/src/seer/automation/codegen/relevant_warnings_component.py
@@ -531,6 +531,18 @@ class StaticAnalysisSuggestionsComponent(
     surface potential issues in the diff (according to an LLM)
     """
 
+    def _format_issue(self, issue: IssueDetails) -> str:
+        # EventDetails are not formatted with the ID, so we add it manually.
+        # Also the formatting is a weird half-XML, so we complete the XML tags.
+        event_details = EventDetails.from_event(issue.events[0]).format_event_without_breadcrumbs()
+        title, other_lines = event_details.split("\n", 1)
+        return (
+            f"<sentry_issue><issue_id>{issue.id}</issue_id>\n"
+            + f"<title>{title}</title>\n"
+            + other_lines
+            + "</sentry_issue>"
+        )
+
     @observe(name="Codegen - Relevant Warnings - Static-Analysis-Suggestions-Based Component")
     @ai_track(
         description="Codegen - Relevant Warnings - Static-Analysis-Suggestions-Based Component"
@@ -539,7 +551,17 @@ class StaticAnalysisSuggestionsComponent(
     def invoke(
         self, request: CodePredictStaticAnalysisSuggestionsRequest, llm_client: LlmClient = injected
     ) -> CodePredictStaticAnalysisSuggestionsOutput | None:
+        # Current open questions on trading-off context for suggestions:
+        # Limit diff size?
+        # Limit number of warnings?
+        # Limit number of fixable issues? or issue size?
+        # Better, more concise way to encode the information for the LLM in the prompt?
         diff = "\n".join([pr_file.patch for pr_file in request.pr_files])
+        formatted_issues = (
+            "<sentry_issues>\n"
+            + "\n".join([self._format_issue(issue) for issue in request.fixable_issues])
+            + "</sentry_issues>"
+        )
         completion = llm_client.generate_structured(
             model=GeminiProvider.model("gemini-2.0-flash-001"),
             system_prompt=StaticAnalysisSuggestionsPrompts.format_system_msg(),
@@ -548,17 +570,7 @@ class StaticAnalysisSuggestionsComponent(
                 formatted_warnings=json.dumps(
                     list(map(lambda w: w.format_warning(), request.warnings)), indent=2
                 ),
-                formatted_issues=json.dumps(
-                    list(
-                        map(
-                            lambda i: EventDetails.from_event(
-                                i.events[0]
-                            ).format_event_without_breadcrumbs(),
-                            request.fixable_issues,
-                        )
-                    ),
-                    indent=2,
-                ),
+                formatted_issues=formatted_issues,
             ),
             response_format=list[StaticAnalysisSuggestion],
             temperature=0.0,

--- a/src/seer/automation/codegen/relevant_warnings_step.py
+++ b/src/seer/automation/codegen/relevant_warnings_step.py
@@ -1,3 +1,4 @@
+import itertools
 import json
 import logging
 from typing import Any
@@ -23,6 +24,8 @@ from seer.automation.codegen.models import (
     CodegenRelevantWarningsRequest,
     CodePredictRelevantWarningsOutput,
     CodePredictRelevantWarningsRequest,
+    CodePredictStaticAnalysisSuggestionsOutput,
+    CodePredictStaticAnalysisSuggestionsRequest,
     FilterWarningsOutput,
     FilterWarningsRequest,
     PrFile,
@@ -33,6 +36,7 @@ from seer.automation.codegen.relevant_warnings_component import (
     FetchIssuesComponent,
     FilterWarningsComponent,
     PredictRelevantWarningsComponent,
+    StaticAnalysisSuggestionsComponent,
 )
 from seer.automation.codegen.step import CodegenStep
 from seer.automation.pipeline import PipelineStepTaskRequest
@@ -75,9 +79,15 @@ class RelevantWarningsStep(CodegenStep):
     @inject
     def _post_results_to_overwatch(
         self,
-        relevant_warnings_output: CodePredictRelevantWarningsOutput,
+        relevant_warnings_output: CodePredictStaticAnalysisSuggestionsOutput | None,
         config: AppConfig = injected,
     ):
+        if relevant_warnings_output is None:
+            self.logger.info("No relevant warnings output to post to Overwatch.")
+            return
+
+        with open("/app/.artifacts/relevant_warnings_output.json", "w") as f:
+            json.dump(relevant_warnings_output.model_dump(), f, indent=4)
         if not self.request.should_post_to_overwatch:
             self.logger.info("Skipping posting relevant warnings results to Overwatch.")
             return
@@ -98,20 +108,24 @@ class RelevantWarningsStep(CodegenStep):
             data=request_data,
         ).raise_for_status()
 
-    def _complete_run(self, relevant_warnings_output: CodePredictRelevantWarningsOutput):
+    def _complete_run(
+        self, static_analysis_suggestions_output: CodePredictStaticAnalysisSuggestionsOutput | None
+    ):
         try:
-            self._post_results_to_overwatch(relevant_warnings_output)
+            self._post_results_to_overwatch(static_analysis_suggestions_output)
         except Exception:
             self.logger.exception("Error posting relevant warnings results to Overwatch")
             raise
         finally:
-            self.context.event_manager.mark_completed_and_extend_relevant_warning_results(
-                relevant_warnings_output.relevant_warning_results
+            self.context.event_manager.mark_completed_and_extend_static_analysis_suggestions(
+                static_analysis_suggestions_output.suggestions
+                if static_analysis_suggestions_output
+                else []
             )
 
     @observe(name="Codegen - Relevant Warnings Step")
     @ai_track(description="Codegen - Relevant Warnings Step")
-    def _invoke(self, **kwargs):
+    def _invoke(self, **kwargs) -> None:
         self.logger.info("Executing Codegen - Relevant Warnings Step")
         self.context.event_manager.mark_running()
 
@@ -142,7 +156,7 @@ class RelevantWarningsStep(CodegenStep):
 
         if not warnings:  # exit early to avoid unnecessary issue-fetching.
             self.logger.info("No warnings to predict relevancy for.")
-            self._complete_run(CodePredictRelevantWarningsOutput(relevant_warning_results=[]))
+            self._complete_run(None)
             return
 
         # 3. Fetch issues related to the PR.
@@ -153,7 +167,11 @@ class RelevantWarningsStep(CodegenStep):
         fetch_issues_output: CodeFetchIssuesOutput = fetch_issues_component.invoke(
             fetch_issues_request
         )
-
+        # Clamp issue to max_num_issues_analyzed
+        all_selected_issues = list(
+            itertools.chain.from_iterable(fetch_issues_output.filename_to_issues.values())
+        )
+        all_selected_issues = all_selected_issues[: self.request.max_num_issues_analyzed]
         # 4. Limit the number of warning-issue associations we analyze to the top
         #    max_num_associations.
         association_component = AssociateWarningsWithIssuesComponent(self.context)
@@ -165,33 +183,52 @@ class RelevantWarningsStep(CodegenStep):
         associations_output: AssociateWarningsWithIssuesOutput = association_component.invoke(
             associations_request
         )
-        associations = associations_output.candidate_associations
+        # Annotate the warnings with potential issues associated
+        for association in associations_output.candidate_associations:
+            assoc_warning, assoc_issue = association
+            warning_from_list = next((w for w in warnings if w.id == assoc_warning.id), None)
+            if warning_from_list:
+                if isinstance(warning_from_list.potentially_related_issue_titles, list):
+                    warning_from_list.potentially_related_issue_titles.append(assoc_issue.title)
+                else:
+                    warning_from_list.potentially_related_issue_titles = [assoc_issue.title]
 
-        # 5. Filter out unfixable issues b/c our definition of "relevant" is that fixing the warning
-        #    will fix the issue.
+        # 5. Filter out unfixable issues b/c it doesn't make much sense to raise suggestions for issues you can't fix.
         are_issues_fixable_component = AreIssuesFixableComponent(self.context)
         are_fixable_output: CodeAreIssuesFixableOutput = are_issues_fixable_component.invoke(
             CodeAreIssuesFixableRequest(
-                candidate_issues=[issue for _, issue in associations],
+                candidate_issues=all_selected_issues,
                 max_num_issues_analyzed=self.request.max_num_issues_analyzed,
             )
         )
-        associations_with_fixable_issues = [
-            association
-            for association, is_fixable in zip(
-                associations, are_fixable_output.are_fixable, strict=True
+        fixable_issues = [
+            issue
+            for issue, is_fixable in zip(
+                all_selected_issues,
+                are_fixable_output.are_fixable,
+                strict=True,
             )
             if is_fixable
         ]
 
+        # 6. Suggest issues based on static analysis warnings and fixable issues.
+        static_analysis_suggestions_component = StaticAnalysisSuggestionsComponent(self.context)
+        static_analysis_suggestions_request = CodePredictStaticAnalysisSuggestionsRequest(
+            warnings=warnings,
+            fixable_issues=fixable_issues,
+            pr_files=pr_files,
+        )
+        static_analysis_suggestions_output: CodePredictStaticAnalysisSuggestionsOutput = (
+            static_analysis_suggestions_component.invoke(static_analysis_suggestions_request)
+        )
         # 6. Predict which warnings are relevant to which issues.
-        prediction_component = PredictRelevantWarningsComponent(self.context)
-        request = CodePredictRelevantWarningsRequest(
-            candidate_associations=associations_with_fixable_issues
-        )
-        relevant_warnings_output: CodePredictRelevantWarningsOutput = prediction_component.invoke(
-            request
-        )
+        # prediction_component = PredictRelevantWarningsComponent(self.context)
+        # request = CodePredictRelevantWarningsRequest(
+        #     candidate_associations=fixa
+        # )
+        # relevant_warnings_output: CodePredictRelevantWarningsOutput = prediction_component.invoke(
+        #     request
+        # )
 
         # 7. Save results.
-        self._complete_run(relevant_warnings_output)
+        self._complete_run(static_analysis_suggestions_output)

--- a/src/seer/automation/codegen/relevant_warnings_step.py
+++ b/src/seer/automation/codegen/relevant_warnings_step.py
@@ -79,22 +79,21 @@ class RelevantWarningsStep(CodegenStep):
         llm_suggestions: CodePredictStaticAnalysisSuggestionsOutput | None,
         config: AppConfig = injected,
     ):
-        if llm_suggestions is None:
-            self.logger.info("No relevant warnings output to post to Overwatch.")
-            return
 
-        with open("/app/.artifacts/relevant_warnings_output.json", "w") as f:
-            json.dump(llm_suggestions.model_dump(), f, indent=4)
         if not self.request.should_post_to_overwatch:
             self.logger.info("Skipping posting relevant warnings results to Overwatch.")
             return
 
         # This should be a temporary solution until we can update
         # Overwatch to accept the new format.
-        suggestions_to_overwatch_expected_format = [
-            suggestion.to_overwatch_format().model_dump()
-            for suggestion in llm_suggestions.suggestions
-        ]
+        suggestions_to_overwatch_expected_format = (
+            [
+                suggestion.to_overwatch_format().model_dump()
+                for suggestion in llm_suggestions.suggestions
+            ]
+            if llm_suggestions
+            else []
+        )
 
         request = {
             "run_id": self.context.run_id,


### PR DESCRIPTION
Significant changes to the Relevant Warnings Step so that we suggestions are better.

* Don't require warning _and_ issue to exist
* Add diff to the analysis
* Change prompt to _predict_ potential issues

This is a significant change to the relevant warnings step. It moves somewhat away from the warnings as the sole main focus, and kinda equally use warnings and issues as extra context for the LLM to evaluate the PR dif.

It changes several smaller LLM calls (that decide if warnings and issues can be paired logically) by 1 bigger one (that analyses the entire diff). Works well for small diffs and a small number of warnings and issues, but we're not very sure the scaling factor here.

The next steps would be to better limit the size of the diff, or break it up into different chunks and analyze the chunks individually.