### PR TITLE
ref: Use SENTRY_REGION instead of USE_EU_REGION

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
             - DATABASE_URL=postgresql+psycopg://root:seer@db/seer
             - GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json
             - GOOGLE_CLOUD_PROJECT=ml-ai-420606
-            - USE_EU_REGION=0
+            - SENTRY_REGION=us
             - IGNORE_API_AUTH=1
         ports:
             - "${APP_PORT:-9091}:9091" # Local dev sentry app looks for port 9091 for the seer service.

--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -431,7 +431,7 @@ class AnthropicProvider:
     def get_client(app_config: AppConfig = injected) -> anthropic.AnthropicVertex:
         return anthropic.AnthropicVertex(
             project_id=app_config.GOOGLE_CLOUD_PROJECT,
-            region="europe-west1" if app_config.USE_EU_REGION else "us-east5",
+            region="europe-west1" if app_config.SENTRY_REGION == "eu" else "us-east5",
             max_retries=8,
         )
 

--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -431,7 +431,7 @@ class AnthropicProvider:
     def get_client(app_config: AppConfig = injected) -> anthropic.AnthropicVertex:
         return anthropic.AnthropicVertex(
             project_id=app_config.GOOGLE_CLOUD_PROJECT,
-            region="europe-west1" if app_config.SENTRY_REGION == "eu" else "us-east5",
+            region="europe-west1" if app_config.SENTRY_REGION == "de" else "us-east5",
             max_retries=8,
         )
 

--- a/src/seer/bootup.py
+++ b/src/seer/bootup.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 import sentry_sdk
 from psycopg import Connection

--- a/src/seer/bootup.py
+++ b/src/seer/bootup.py
@@ -68,9 +68,8 @@ def initialize_sentry_sdk(integrations: list[Integration], config: AppConfig = i
         },
     )
 
-    sentry_region = os.environ.get("SENTRY_REGION")
-    if sentry_region:
-        sentry_sdk.set_tag("sentry_region", sentry_region)
+    if config.SENTRY_REGION:
+        sentry_sdk.set_tag("sentry_region", config.SENTRY_REGION)
 
 
 module.enable()

--- a/src/seer/configuration.py
+++ b/src/seer/configuration.py
@@ -44,6 +44,7 @@ class AppConfig(BaseModel):
 
     SENTRY_DSN: str = ""
     SENTRY_ENVIRONMENT: str = "production"
+    SENTRY_REGION: str = ""
 
     DATABASE_URL: str
     DATABASE_MIGRATIONS_URL: str | None = None
@@ -71,7 +72,6 @@ class AppConfig(BaseModel):
     DEV: ParseBool = False
 
     GOOGLE_CLOUD_PROJECT: str = ""
-    USE_EU_REGION: ParseBool = False
 
     SMOKE_CHECK: ParseBool = False
 
@@ -147,6 +147,7 @@ class AppConfig(BaseModel):
 
             assert self.has_sentry_integration, "Sentry integration required for production mode."
             assert self.SENTRY_DSN, "SENTRY_DSN required for production!"
+            assert self.SENTRY_REGION, "SENTRY_REGION required for production!"
 
             # assert self.LANGFUSE_HOST, "LANGFUSE_HOST required for production!"
             # assert self.LANGFUSE_PUBLIC_KEY, "LANGFUSE_PUBLIC_KEY required for production!"


### PR DESCRIPTION
`SENTRY_REGION` is already set in all the seers in prod via https://github.com/getsentry/ops/pull/14607

(The AppConfig setup will fail the deploy if this var is not actually set)