### PR TITLE
fix(autofix-evals): move score outside observation

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Send a POST request to `/v1/automation/autofix/evaluations/start` with the follo
 ```jsonc
 {
 "dataset_name": "string", // Name of the dataset to run on (currently only internal datasets available)
-"run_name": "string", // Custom name for your evaluation run
+"run_name": "string", // Custom name for your evaluation run...MAKE SURE THIS NAME IS UNIQUE EVEN IF YOU DELETED A PREVIOUS RUN! LANGFUSE KEYS ON THIS!!
 "run_description": "string", // Description of your evaluation run
 "run_type": "full | root_cause | execution", // Type of evaluation to perform
 "test": boolean, // Set to true to run on a single item (for testing)

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -1123,5 +1123,3 @@ def run_autofix_evaluation_on_item(
             value=mean_conciseness_score,
         )
         # If no coding scores, we don't do anything...
-
-    print("I AM DONE!, item_index:", item_index, item_id)


### PR DESCRIPTION
Moves the scoring calls outside the main eval item observation context manager. This is part of fixing the bug we saw where we had nested eval runs.

The 2nd part of that is we **NEED** to run each eval run with a unique name, even if you deleted the previous one