### PR TITLE
fix(relevant-warnings) Order evidence before confidence

### DIFF
--- a/src/seer/automation/codegen/models.py
+++ b/src/seer/automation/codegen/models.py
@@ -48,14 +48,14 @@ class StaticAnalysisSuggestion(BaseModel):
         default=None,
         description="If this suggestion is based on an issue, include the issue id here. Else use null.",
     )
+    missing_evidence: list[str] = Field(
+        description="A short list of evidence that you did NOT have but would increase your confidence score. At most 5 items. Be very specific."
+    )
     severity_score: float = Field(
         description="From 0 to 1 how serious is this potential bug? 1 being 'guaranteed exception will happen and not be caught by the code'."
     )
     confidence_score: float = Field(
         description="From 0 to 1 how confident are you that this is a bug? 1 being 'I am 100% confident that this is a bug'. This should be based on the amount of evidence you had to reach your conclusion."
-    )
-    missing_evidence: list[str] = Field(
-        description="A short list of evidence that you did NOT have but would increase your confidence score. At most 5 items. Be very specific."
     )
 
     def to_overwatch_format(self) -> RelevantWarningResult:

--- a/tests/automation/codegen/test_relevant_warnings.py
+++ b/tests/automation/codegen/test_relevant_warnings.py
@@ -1011,9 +1011,9 @@ class TestStaticAnalysisSuggestionsComponent:
                     justification="Test justification",
                     related_warning_id="123",
                     related_issue_id="456",
+                    missing_evidence=["More context", "Test cases"],
                     severity_score=0.8,
                     confidence_score=0.9,
-                    missing_evidence=["More context", "Test cases"],
                 )
             ]
             # Set the parsed attribute directly
@@ -1054,9 +1054,9 @@ class TestStaticAnalysisSuggestionsComponent:
         assert output.suggestions[0].justification == "Test justification"
         assert output.suggestions[0].related_warning_id == "123"
         assert output.suggestions[0].related_issue_id == "456"
+        assert output.suggestions[0].missing_evidence == ["More context", "Test cases"]
         assert output.suggestions[0].severity_score == 0.8
         assert output.suggestions[0].confidence_score == 0.9
-        assert output.suggestions[0].missing_evidence == ["More context", "Test cases"]
 
     def test_invoke_no_suggestions(
         self, component: StaticAnalysisSuggestionsComponent, monkeypatch
@@ -1119,9 +1119,9 @@ class TestStaticAnalysisSuggestionsComponent:
                 justification="This is a test justification",
                 related_warning_id="123",
                 related_issue_id="456",
+                missing_evidence=[],
                 severity_score=0.8,
                 confidence_score=0.9,
-                missing_evidence=[],
             ),
             {
                 "warning_id": 123,
@@ -1142,9 +1142,9 @@ class TestStaticAnalysisSuggestionsComponent:
                 justification="Another justification",
                 related_warning_id="789",
                 related_issue_id="101",
+                missing_evidence=["evidence1", "evidence2"],
                 severity_score=0.5,
                 confidence_score=0.6,
-                missing_evidence=["evidence1", "evidence2"],
             ),
             {
                 "warning_id": 789,
@@ -1165,9 +1165,9 @@ class TestStaticAnalysisSuggestionsComponent:
                 justification="Minimal justification",
                 related_warning_id=None,
                 related_issue_id=None,
+                missing_evidence=[],
                 severity_score=0.1,
                 confidence_score=0.2,
-                missing_evidence=[],
             ),
             {
                 "warning_id": None,


### PR DESCRIPTION
Structured output respects order, so will probably get better confidence scores if the missing evidence is generated before confidence. Missed this minor thing during review. 