### PR TITLE
feat(relevant-warnings) Embed warnings into diff

### DIFF
--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -209,8 +209,7 @@ class StaticAnalysisWarning(BaseModel):
             Potentially related issue titles:
             {formatted_issue_titles}
             ----------
-            {formatted_rule}</warning>
-            """
+            {formatted_rule}</warning>"""
         ).format(
             id=self.id,
             message=self.message,

--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -190,7 +190,8 @@ class StaticAnalysisWarning(BaseModel):
                 Code Snippet:
                 ```{language}
                 {snippet}
-                ```"""
+                ```
+                """
             ).format(language=language, snippet=self.encoded_code_snippet)
         else:
             formatted_code_snippet = ""
@@ -204,13 +205,11 @@ class StaticAnalysisWarning(BaseModel):
                 filename: {location_filename}
                 start_line: {location_start_line}
                 end_line: {location_end_line}
-            {formatted_code_snippet}
-            ----------
+            {formatted_code_snippet}----------
             Potentially related issue titles:
             {formatted_issue_titles}
             ----------
-            {formatted_rule}
-            </warning>
+            {formatted_rule}</warning>
             """
         ).format(
             id=self.id,

--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -199,6 +199,7 @@ class StaticAnalysisWarning(BaseModel):
         return textwrap.dedent(
             """\
             <warning><warning_id>{id}</warning_id>
+            Warning (ID {id})
             Warning message: {message}
             ----------
             Location:

--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -175,7 +175,7 @@ class StaticAnalysisWarning(BaseModel):
     def end_line(self) -> int:
         return int(Location.from_encoded(self.encoded_location).end_line)
 
-    def format_warning(self) -> str:
+    def format_warning(self, filename: str | None = None) -> str:
         location = Location.from_encoded(self.encoded_location)
         if not self.potentially_related_issue_titles:
             formatted_issue_titles = "    (no related issues found)"
@@ -213,7 +213,7 @@ class StaticAnalysisWarning(BaseModel):
         ).format(
             id=self.id,
             message=self.message,
-            location_filename=location.filename,
+            location_filename=filename or location.filename,
             location_start_line=location.start_line,
             location_end_line=location.end_line,
             formatted_code_snippet=formatted_code_snippet,

--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -167,6 +167,14 @@ class StaticAnalysisWarning(BaseModel):
             return "php"
         return None
 
+    @property
+    def start_line(self) -> int:
+        return int(Location.from_encoded(self.encoded_location).start_line)
+
+    @property
+    def end_line(self) -> int:
+        return int(Location.from_encoded(self.encoded_location).end_line)
+
     def format_warning(self) -> str:
         location = Location.from_encoded(self.encoded_location)
         related_issue_titles = self.potentially_related_issue_titles or []

--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -206,3 +206,6 @@ class StaticAnalysisWarning(BaseModel):
             .replace("FORMATTED_RULE", self.rule.format_rule() if self.rule else "")
             .replace("FORMATTED_ISSUE_TITLES", formatted_issue_titles)
         )
+
+    def format_warning_id_and_message(self) -> str:
+        return f"WARNING (ID {self.id}): {self.message}"

--- a/src/seer/automation/codebase/models.py
+++ b/src/seer/automation/codebase/models.py
@@ -177,34 +177,50 @@ class StaticAnalysisWarning(BaseModel):
 
     def format_warning(self) -> str:
         location = Location.from_encoded(self.encoded_location)
-        related_issue_titles = self.potentially_related_issue_titles or []
-        formatted_issue_titles = "\n".join([f"* {title}" for title in related_issue_titles])
-        return (
-            textwrap.dedent(
-                f"""\
-            Warning ID: {self.id}
-            Warning message: {self.message}
+        if not self.potentially_related_issue_titles:
+            formatted_issue_titles = "    (no related issues found)"
+        else:
+            related_issue_titles = self.potentially_related_issue_titles or []
+            formatted_issue_titles = "\n".join([f"* {title}" for title in related_issue_titles])
+
+        if (language := self._try_get_language()) and (self.encoded_code_snippet):
+            formatted_code_snippet = textwrap.dedent(
+                """\
+                ----------
+                Code Snippet:
+                ```{language}
+                {snippet}
+                ```"""
+            ).format(language=language, snippet=self.encoded_code_snippet)
+        else:
+            formatted_code_snippet = ""
+
+        return textwrap.dedent(
+            """\
+            <warning><warning_id>{id}</warning_id>
+            Warning message: {message}
             ----------
             Location:
-                filename: {location.filename}
-                start_line: {location.start_line}
-                end_line: {location.end_line}
-            Code Snippet:
-            ```{self._try_get_language() or ""}
-            CODE_SNIPPET
-            ```
+                filename: {location_filename}
+                start_line: {location_start_line}
+                end_line: {location_end_line}
+            {formatted_code_snippet}
             ----------
             Potentially related issue titles:
-            FORMATTED_ISSUE_TITLES
+            {formatted_issue_titles}
             ----------
-            FORMATTED_RULE
+            {formatted_rule}
+            </warning>
             """
-            )
-            # Multiline strings being substituted inside textwrap.dedent would mess with the formatting.
-            # So we substitute afterwards.
-            .replace("CODE_SNIPPET", textwrap.dedent(self.encoded_code_snippet or "").strip())
-            .replace("FORMATTED_RULE", self.rule.format_rule() if self.rule else "")
-            .replace("FORMATTED_ISSUE_TITLES", formatted_issue_titles)
+        ).format(
+            id=self.id,
+            message=self.message,
+            location_filename=location.filename,
+            location_start_line=location.start_line,
+            location_end_line=location.end_line,
+            formatted_code_snippet=formatted_code_snippet,
+            formatted_issue_titles=formatted_issue_titles,
+            formatted_rule=self.rule.format_rule() if self.rule else "",
         )
 
     def format_warning_id_and_message(self) -> str:

--- a/src/seer/automation/codegen/models.py
+++ b/src/seer/automation/codegen/models.py
@@ -32,9 +32,7 @@ class RelevantWarningResult(BaseModel):
 
 
 class StaticAnalysisSuggestion(BaseModel):
-    path: str = Field(
-        description="The path to the file that contains the suggestion, as indicated in the <filename> tag."
-    )
+    path: str = Field(description="The path to the file that contains the suggestion.")
     line: int = Field(description="The line number of the suggestion.")
     short_description: str = Field(
         description=(

--- a/src/seer/automation/codegen/models.py
+++ b/src/seer/automation/codegen/models.py
@@ -225,10 +225,7 @@ class WarningAndPrFile(BaseModel):
 
     @cached_property
     def overlapping_hunk_idxs(self) -> list[int]:
-        warning_location = Location.from_encoded(self.warning.encoded_location)
-        warning_start = int(warning_location.start_line)
-        warning_end = int(warning_location.end_line)
-        return self.pr_file.overlapping_hunk_idxs(warning_start, warning_end)
+        return self.pr_file.overlapping_hunk_idxs(self.warning.start_line, self.warning.end_line)
 
     def format_overlapping_hunks(self) -> str:
         """
@@ -287,7 +284,7 @@ class CodePredictRelevantWarningsRequest(BaseComponentRequest):
 
 
 class CodePredictStaticAnalysisSuggestionsRequest(BaseComponentRequest):
-    warnings: list[StaticAnalysisWarning]
+    warning_and_pr_files: list[WarningAndPrFile]
     fixable_issues: list[IssueDetails]
     pr_files: list[PrFile]
 

--- a/src/seer/automation/codegen/models.py
+++ b/src/seer/automation/codegen/models.py
@@ -35,10 +35,17 @@ class StaticAnalysisSuggestion(BaseModel):
     path: str = Field(description="The path to the file that contains the suggestion.")
     line: int = Field(description="The line number of the suggestion.")
     short_description: str = Field(
-        description="A short, fluff-free, information-dense description of the problem. Max 30 words."
+        description=(
+            "A short, fluff-free, information-dense description of the problem. Max 30 words. "
+            "Don't mention warnings or issues by their IDs; mention the substantive problem."
+        )
     )
     justification: str = Field(
-        description="A short, fluff-free, information-dense summary of your analysis for why this is a problem. This justification should be at most 15 words."
+        description=(
+            "A short, fluff-free, information-dense summary of your analysis for why this is a problem. "
+            "This justification should be at most 15 words. "
+            "Don't mention warnings or issues by their IDs; justify the substantive problem."
+        )
     )
     related_warning_id: str | None = Field(
         default=None,

--- a/src/seer/automation/codegen/models.py
+++ b/src/seer/automation/codegen/models.py
@@ -36,15 +36,18 @@ class StaticAnalysisSuggestion(BaseModel):
     line: int = Field(description="The line number of the suggestion.")
     short_description: str = Field(
         description=(
-            "A short, fluff-free, information-dense description of the problem. Max 30 words. "
-            "Don't mention warnings or issues by their IDs; mention the substantive problem."
+            "A short, fluff-free, information-dense description of the problem. "
+            "Max 30 words. "
+            "Don't mention warnings or issues by their IDs, or that this is a static analysis warning. "
+            "Focus on the substantive problem."
         )
     )
     justification: str = Field(
         description=(
             "A short, fluff-free, information-dense summary of your analysis for why this is a problem. "
-            "This justification should be at most 15 words. "
-            "Don't mention warnings or issues by their IDs; justify the substantive problem."
+            "Max 30 words. "
+            "Don't mention warnings or issues by their IDs, or that this is a static analysis warning. "
+            "Focus on the substantive problem."
         )
     )
     related_warning_id: str | None = Field(

--- a/src/seer/automation/codegen/models.py
+++ b/src/seer/automation/codegen/models.py
@@ -32,7 +32,9 @@ class RelevantWarningResult(BaseModel):
 
 
 class StaticAnalysisSuggestion(BaseModel):
-    path: str = Field(description="The path to the file that contains the suggestion.")
+    path: str = Field(
+        description="The path to the file that contains the suggestion, as indicated in the <filename> tag."
+    )
     line: int = Field(description="The line number of the suggestion.")
     short_description: str = Field(
         description=(

--- a/src/seer/automation/codegen/prompts.py
+++ b/src/seer/automation/codegen/prompts.py
@@ -296,6 +296,7 @@ class StaticAnalysisSuggestionsPrompts:
         return textwrap.dedent(
             """\
             You are given a diff block annotated with static analysis warnings:
+
             {diff_with_warnings}
 
             You are also given a list of existing Sentry issues that exist in the codebase close to the diff:

--- a/src/seer/automation/codegen/prompts.py
+++ b/src/seer/automation/codegen/prompts.py
@@ -292,20 +292,17 @@ class StaticAnalysisSuggestionsPrompts:
         )
 
     @staticmethod
-    def format_prompt(diff: str, formatted_warnings: str, formatted_issues: str):
+    def format_prompt(diff_with_warnings: str, formatted_issues: str):
         return textwrap.dedent(
             """\
-            You are given a diff block:
-            {diff}
-
-            You are also given a list of static analysis warnings that exist in the codebase close to the diff:
-            {formatted_warnings}
+            You are given a diff block annotated with static analysis warnings:
+            {diff_with_warnings}
 
             You are also given a list of existing Sentry issues that exist in the codebase close to the diff:
             {formatted_issues}
 
             # Your Goal:
-            Carefully review the code changes in the diff, understand the context and surface any potential bugs that might be introduced by the changes. In your review focus on actual bugs. You should IGNORE code style, nit suggestions, and anything else that is not likely to cause a Sentry issue.
+            Carefully review the code changes in the diff, understand the context and surface any potential bugs that might be introduced by the changes. In your review focus on actual bugs. You should IGNORE code style, nit suggestions, and anything else that is not likely to cause a production issue.
             You SHOULD make suggestions based on the warnings and issues provided, as well as your own analysis of the code.
             Follow ALL the guidelines!!!
 
@@ -322,8 +319,7 @@ class StaticAnalysisSuggestionsPrompts:
             - Return your response as a list of JSON objects, where each object is a suggestion. Your response should be ONLY the list of objects.
             """
         ).format(
-            diff=diff,
-            formatted_warnings=formatted_warnings,
+            diff_with_warnings=diff_with_warnings,
             formatted_issues=formatted_issues,
         )
 

--- a/src/seer/automation/codegen/relevant_warnings_component.py
+++ b/src/seer/automation/codegen/relevant_warnings_component.py
@@ -368,7 +368,6 @@ class AreIssuesFixableComponent(
 
 
 def _format_patch_with_warnings(
-    file_idx: int,
     pr_file: PrFile,
     warnings: list[StaticAnalysisWarning],
     include_warnings_after_patch: bool = False,
@@ -420,12 +419,9 @@ def format_diff(
         )
     body = patch_delim.join(
         _format_patch_with_warnings(
-            file_idx,
-            pr_file,
-            filename_to_warnings[pr_file.filename],
-            include_warnings_after_patch,
+            pr_file, filename_to_warnings[pr_file.filename], include_warnings_after_patch
         )
-        for file_idx, pr_file in enumerate(pr_files)
+        for pr_file in pr_files
     )
     return f"<diff>\n\n{body}\n\n</diff>"
 

--- a/src/seer/automation/codegen/relevant_warnings_component.py
+++ b/src/seer/automation/codegen/relevant_warnings_component.py
@@ -392,7 +392,7 @@ def _format_patch_with_warnings(
 
     if include_warnings_after_patch:
         formatted_warnings = "\n\n".join(warning.format_warning() for warning in warnings)
-        formatted_warnings = f"<warnings>\n{formatted_warnings}\n</warnings>"
+        formatted_warnings = f"<warnings>\n\n{formatted_warnings}\n\n</warnings>"
     else:
         formatted_warnings = ""
 
@@ -422,7 +422,7 @@ def format_diff(
         )
         for file_idx, pr_file in enumerate(pr_files)
     )
-    return f"<diff>\n{body}\n</diff>"
+    return f"<diff>\n\n{body}\n\n</diff>"
 
 
 @cached(cache=LRUCache(maxsize=MAX_FILES_ANALYZED))

--- a/src/seer/automation/codegen/relevant_warnings_component.py
+++ b/src/seer/automation/codegen/relevant_warnings_component.py
@@ -392,13 +392,18 @@ def _format_patch_with_warnings(
 
     if include_warnings_after_patch:
         formatted_warnings = "\n\n".join(warning.format_warning() for warning in warnings)
-        formatted_warnings = f"<warnings>\n\n{formatted_warnings}\n\n</warnings>"
+        formatted_warnings = "\n\n".join(
+            (
+                f"Here's more information about the static analysis warnings in {pr_file.filename}:",
+                f"<warnings>\n\n{formatted_warnings}\n\n</warnings>",
+            )
+        )
     else:
         formatted_warnings = ""
 
     tag_start = f"<file><filename>{pr_file.filename}</filename>"
     tag_end = "</file>"
-    title = f"Here are the changes made to file {pr_file.filename}"
+    title = f"Here are the changes made to file {pr_file.filename}:"
     return "\n\n".join((tag_start, title, formatted_hunks, formatted_warnings, tag_end))
 
 

--- a/src/seer/automation/codegen/relevant_warnings_component.py
+++ b/src/seer/automation/codegen/relevant_warnings_component.py
@@ -390,7 +390,9 @@ def _format_patch_with_warnings(
     formatted_hunks = "\n\n".join(annotate_hunks(hunks))
 
     if include_warnings_after_patch:
-        formatted_warnings = "\n\n".join(warning.format_warning() for warning in warnings)
+        formatted_warnings = "\n\n".join(
+            warning.format_warning(filename=pr_file.filename) for warning in warnings
+        )  # override the filename to reduce the chance of a hallucinated path
         formatted_warnings = "\n\n".join(
             (
                 f"Here's more information about the static analysis warnings in {pr_file.filename}:",

--- a/src/seer/automation/codegen/relevant_warnings_step.py
+++ b/src/seer/automation/codegen/relevant_warnings_step.py
@@ -222,7 +222,7 @@ class RelevantWarningsStep(CodegenStep):
         # 6. Suggest issues based on static analysis warnings and fixable issues.
         static_analysis_suggestions_component = StaticAnalysisSuggestionsComponent(self.context)
         static_analysis_suggestions_request = CodePredictStaticAnalysisSuggestionsRequest(
-            warnings=[warning.warning for warning in warning_and_pr_files],
+            warning_and_pr_files=warning_and_pr_files,
             fixable_issues=fixable_issues,
             pr_files=pr_files,
         )

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -1142,16 +1142,17 @@ class Hunk(BaseModel):
         )
 
 
-def format_annotated_hunks(hunks: list[Hunk]) -> str:
+def annotate_hunks(hunks: list[Hunk]) -> list[str]:
     """
-    Patch string with line numbers for the source and target, like you see in GitHub.
+    Hunks annotated with line numbers for the source and target, like you see in GitHub.
+    Join via `"\\n\\n"` to get the full annotated patch.
     """
     max_digits_source = max(len(str(hunk.lines[-1].source_line_no)) for hunk in hunks)
     max_digits_target = max(len(str(hunk.lines[-1].target_line_no)) for hunk in hunks)
-    return "\n\n".join(
+    return [
         hunk.annotated(max_digits_source=max_digits_source, max_digits_target=max_digits_target)
         for hunk in hunks
-    )
+    ]
 
 
 class FilePatch(BaseModel):

--- a/tests/automation/codegen/test_relevant_warnings.py
+++ b/tests/automation/codegen/test_relevant_warnings.py
@@ -141,8 +141,7 @@ def _mock_issue_details() -> IssueDetails:
                     Is auto-fixable: False
                     Is stable: None
                     Category: style
-                </warning>
-                """
+                </warning>"""
             ),
             id="python-warning",
         ),
@@ -181,8 +180,7 @@ def _mock_issue_details() -> IssueDetails:
                     Is auto-fixable: False
                     Is stable: False
                     Category: style
-                </warning>
-                """
+                </warning>"""
             ),
             id="javascript-warning-no-snippet",
         ),

--- a/tests/automation/codegen/test_relevant_warnings.py
+++ b/tests/automation/codegen/test_relevant_warnings.py
@@ -117,6 +117,7 @@ def _mock_issue_details() -> IssueDetails:
             textwrap.dedent(
                 """\
                 <warning><warning_id>1</warning_id>
+                Warning (ID 1)
                 Warning message: Warning message
                 ----------
                 Location:
@@ -164,6 +165,7 @@ def _mock_issue_details() -> IssueDetails:
             textwrap.dedent(
                 """\
                 <warning><warning_id>2</warning_id>
+                Warning (ID 2)
                 Warning message: Warning message
                 ----------
                 Location:

--- a/tests/automation/codegen/test_relevant_warnings.py
+++ b/tests/automation/codegen/test_relevant_warnings.py
@@ -141,7 +141,6 @@ def _mock_issue_details() -> IssueDetails:
                     Is auto-fixable: False
                     Is stable: None
                     Category: style
-
                 </warning>
                 """
             ),
@@ -172,7 +171,6 @@ def _mock_issue_details() -> IssueDetails:
                     filename: path/to/file.js
                     start_line: 1
                     end_line: 2
-
                 ----------
                 Potentially related issue titles:
                     (no related issues found)
@@ -183,7 +181,6 @@ def _mock_issue_details() -> IssueDetails:
                     Is auto-fixable: False
                     Is stable: False
                     Category: style
-
                 </warning>
                 """
             ),

--- a/tests/automation/codegen/test_relevant_warnings.py
+++ b/tests/automation/codegen/test_relevant_warnings.py
@@ -116,17 +116,19 @@ def _mock_issue_details() -> IssueDetails:
             ),
             textwrap.dedent(
                 """\
-                Warning ID: 1
+                <warning><warning_id>1</warning_id>
                 Warning message: Warning message
                 ----------
                 Location:
                     filename: path/to/file.py
                     start_line: 1
                     end_line: 2
+                ----------
                 Code Snippet:
                 ```python
-                def test_format_code_snippet(self):
-                    pass
+                    def test_format_code_snippet(self):
+                        pass
+
                 ```
                 ----------
                 Potentially related issue titles:
@@ -140,6 +142,7 @@ def _mock_issue_details() -> IssueDetails:
                     Is stable: None
                     Category: style
 
+                </warning>
                 """
             ),
             id="python-warning",
@@ -162,20 +165,17 @@ def _mock_issue_details() -> IssueDetails:
             ),
             textwrap.dedent(
                 """\
-                Warning ID: 2
+                <warning><warning_id>2</warning_id>
                 Warning message: Warning message
                 ----------
                 Location:
                     filename: path/to/file.js
                     start_line: 1
                     end_line: 2
-                Code Snippet:
-                ```javascript
 
-                ```
                 ----------
                 Potentially related issue titles:
-
+                    (no related issues found)
                 ----------
                 Static Analysis Rule:
                     Rule: unused-variable
@@ -184,6 +184,7 @@ def _mock_issue_details() -> IssueDetails:
                     Is stable: False
                     Category: style
 
+                </warning>
                 """
             ),
             id="javascript-warning-no-snippet",
@@ -983,9 +984,10 @@ def test_relevant_warnings_step_invoke(
     assert (
         mock_invoke_static_analysis_suggestions_component.call_args[0][0].pr_files == mock_pr_files
     )
-    assert mock_invoke_static_analysis_suggestions_component.call_args[0][0].warnings == [
-        warning_and_pr_file.warning for warning_and_pr_file in mock_warning_and_pr_files
-    ]
+    assert (
+        mock_invoke_static_analysis_suggestions_component.call_args[0][0].warning_and_pr_files
+        == mock_warning_and_pr_files
+    )
     assert (
         mock_invoke_static_analysis_suggestions_component.call_args[0][0].fixable_issues
         == all_selected_issues[1:]
@@ -1030,7 +1032,7 @@ class TestStaticAnalysisSuggestionsComponent:
         pr_files = [
             PrFile(
                 filename="test/path/file.py",
-                patch="@@ -1,3 +1,4 @@\ndef hello():\n    print('hello')\n+    print('world')",
+                patch="@@ -1,3 +1,4 @@\n def hello():\n     print('hello')\n+    print('world')",
                 status="modified",
                 changes=1,
                 sha="sha1",
@@ -1040,9 +1042,11 @@ class TestStaticAnalysisSuggestionsComponent:
         fixable_issues = [_mock_issue_details() for _ in range(2)]
 
         request = CodePredictStaticAnalysisSuggestionsRequest(
-            pr_files=pr_files,
-            warnings=warnings,
+            warning_and_pr_files=[
+                WarningAndPrFile(warning=warning, pr_file=pr_files[0]) for warning in warnings
+            ],
             fixable_issues=fixable_issues,
+            pr_files=pr_files,
         )
 
         output = component.invoke(request)
@@ -1076,7 +1080,7 @@ class TestStaticAnalysisSuggestionsComponent:
         pr_files = [
             PrFile(
                 filename="test/path/file.py",
-                patch="@@ -1,3 +1,4 @@\ndef hello():\n    print('hello')\n+    print('world')",
+                patch="@@ -1,3 +1,4 @@\n def hello():\n     print('hello')\n+    print('world')",
                 status="modified",
                 changes=1,
                 sha="sha1",
@@ -1086,9 +1090,11 @@ class TestStaticAnalysisSuggestionsComponent:
         fixable_issues = [_mock_issue_details() for _ in range(2)]
 
         request = CodePredictStaticAnalysisSuggestionsRequest(
-            pr_files=pr_files,
-            warnings=warnings,
+            warning_and_pr_files=[
+                WarningAndPrFile(warning=warning, pr_file=pr_files[0]) for warning in warnings
+            ],
             fixable_issues=fixable_issues,
+            pr_files=pr_files,
         )
 
         output = component.invoke(request)

--- a/tests/automation/test_automation_models.py
+++ b/tests/automation/test_automation_models.py
@@ -15,7 +15,7 @@ from seer.automation.models import (
     Span,
     TraceEvent,
     TraceTree,
-    format_annotated_hunks,
+    annotate_hunks,
     right_justified,
 )
 
@@ -1285,10 +1285,10 @@ def test_file_patch_to_hunks(patch_and_hunks: tuple[str, list[Hunk]]):
     assert annotated_hunk == annotated_hunk_expected
 
 
-def test_format_annotated_hunks(patch_and_hunks: tuple[str, list[Hunk]]):
+def test_annotated_hunks(patch_and_hunks: tuple[str, list[Hunk]]):
     _, hunks = patch_and_hunks
-    annotated_hunks = format_annotated_hunks(hunks)
-    annotated_hunks_expected = textwrap.dedent(
+    formatted_annotated_hunks = "\n\n".join(annotate_hunks(hunks))
+    formatted_annotated_hunks_expected = textwrap.dedent(
         """\
                   @@ -1,3 +1,4 @@
          1     1  def hello():
@@ -1302,4 +1302,4 @@ def test_format_annotated_hunks(patch_and_hunks: tuple[str, list[Hunk]]):
               22 +    print('new end')  # Line 22 is added
         21    23      return"""
     ).replace("__NO_SPACE__", "")
-    assert annotated_hunks == annotated_hunks_expected
+    assert formatted_annotated_hunks == formatted_annotated_hunks_expected


### PR DESCRIPTION
Here's an [example of a prompt](https://github.com/getsentry/data-analysis/blob/main/error_prevention/relevant_warnings/prompt.txt) w/ embedded warnings ([for this dummy PR](https://github.com/getsentry/seer/pull/2406) and dummy warnings)

The annotations are in `<-- STATIC ANALYSIS WARNINGS`