### PR TITLE
fix(relevant-warnings) Add analysis section

### DIFF
--- a/src/seer/automation/codegen/prompts.py
+++ b/src/seer/automation/codegen/prompts.py
@@ -321,7 +321,8 @@ class StaticAnalysisSuggestionsPrompts:
             - Assign a severity score and confidence score to each suggestion, from 0 to 1. The score should be granular, e.g., 0.432.
                 - Severity score: 1 being "guaranteed an _uncaught_ exception will happen and not be caught by the code"; 0.5 being "an exception will happen but it's being caught" OR "an exception may happen depending on inputs"; 0 being "no exception will happen";
                 - Confidence score: 1 being "I am 100%% confident that this is a bug";
-            - Before giving your final answer, think step-by-step to ensure your review is thorough. We prefer fewer suggestions with high quality over more suggestions with low quality.
+            - Before giving your final answer, think carefully about which warnings caused by the code change will cause production errors.
+              Only consider suggestions that are critical to address. Ignore issues or warnings that aren't caused by the code change.
             """
         ).format(
             diff_with_warnings=diff_with_warnings,

--- a/src/seer/automation/codegen/prompts.py
+++ b/src/seer/automation/codegen/prompts.py
@@ -1,8 +1,9 @@
 import textwrap
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from seer.automation.autofix.components.coding.models import PlanStepsPromptXml, PlanTaskPromptXml
+from seer.automation.codegen.models import StaticAnalysisSuggestion
 
 
 class CodingUnitTestPrompts:
@@ -279,6 +280,10 @@ class IsFixableIssuePrompts(_RelevantWarningsPromptPrefix):
 
 class StaticAnalysisSuggestionsPrompts:
 
+    class AnalysisAndSuggestions(BaseModel):
+        analysis: str = Field(description="Your room to think step-by-step. At most 1000 words.")
+        suggestions: list[StaticAnalysisSuggestion]
+
     @staticmethod
     def format_system_msg():
         return textwrap.dedent(
@@ -319,7 +324,6 @@ class StaticAnalysisSuggestionsPrompts:
                 - Severity score: 1 being "guaranteed an _uncaught_ exception will happen and not be caught by the code"; 0.5 being "an exception will happen but it's being caught" OR "an exception may happen depending on inputs"; 0 being "no exception will happen";
                 - Confidence score: 1 being "I am 100%% confident that this is a bug";
             - Before giving your final answer, think step-by-step to ensure your review is thorough. We prefer fewer suggestions with high quality over more suggestions with low quality.
-            - Return your response as a list of JSON objects, where each object is a suggestion. Your response should be ONLY the list of objects.
             """
         ).format(
             diff=diff,

--- a/src/seer/automation/codegen/relevant_warnings_component.py
+++ b/src/seer/automation/codegen/relevant_warnings_component.py
@@ -30,7 +30,6 @@ from seer.automation.codegen.models import (
     FilterWarningsOutput,
     FilterWarningsRequest,
     RelevantWarningResult,
-    StaticAnalysisSuggestion,
     WarningAndPrFile,
 )
 from seer.automation.codegen.prompts import (
@@ -526,10 +525,10 @@ class StaticAnalysisSuggestionsComponent(
                 ),
                 formatted_issues=formatted_issues,
             ),
-            response_format=list[StaticAnalysisSuggestion],
+            response_format=StaticAnalysisSuggestionsPrompts.AnalysisAndSuggestions,
             temperature=0.0,
             max_tokens=8192,
         )
         if completion.parsed is None:
             return None
-        return CodePredictStaticAnalysisSuggestionsOutput(suggestions=completion.parsed)
+        return CodePredictStaticAnalysisSuggestionsOutput(suggestions=completion.parsed.suggestions)

--- a/tests/automation/codegen/test_relevant_warnings.py
+++ b/tests/automation/codegen/test_relevant_warnings.py
@@ -31,7 +31,11 @@ from seer.automation.codegen.models import (
     StaticAnalysisSuggestion,
     WarningAndPrFile,
 )
-from seer.automation.codegen.prompts import IsFixableIssuePrompts, ReleventWarningsPrompts
+from seer.automation.codegen.prompts import (
+    IsFixableIssuePrompts,
+    ReleventWarningsPrompts,
+    StaticAnalysisSuggestionsPrompts,
+)
 from seer.automation.codegen.relevant_warnings_component import (
     AreIssuesFixableComponent,
     AssociateWarningsWithIssuesComponent,
@@ -1000,9 +1004,7 @@ class TestStaticAnalysisSuggestionsComponent:
     @pytest.fixture(autouse=True)
     def patch_generate_structured(self, monkeypatch: pytest.MonkeyPatch):
         def mock_generate_structured(*args, **kwargs):
-            # Create a mock response object
             mock_response = MagicMock()
-            # Create a list of suggestions
             suggestions = [
                 StaticAnalysisSuggestion(
                     path="test/path/file.py",
@@ -1016,8 +1018,10 @@ class TestStaticAnalysisSuggestionsComponent:
                     confidence_score=0.9,
                 )
             ]
-            # Set the parsed attribute directly
-            mock_response.parsed = suggestions
+            analysis_and_suggestions = StaticAnalysisSuggestionsPrompts.AnalysisAndSuggestions(
+                analysis="Test analysis", suggestions=suggestions
+            )
+            mock_response.parsed = analysis_and_suggestions
             return mock_response
 
         monkeypatch.setattr(


### PR DESCRIPTION
The prompt asks for step-by-step thinking, but the output is immediately the list of suggestions. When using structured output, need to explicitly add in a section for thinking (unless it's a reasoning model, which flash 2.0 is not). I missed this during review