### PR TITLE
fix(autofix): only clear stream if there is content in the new stream

### DIFF
--- a/src/seer/automation/autofix/autofix_agent.py
+++ b/src/seer/automation/autofix/autofix_agent.py
@@ -133,10 +133,10 @@ class AutofixAgent(LlmAgent):
             if isinstance(chunk, tuple):
                 with self.context.state.update() as cur:
                     cur_step = cur.steps[-1]
-                    if not cleared:
-                        cur_step.clear_output_stream()
-                        cleared = True
                     if chunk[0] == "thinking_content" or chunk[0] == "content":
+                        if not cleared and len(chunk[1]) > 0:
+                            cur_step.clear_output_stream()
+                            cleared = True
                         cur_step.receive_output_stream(chunk[1])
                 if chunk[0] == "thinking_content":
                     thinking_content_chunks.append(chunk[1])


### PR DESCRIPTION
Before: cleared the user-facing output stream whenever we started a new stream
After: clear the user-facing output stream whenever we start a new stream AND the new stream has text in it

This handle no token streams from Gemini causing a bad UX.