### PR TITLE
fix(autofix): autocorrect grep command if simply missing -r flag

### DIFF
--- a/src/seer/automation/autofix/tools.py
+++ b/src/seer/automation/autofix/tools.py
@@ -488,6 +488,25 @@ class BaseTools:
                         timeout=45,
                     )
 
+                    # Check if error is due to "is a directory" and retry with -r flag
+                    if (
+                        process.returncode != 0
+                        and process.returncode != 1
+                        and "is a directory" in process.stderr.lower()
+                    ):
+                        if "-r" not in cmd_args and "--recursive" not in cmd_args:
+                            recursive_cmd_args = cmd_args.copy()
+                            recursive_cmd_args.insert(1, "-r")
+                            process = subprocess.run(
+                                recursive_cmd_args,
+                                shell=False,
+                                cwd=tmp_repo_dir,
+                                capture_output=True,
+                                text=True,
+                                check=False,
+                                timeout=45,
+                            )
+
                     if (
                         process.returncode != 0 and process.returncode != 1
                     ):  # grep returns 1 when no matches found

--- a/src/seer/automation/autofix/tools.py
+++ b/src/seer/automation/autofix/tools.py
@@ -32,6 +32,7 @@ from seer.rpc import RpcClient
 logger = logging.getLogger(__name__)
 
 MAX_FILES_IN_TREE = 100
+GREP_TIMEOUT_SECONDS = 45
 MAX_GREP_LINE_CHARACTER_LENGTH = 1024
 TOTAL_GREP_RESULTS_CHARACTER_LENGTH = 16384
 
@@ -485,7 +486,7 @@ class BaseTools:
                         capture_output=True,
                         text=True,
                         check=False,
-                        timeout=45,
+                        timeout=GREP_TIMEOUT_SECONDS,
                     )
 
                     # Check if error is due to "is a directory" and retry with -r flag
@@ -504,7 +505,7 @@ class BaseTools:
                                 capture_output=True,
                                 text=True,
                                 check=False,
-                                timeout=45,
+                                timeout=GREP_TIMEOUT_SECONDS,
                             )
 
                     if (


### PR DESCRIPTION
Common failure mode for the grep tool is the agent tried to grep a directory but forgets the `-r` flag. Just catching that and auto-retrying to save iterations here.