### PR TITLE
feat(autofix): New semantic search tool

### DIFF
--- a/src/seer/automation/autofix/components/coding/component.py
+++ b/src/seer/automation/autofix/components/coding/component.py
@@ -14,7 +14,7 @@ from seer.automation.autofix.components.coding.models import CodingOutput, Codin
 from seer.automation.autofix.components.coding.prompts import CodingPrompts
 from seer.automation.autofix.components.root_cause.models import RootCauseAnalysisItem
 from seer.automation.autofix.prompts import format_repo_prompt
-from seer.automation.autofix.tools import BaseTools
+from seer.automation.autofix.tools.tools import BaseTools
 from seer.automation.component import BaseComponent
 from seer.configuration import AppConfig
 from seer.dependency_injection import inject, injected

--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -14,7 +14,7 @@ from seer.automation.autofix.components.root_cause.models import (
 )
 from seer.automation.autofix.components.root_cause.prompts import RootCauseAnalysisPrompts
 from seer.automation.autofix.prompts import format_repo_prompt
-from seer.automation.autofix.tools import BaseTools
+from seer.automation.autofix.tools.tools import BaseTools
 from seer.automation.component import BaseComponent
 from seer.dependency_injection import inject, injected
 

--- a/src/seer/automation/autofix/components/solution/component.py
+++ b/src/seer/automation/autofix/components/solution/component.py
@@ -13,7 +13,7 @@ from seer.automation.autofix.components.root_cause.models import RootCauseAnalys
 from seer.automation.autofix.components.solution.models import SolutionOutput, SolutionRequest
 from seer.automation.autofix.components.solution.prompts import SolutionPrompts
 from seer.automation.autofix.prompts import format_repo_prompt
-from seer.automation.autofix.tools import BaseTools
+from seer.automation.autofix.tools.tools import BaseTools
 from seer.automation.component import BaseComponent
 from seer.dependency_injection import inject, injected
 

--- a/src/seer/automation/autofix/tools/semantic_search.py
+++ b/src/seer/automation/autofix/tools/semantic_search.py
@@ -1,0 +1,55 @@
+import textwrap
+
+from seer.automation.agent.agent import AgentConfig, LlmAgent, RunConfig
+from seer.automation.agent.client import GeminiProvider
+from seer.automation.autofix.autofix_context import AutofixContext
+from seer.automation.autofix.prompts import format_repo_prompt
+from seer.automation.autofix.tools.tools import SemanticSearchTools
+from seer.automation.codegen.codegen_context import CodegenContext
+
+
+def semantic_search(query: str, context: AutofixContext | CodegenContext) -> str:
+    """
+    Uses an LLM agent to search the codebase and return relevant files and insights.
+
+    Args:
+        query: The search query to find relevant code
+        context: The context object (either AutofixContext or CodegenContext)
+
+    Returns:
+        A string containing the agent's response with relevant files and insights
+    """
+    tools = SemanticSearchTools(context=context)
+
+    agent_config = AgentConfig(interactive=False)
+    agent = LlmAgent(
+        config=agent_config,
+        tools=tools.get_tools(can_access_repos=True),
+        name="SemanticSearchAgent",
+    )
+
+    state = context.state.get()
+    readable_repos = state.readable_repos
+    unreadable_repos = state.unreadable_repos
+    repo_str = format_repo_prompt(readable_repos=readable_repos, unreadable_repos=unreadable_repos)
+
+    system_prompt = textwrap.dedent(
+        """\
+        You are an exceptional codebase search agent. Your goal is to find the most relevant files in the codebase that match the user's query.
+
+        Use the available tools to explore the codebase tree structure, and when necessary, to read the contents of specific files.
+
+        You have access to the following repositories:
+        {repo_str}
+
+        In your final response, list the relevant files and their full paths, and explain why they are relevant to the query."""
+    ).format(repo_str=repo_str)
+
+    run_config = RunConfig(
+        system_prompt=system_prompt,
+        prompt=query,
+        model=GeminiProvider(model_name="gemini-2.0-flash-001"),
+        temperature=0.0,
+    )
+
+    return agent.run(run_config)

--- a/src/seer/automation/autofix/tools/semantic_search.py
+++ b/src/seer/automation/autofix/tools/semantic_search.py
@@ -37,8 +37,8 @@ def semantic_search(query: str, context: AutofixContext | CodegenContext) -> str
         repo_str = format_repo_prompt(
             readable_repos=readable_repos, unreadable_repos=unreadable_repos
         )
-    elif isinstance(context, CodegenContinuation):
-        repo_str = format_repo_prompt(readable_repos=[context.repo], unreadable_repos=[])
+    elif isinstance(state, CodegenContinuation):
+        repo_str = format_repo_prompt(readable_repos=[state.request.repo], unreadable_repos=[])
 
     system_prompt = textwrap.dedent(
         """\

--- a/src/seer/automation/autofix/tools/semantic_search.py
+++ b/src/seer/automation/autofix/tools/semantic_search.py
@@ -29,9 +29,16 @@ def semantic_search(query: str, context: AutofixContext | CodegenContext) -> str
     )
 
     state = context.state.get()
-    readable_repos = state.readable_repos
-    unreadable_repos = state.unreadable_repos
-    repo_str = format_repo_prompt(readable_repos=readable_repos, unreadable_repos=unreadable_repos)
+    if isinstance(context, AutofixContext):
+        readable_repos = state.readable_repos
+        unreadable_repos = state.unreadable_repos
+        repo_str = format_repo_prompt(
+            readable_repos=readable_repos, unreadable_repos=unreadable_repos
+        )
+    elif isinstance(context, CodegenContext):
+        repo_str = format_repo_prompt(readable_repos=[context.repo], unreadable_repos=[])
+    else:
+        raise ValueError(f"Unsupported context type: {type(context)}")
 
     system_prompt = textwrap.dedent(
         """\

--- a/src/seer/automation/autofix/tools/semantic_search.py
+++ b/src/seer/automation/autofix/tools/semantic_search.py
@@ -3,9 +3,11 @@ import textwrap
 from seer.automation.agent.agent import AgentConfig, LlmAgent, RunConfig
 from seer.automation.agent.client import GeminiProvider
 from seer.automation.autofix.autofix_context import AutofixContext
+from seer.automation.autofix.models import AutofixContinuation
 from seer.automation.autofix.prompts import format_repo_prompt
 from seer.automation.autofix.tools.tools import SemanticSearchTools
 from seer.automation.codegen.codegen_context import CodegenContext
+from seer.automation.codegen.models import CodegenContinuation
 
 
 def semantic_search(query: str, context: AutofixContext | CodegenContext) -> str:
@@ -29,13 +31,13 @@ def semantic_search(query: str, context: AutofixContext | CodegenContext) -> str
     )
 
     state = context.state.get()
-    if isinstance(context, AutofixContext):
+    if isinstance(state, AutofixContinuation):
         readable_repos = state.readable_repos
         unreadable_repos = state.unreadable_repos
         repo_str = format_repo_prompt(
             readable_repos=readable_repos, unreadable_repos=unreadable_repos
         )
-    elif isinstance(context, CodegenContext):
+    elif isinstance(context, CodegenContinuation):
         repo_str = format_repo_prompt(readable_repos=[context.repo], unreadable_repos=[])
 
     system_prompt = textwrap.dedent(

--- a/src/seer/automation/autofix/tools/semantic_search.py
+++ b/src/seer/automation/autofix/tools/semantic_search.py
@@ -37,8 +37,6 @@ def semantic_search(query: str, context: AutofixContext | CodegenContext) -> str
         )
     elif isinstance(context, CodegenContext):
         repo_str = format_repo_prompt(readable_repos=[context.repo], unreadable_repos=[])
-    else:
-        raise ValueError(f"Unsupported context type: {type(context)}")
 
     system_prompt = textwrap.dedent(
         """\

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -147,41 +147,16 @@ class BaseTools:
     @ai_track(description="Semantic File Search")
     @inject
     def semantic_file_search(self, query: str, llm_client: LlmClient = injected):
-        repo_names = self._get_repo_names()
-        files_per_repo = {}
-        for repo_name in repo_names:
-            repo_client = self.context.get_repo_client(
-                repo_name=repo_name, type=self.repo_client_type
-            )
-            valid_file_paths = repo_client.get_valid_file_paths()
-
-            # Convert the list of file paths to a tree structure
-            files_with_status = [{"path": path, "status": ""} for path in valid_file_paths]
-            tree_representation = repo_client._build_file_tree_string(files_with_status)
-            files_per_repo[repo_name] = tree_representation
+        from seer.automation.autofix.tools.semantic_search import semantic_search
 
         self.context.event_manager.add_log(f'Searching for "{query}"...')
 
-        all_valid_paths = "\n".join(
-            [
-                f"FILES IN REPO {repo_name}:\n{files_per_repo[repo_name]}\n------------"
-                for repo_name in repo_names
-            ]
-        )
-        file_location = self._semantic_file_search_completion(
-            query, all_valid_paths, repo_names, llm_client
-        )
-        file_path = file_location.file_path if file_location else None
-        repo_name = file_location.repo_name if file_location else None
-        if file_path is None or repo_name is None:
+        result = semantic_search(query=query, context=self.context)
+
+        if not result:
             return "Could not figure out which file matches what you were looking for. You'll have to try yourself."
 
-        file_contents = self.context.get_file_contents(file_path, repo_name=repo_name)
-
-        if file_contents is None:
-            return "Could not figure out which file matches what you were looking for. You'll have to try yourself."
-
-        return f"This file might be what you're looking for: `{file_path}`. Contents:\n\n{file_contents}"
+        return result
 
     @observe(name="Expand Document")
     @ai_track(description="Expand Document")
@@ -1275,3 +1250,55 @@ class BaseTools:
                 )
 
         return tools
+
+
+class SemanticSearchTools(BaseTools):
+    def get_tools(
+        self, can_access_repos: bool = True, include_claude_tools: bool = False
+    ) -> list[ClaudeTool | FunctionTool]:
+        if not can_access_repos:
+            return []
+
+        return [
+            FunctionTool(
+                name="tree",
+                fn=self.tree,
+                description="Given the path for a directory in this codebase, returns a tree representation of the directory structure and files.",
+                parameters=[
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "description": 'The path to view. For example, "src/app/components"',
+                    },
+                    {
+                        "name": "repo_name",
+                        "type": "string",
+                        "description": "Optional name of the repository to search in if you know it.",
+                    },
+                ],
+                required=["path"],
+            ),
+            FunctionTool(
+                name="expand_document",
+                fn=self.expand_document,
+                description=textwrap.dedent(
+                    """\
+                Given a document path, returns the entire document text.
+                - Note: To save time and money, if you're looking to expand multiple documents, call this tool multiple times in the same message.
+                - If a document has already been expanded earlier in the conversation, don't use this tool again for the same file path."""
+                ),
+                parameters=[
+                    {
+                        "name": "file_path",
+                        "type": "string",
+                        "description": "The document path to expand.",
+                    },
+                    {
+                        "name": "repo_name",
+                        "type": "string",
+                        "description": "Name of the repository containing the file.",
+                    },
+                ],
+                required=["file_path", "repo_name"],
+            ),
+        ]

--- a/src/seer/automation/codegen/pr_review_coding_component.py
+++ b/src/seer/automation/codegen/pr_review_coding_component.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 from langfuse.decorators import observe
@@ -6,13 +5,12 @@ from sentry_sdk.ai.monitoring import ai_track
 
 from seer.automation.agent.agent import AgentConfig, LlmAgent, RunConfig
 from seer.automation.agent.client import AnthropicProvider, GeminiProvider, LlmClient
-from seer.automation.autofix.tools import BaseTools
+from seer.automation.autofix.tools.tools import BaseTools
 from seer.automation.codebase.repo_client import RepoClientType
 from seer.automation.codegen.codegen_context import CodegenContext
 from seer.automation.codegen.models import CodePrReviewOutput, CodePrReviewRequest
 from seer.automation.codegen.prompts import CodingCodeReviewPrompts, CodingUnitTestPrompts
 from seer.automation.component import BaseComponent
-from seer.automation.utils import extract_text_inside_tags
 from seer.dependency_injection import inject, injected
 
 logger = logging.getLogger(__name__)

--- a/src/seer/automation/codegen/retry_unittest_coding_component.py
+++ b/src/seer/automation/codegen/retry_unittest_coding_component.py
@@ -12,7 +12,7 @@ from seer.automation.autofix.components.coding.utils import (
     task_to_file_create,
     task_to_file_delete,
 )
-from seer.automation.autofix.tools import BaseTools
+from seer.automation.autofix.tools.tools import BaseTools
 from seer.automation.codebase.repo_client import RepoClientType
 from seer.automation.codegen.codegen_context import CodegenContext
 from seer.automation.codegen.models import CodeUnitTestOutput, CodeUnitTestRequest

--- a/src/seer/automation/codegen/unit_test_coding_component.py
+++ b/src/seer/automation/codegen/unit_test_coding_component.py
@@ -12,7 +12,7 @@ from seer.automation.autofix.components.coding.utils import (
     task_to_file_create,
     task_to_file_delete,
 )
-from seer.automation.autofix.tools import BaseTools
+from seer.automation.autofix.tools.tools import BaseTools
 from seer.automation.codebase.repo_client import RepoClientType
 from seer.automation.codegen.codegen_context import CodegenContext
 from seer.automation.codegen.models import CodeUnitTestOutput, CodeUnitTestRequest

--- a/tests/automation/autofix/test_autofix_tools.py
+++ b/tests/automation/autofix/test_autofix_tools.py
@@ -5,7 +5,7 @@ import pytest
 
 from seer.automation.agent.client import LlmClient
 from seer.automation.autofix.autofix_context import AutofixContext
-from seer.automation.autofix.tools import BaseTools
+from seer.automation.autofix.tools.tools import BaseTools
 from seer.automation.codebase.repo_client import RepoClientType
 from seer.automation.models import FileChange
 


### PR DESCRIPTION
The old semantic search tool was pretty hit-or-miss, and completely broke on big repos. Replacing it with a small gemini flash agent that can use `tree` and `expand_document` to find the exact answer to the query. In some examples on `sentry` it could find most things within 10 seconds.

Bumps solution score to ~61%, cuts latency and cost further from last eval (though that could be the broken evals).