### PR TITLE
fix(autofix): Parallelize grep search

### DIFF
--- a/src/seer/automation/autofix/tools/grep_search.py
+++ b/src/seer/automation/autofix/tools/grep_search.py
@@ -1,0 +1,140 @@
+import logging
+import subprocess
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from seer.dependency_injection import copy_modules_initializer
+
+logger = logging.getLogger(__name__)
+
+# Constants moved from tools.py
+GREP_TIMEOUT_SECONDS = 10
+MAX_GREP_LINE_CHARACTER_LENGTH = 1000
+TOTAL_GREP_RESULTS_CHARACTER_LENGTH = 20000
+
+
+def _run_grep_in_repo(
+    repo_name: str,
+    cmd_args: list[str],
+    tmp_dir: dict[str, tuple[str, str]],
+    tmp_repo_dir: str,
+) -> str | None:
+    """Runs the grep command in a specific repository directory."""
+    try:
+        # Run the grep command in the repo directory
+        try:
+            process = subprocess.run(
+                cmd_args,
+                shell=False,
+                cwd=tmp_repo_dir,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=GREP_TIMEOUT_SECONDS,
+            )
+
+            # Check if error is due to "is a directory" and retry with -r flag
+            if (
+                process.returncode != 0
+                and process.returncode != 1
+                and "is a directory" in process.stderr.lower()
+            ):
+                if "-r" not in cmd_args and "--recursive" not in cmd_args:
+                    recursive_cmd_args = cmd_args.copy()
+                    # Insert -r after the command itself (e.g., grep -r ...)
+                    # Handle potential edge cases like `rg -r` already existing
+                    if cmd_args[0] == "grep":
+                        recursive_cmd_args.insert(1, "-r")
+                    else:  # Assume ripgrep or similar, add --recursive
+                        recursive_cmd_args.insert(1, "--recursive")
+
+                    process = subprocess.run(
+                        recursive_cmd_args,
+                        shell=False,
+                        cwd=tmp_repo_dir,
+                        capture_output=True,
+                        text=True,
+                        check=False,
+                        timeout=GREP_TIMEOUT_SECONDS,
+                    )
+
+            if (
+                process.returncode != 0 and process.returncode != 1
+            ):  # grep returns 1 when no matches found
+                return f"Results from {repo_name}: {process.stderr}"
+            elif process.stdout:
+                final_output = process.stdout
+                # Each line is a grep result, -A, -B, -C are ways to get lines before, after, and around the match
+                if "-A" not in cmd_args and "-B" not in cmd_args and "-C" not in cmd_args:
+                    lines = process.stdout.split("\n")
+                    final_output = ""
+                    for line in lines:
+                        if len(line) > MAX_GREP_LINE_CHARACTER_LENGTH:
+                            line = (
+                                line[:MAX_GREP_LINE_CHARACTER_LENGTH]
+                                + "...[TRUNCATED: line too long to display]"
+                            )
+                        final_output += line + "\n"
+
+                if len(final_output) > TOTAL_GREP_RESULTS_CHARACTER_LENGTH:
+                    final_output = (
+                        final_output[:TOTAL_GREP_RESULTS_CHARACTER_LENGTH]
+                        + "...[GREP RESULTS TRUNCATED: too long to display, try narrowing your search]"
+                    )
+
+                return f"Results from {repo_name}:\n------\n{final_output}\n------"
+            else:
+                return f"Results from {repo_name}: no results found."
+        except subprocess.TimeoutExpired:
+            return f"Results from {repo_name}: command timed out. Try narrowing your search."
+    except Exception as e:
+        logger.exception(f"Error running grep in repo {repo_name}: {e}")
+        return f"Error in repo {repo_name}: {str(e)}"
+
+
+def run_grep_search(
+    cmd_args: list[str], repo_names: list[str], tmp_dirs: dict[str, tuple[str, str]]
+) -> str:
+    """
+    Performs the grep search across one or more repositories.
+
+    Args:
+        cmd_args: The parsed grep command arguments.
+        repo_names: List of repository names to search within.
+        tmp_dirs: Dictionary mapping repo names to their temporary directory paths.
+
+    Returns:
+        A string containing the combined results from all repositories.
+    """
+    all_results = []
+
+    def run_grep_for_repo(repo_name: str):
+        if repo_name not in tmp_dirs:
+            return None
+        _, tmp_repo_dir = tmp_dirs[repo_name]
+        if not tmp_repo_dir:
+            return None
+        return _run_grep_in_repo(repo_name, cmd_args, tmp_dirs, tmp_repo_dir)
+
+    if len(repo_names) == 1:
+        result = run_grep_for_repo(repo_names[0])
+        if result:
+            all_results.append(result)
+    else:
+        with ThreadPoolExecutor(initializer=copy_modules_initializer()) as executor:
+            future_to_repo = {
+                executor.submit(run_grep_for_repo, repo_name): repo_name for repo_name in repo_names
+            }
+            for future in as_completed(future_to_repo):
+                try:
+                    result = future.result()
+                    if result:
+                        all_results.append(result)
+                except Exception as e:
+                    repo_name = future_to_repo[future]
+                    logger.exception(f"Error processing grep result for repo {repo_name}: {e}")
+                    all_results.append(f"Error processing result for {repo_name}: {str(e)}")
+
+    if not all_results:
+        return "No results found."
+
+    return "\n\n".join(all_results)

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -3,7 +3,7 @@ import os
 import shlex
 import subprocess
 import textwrap
-from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError, as_completed
 from threading import Lock
 from typing import Any, cast
 
@@ -28,12 +28,14 @@ from seer.dependency_injection import copy_modules_initializer, inject, injected
 from seer.langfuse import append_langfuse_observation_metadata
 from seer.rpc import RpcClient
 
+from .grep_search import run_grep_search
+
 logger = logging.getLogger(__name__)
 
 MAX_FILES_IN_TREE = 100
-GREP_TIMEOUT_SECONDS = 45
-MAX_GREP_LINE_CHARACTER_LENGTH = 1024
-TOTAL_GREP_RESULTS_CHARACTER_LENGTH = 16384
+GREP_TIMEOUT_SECONDS = 10
+MAX_GREP_LINE_CHARACTER_LENGTH = 1000
+TOTAL_GREP_RESULTS_CHARACTER_LENGTH = 20000
 
 
 class BaseTools:
@@ -406,7 +408,6 @@ class BaseTools:
         self._ensure_repos_downloaded(repo_name)
 
         repo_names = [repo_name] if repo_name else self._get_repo_names()
-        all_results = []
 
         # Parse the command into a list of arguments
         try:
@@ -414,85 +415,7 @@ class BaseTools:
         except Exception as e:
             return f"Error parsing grep command: {str(e)}"
 
-        for repo_name in repo_names:
-            if repo_name not in self.tmp_dir:
-                continue
-            tmp_dir, tmp_repo_dir = self.tmp_dir[repo_name]
-            if not tmp_repo_dir:
-                continue
-
-            try:
-                # Run the grep command in the repo directory
-                try:
-                    process = subprocess.run(
-                        cmd_args,
-                        shell=False,
-                        cwd=tmp_repo_dir,
-                        capture_output=True,
-                        text=True,
-                        check=False,
-                        timeout=GREP_TIMEOUT_SECONDS,
-                    )
-
-                    # Check if error is due to "is a directory" and retry with -r flag
-                    if (
-                        process.returncode != 0
-                        and process.returncode != 1
-                        and "is a directory" in process.stderr.lower()
-                    ):
-                        if "-r" not in cmd_args and "--recursive" not in cmd_args:
-                            recursive_cmd_args = cmd_args.copy()
-                            recursive_cmd_args.insert(1, "-r")
-                            process = subprocess.run(
-                                recursive_cmd_args,
-                                shell=False,
-                                cwd=tmp_repo_dir,
-                                capture_output=True,
-                                text=True,
-                                check=False,
-                                timeout=GREP_TIMEOUT_SECONDS,
-                            )
-
-                    if (
-                        process.returncode != 0 and process.returncode != 1
-                    ):  # grep returns 1 when no matches found
-                        all_results.append(f"Results from {repo_name}: {process.stderr}")
-                    elif process.stdout:
-                        final_output = process.stdout
-                        # Each line is a grep result, -A, -B, -C are ways to get lines before, after, and around the match
-                        if "-A" not in cmd_args and "-B" not in cmd_args and "-C" not in cmd_args:
-                            lines = process.stdout.split("\n")
-                            final_output = ""
-                            for line in lines:
-                                if len(line) > MAX_GREP_LINE_CHARACTER_LENGTH:
-                                    line = (
-                                        line[:MAX_GREP_LINE_CHARACTER_LENGTH]
-                                        + "...[TRUNCATED: line too long to display]"
-                                    )
-                                final_output += line + "\n"
-
-                        if len(final_output) > TOTAL_GREP_RESULTS_CHARACTER_LENGTH:
-                            final_output = (
-                                final_output[:TOTAL_GREP_RESULTS_CHARACTER_LENGTH]
-                                + "...[GREP RESULTS TRUNCATED: too long to display, try narrowing your search]"
-                            )
-
-                        all_results.append(
-                            f"Results from {repo_name}:\n------\n{final_output}\n------"
-                        )
-                    else:
-                        all_results.append(f"Results from {repo_name}: no results found.")
-                except subprocess.TimeoutExpired:
-                    all_results.append(
-                        f"Results from {repo_name}: command timed out. Try narrowing your search."
-                    )
-            except Exception as e:
-                all_results.append(f"Error in repo {repo_name}: {str(e)}")
-
-        if not all_results:
-            return "No results found."
-
-        return "\n\n".join(all_results)
+        return run_grep_search(cmd_args, repo_names, self.tmp_dir)
 
     def _ensure_repos_downloaded(self, repo_name: str | None = None):
         """


### PR DESCRIPTION
If we run a bad grep query that times out when multiple repos are available, it seems like the run freezes (and often it'll time out).
e.g. 45 second timeout * 4 selected repos = 3 min of doing nothing

So this PR parallelizes grep calls if there are multiple repos so that at most we wait only 45 seconds.