### PR TITLE
fix(autofix): Downgrade coding to 3.5 sonnet v2

### DIFF
--- a/src/seer/automation/autofix/components/coding/component.py
+++ b/src/seer/automation/autofix/components/coding/component.py
@@ -164,7 +164,7 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
             response = agent.run(
                 RunConfig(
                     system_prompt=CodingPrompts.format_system_msg(),
-                    model=AnthropicProvider.model("claude-3-7-sonnet@20250219"),
+                    model=AnthropicProvider.model("claude-3-5-sonnet-v2@20241022"),
                     memory_storage_key="code",
                     run_name="Code",
                     max_iterations=64,


### PR DESCRIPTION
Should be more reliable after looking at the logs of the eval run it looks like less overloaded errors?

No difference in coding eval:

![CleanShot 2025-04-22 at 02 56 57@2x](https://github.com/user-attachments/assets/7365f6c4-d5f7-487c-bd45-6d59a178bd1c)

![CleanShot 2025-04-22 at 03 01 22@2x](https://github.com/user-attachments/assets/8bf976e4-1f6f-48d2-8e19-4b9b96343b91)
