### PR TITLE
fix(fixability) Lower thresh further for dogfooding

### DIFF
--- a/src/seer/automation/summarize/issue.py
+++ b/src/seer/automation/summarize/issue.py
@@ -259,6 +259,6 @@ def evaluate_autofixability(
         f"Possible cause: {issue_summary.possible_cause}"
     )
     score = autofixability_model.score(issue_summary_input)
-    is_fixable = score > 0.718  # 75th percentile on test set
+    is_fixable = score > 0.687  # 65th percentile on test set, which is a mix of many orgs' issues
     sentry_sdk.set_tag("is_fixable", is_fixable)
     return score, is_fixable


### PR DESCRIPTION
Currently, most fixability invocations are on our org's issues, which have a lower fixability rate than the test set used to derive the current threshold.

Can reset this back before launch. Would like to stretch it out a bit for now for better dogfooding / to see more potential failure cases

