### PR TITLE
gha: pin action versions

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       packages: "write"
     steps:
-      - uses: snok/container-retention-policy@v3.0.0
+      - uses: snok/container-retention-policy@4f22ef80902ad409ed55a99dc5133cc1250a0d03 # v3.0.0
         with:
           account: getsentry
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -16,7 +16,7 @@ jobs:
       statuses: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get changed files
         id: changes
         uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
@@ -49,7 +49,7 @@ jobs:
       - name: Get auth token
         id: token
         if: ${{ steps.pre-commit_results.outcome == 'failure' }}
-        uses: getsentry/action-github-app-token@v3.0.0
+        uses: getsentry/action-github-app-token@d4b5da6c5e37703f8c3b3e43abb5705b46e159cc # v3.0.0
         with:
           app_id: ${{ vars.SENTRY_INTERNAL_APP_ID }}
           private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
@@ -57,7 +57,7 @@ jobs:
       - name: Apply any pre-commit fixed files
         if: ${{ steps.pre-commit_results.outcome == 'failure' }}
         # note: this runs "always" or else it's skipped when pre-commit fails
-        uses: getsentry/action-github-commit@v2.1.0
+        uses: getsentry/action-github-commit@5972d5f578ad77306063449e718c0c2a6fbc4ae1 # v2.1.0
         with:
           github-token: ${{ steps.token.outputs.token }}
           message: ":hammer_and_wrench: apply pre-commit fixes"

--- a/.github/workflows/relevant-warnings.yml
+++ b/.github/workflows/relevant-warnings.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,20 +17,20 @@ jobs:
       id-token: "write"
       packages: "write"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
       - id: "auth"
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@3a3c4c57d294ef65efaaee4ff17b22fa88dd3c69 # v1
         with:
           workload_identity_provider: "projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool"
           service_account: "gha-seer-models@sac-prod-sa.iam.gserviceaccount.com"
@@ -58,10 +58,10 @@ jobs:
     env:
       IMAGE_TAG: cache-${{ github.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -94,17 +94,17 @@ jobs:
       matrix:
         group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: "auth"
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@3a3c4c57d294ef65efaaee4ff17b22fa88dd3c69 # v1
         with:
           workload_identity_provider: "projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool"
           service_account: "gha-seer-models@sac-prod-sa.iam.gserviceaccount.com"
@@ -114,7 +114,7 @@ jobs:
           create_credentials_file: true
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1
 
       - name: Pull pre-built Docker image
         run: |
@@ -158,7 +158,7 @@ jobs:
 
       - name: Upload to codecov
         if: ${{ always() }}
-        uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044
+        uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ".artifacts/coverage.xml"

--- a/.github/workflows/validate-pipelines.yml
+++ b/.github/workflows/validate-pipelines.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       gocd: ${{ steps.changes.outputs.gocd }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: Check for relevant file changes
         uses: getsentry/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: changes
@@ -38,21 +38,21 @@ jobs:
       id-token: "write"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - id: "auth"
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@3a3c4c57d294ef65efaaee4ff17b22fa88dd3c69 # v1
         with:
           workload_identity_provider: "projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool"
           service_account: "gha-gocd-api@sac-prod-sa.iam.gserviceaccount.com"
           token_format: "id_token"
           id_token_audience: "610575311308-9bsjtgqg4jm01mt058rncpopujgk3627.apps.googleusercontent.com"
           id_token_include_email: true
-      - uses: getsentry/action-gocd-jsonnet@v1
+      - uses: getsentry/action-gocd-jsonnet@3aec6fd54ac8d2fecfe700360f5d020e6902ba2d # v1
         with:
           jb-install: true
           jsonnet-dir: gocd/templates
           generated-dir: gocd/generated-pipelines
-      - uses: getsentry/action-validate-gocd-pipelines@v1
+      - uses: getsentry/action-validate-gocd-pipelines@5662a2b631d4e2aa1bfc21e878f9e131c31c40c1 # v1
         with:
           configrepo: seer__main
           gocd_access_token: ${{ secrets.GOCD_ACCESS_TOKEN }}


### PR DESCRIPTION
Using version tags or no specifier at all can open us up to dependency attacks.
Pinning the SHA is a strong mitigation. 

See: https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/