### PR TITLE
fix(autofix): Limit parallel tool calls

### DIFF
--- a/src/seer/automation/autofix/autofix_agent.py
+++ b/src/seer/automation/autofix/autofix_agent.py
@@ -248,9 +248,19 @@ class AutofixAgent(LlmAgent):
 
         # call any tools the model wants to use
         if completion.message.tool_calls:
-            for tool_call in completion.message.tool_calls:
-                tool_response = self.call_tool(tool_call)
-                self.memory.append(tool_response)
+            for i, tool_call in enumerate(completion.message.tool_calls):
+                if i < 3:  # only allowing up to 3 simultaneous tool calls
+                    tool_response = self.call_tool(tool_call)
+                    self.memory.append(tool_response)
+                else:
+                    self.memory.append(
+                        Message(
+                            role="tool",
+                            content="This tool was not called as you cannot call more than 3 tools at a time.",
+                            tool_call_id=tool_call.id,
+                            tool_call_function=tool_call.function,
+                        )
+                    )
 
         self.iterations += 1
         self.usage += completion.metadata.usage


### PR DESCRIPTION
In some edge cases, autofix will call hundreds of tools at once and cause run timeouts. So this rejects any tool calls after the first 3 in the same iteration. The reason we still have to add the rejections to memory is so Claude API doesn't complain.