### PR TITLE
fix(autofix): Handle some claude tools faillures

### DIFF
--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -779,7 +779,7 @@ class BaseTools:
             file_diff, _ = make_file_patches([file_change], [path], [document])
 
             if not file_diff:
-                return "Error: No changes were made to the file. Make sure old_str is exact, even including whitespace."
+                return "Error: No changes were made to the file. Make sure old_str is exact, even including indentation."
 
             self.context.event_manager.send_insight(
                 InsightSharingOutput(

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -255,8 +255,10 @@ class BaseTools:
 
         for p in all_files:
             if p.endswith(normalized_path):
+                # is a valid file path
                 return p
             if p.startswith(normalized_path):
+                # is a valid directory path
                 return normalized_path
 
         return None

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -249,13 +249,15 @@ class BaseTools:
         repo_client = self.context.get_repo_client(repo_name=repo_name, type=self.repo_client_type)
         all_files = repo_client.get_index_file_set()
 
+        normalized_path = path.lstrip("./").lstrip("/")
+        if not normalized_path:
+            return None
+
         for p in all_files:
-            if p.endswith(path):
-                # is a valid file path
+            if p.endswith(normalized_path):
                 return p
-            if p.startswith(path):
-                # is a valid directory path
-                return path
+            if p.startswith(normalized_path):
+                return normalized_path
 
         return None
 
@@ -777,7 +779,7 @@ class BaseTools:
             file_diff, _ = make_file_patches([file_change], [path], [document])
 
             if not file_diff:
-                return "Error: No changes were made to the file."
+                return "Error: No changes were made to the file. Make sure old_str is exact, even including whitespace."
 
             self.context.event_manager.send_insight(
                 InsightSharingOutput(


### PR DESCRIPTION
Tweaks to address common Claude coding tools failures that were leading to more iterations than necessary.
- handle leading slashes in paths
- handle claude messing up indentation by giving it a better error message