### PR TITLE
ci(st): Fix deploys for customer 4

### DIFF
--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -2,18 +2,12 @@
 
 eval "$(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")"
 
-if [ "${SENTRY_REGION}" != "customer-1" ] && [ "${SENTRY_REGION}" != "customer-2" ] && [ "${SENTRY_REGION}" != "customer-4" ] && [ "${SENTRY_REGION}" != "customer-7" ]; then
+if [ "${SENTRY_REGION}" != "customer-1" ] && [ "${SENTRY_REGION}" != "customer-2" ] && [ "${SENTRY_REGION}" != "customer-7" ]; then
   /devinfra/scripts/k8s/k8stunnel \
     && /devinfra/scripts/k8s/k8s-deploy.py \
     --label-selector="service=seer" \
     --image="us-central1-docker.pkg.dev/sentryio/seer/image:${GO_REVISION_SEER_REPO}" \
     --container-name="seer"
-
-  /devinfra/scripts/k8s/k8stunnel \
-    && /devinfra/scripts/k8s/k8s-deploy.py \
-    --label-selector="service=seer-autofix" \
-    --image="us-central1-docker.pkg.dev/sentryio/seer/image:${GO_REVISION_SEER_REPO}" \
-    --container-name="seer-autofix"
 fi
 
 /devinfra/scripts/k8s/k8stunnel \

--- a/gocd/templates/bash/run-migrations.sh
+++ b/gocd/templates/bash/run-migrations.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "${SENTRY_REGION}" != "customer-1" ] && [ "${SENTRY_REGION}" != "customer-2" ] && [ "${SENTRY_REGION}" != "customer-4" ] && [ "${SENTRY_REGION}" != "customer-7" ]; then
+if [ "${SENTRY_REGION}" != "customer-1" ] && [ "${SENTRY_REGION}" != "customer-2" ] && [ "${SENTRY_REGION}" != "customer-7" ]; then
   echo "running flask db upgrade" \
     && eval "$(/devinfra/scripts/regions/project_env_vars.py --region="${SENTRY_REGION}")" \
     && /devinfra/scripts/k8s/k8stunnel \


### PR DESCRIPTION
1. We weren't actually deploying normal `seer` to customer 4
2. On customer 4 normal `seer` exists now so we can use it for migrations and not `seer-gpu`