### PR TITLE
fix(autofix): Attempt fix for repo metadata read

### DIFF
--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -57,13 +57,13 @@ class BaseTools:
         self._executor = ThreadPoolExecutor(initializer=copy_modules_initializer())
         self._start_parallel_repo_download()
 
-    @sentry_sdk.trace
     def _start_parallel_repo_download(self):
         """Start downloading all repositories in parallel in the background."""
         repo_names = self._get_repo_names()
         if not repo_names:
             return
 
+        @sentry_sdk.trace
         def download_all_repos():
             """Download all repositories and update self.tmp_dir directly."""
             # Create a lock for thread-safe updates to self.tmp_dir

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -207,11 +207,11 @@ class RepoClient:
                         description=repo_definition.external_id,
                     ):
                         self.repo = self.github.get_repo(int(repo_definition.external_id))
-                except Exception as e:
+                except Exception as e2:
                     logger.exception(
                         f"Error getting repo via external id {repo_definition.external_id}"
                     )
-                    raise e
+                    raise e2
             else:
                 raise e
 


### PR DESCRIPTION
o3 suggested that the undocumented `repositories/:id` endpoint is not whitelisted for github app installations? This will try to use the full name before using the id.

- fixes a trace for repo downloading
- adds spans for the repo metadata read call