### PR TITLE
fix(autofix): Set celery max tasks per child

### DIFF
--- a/src/celery_app/config.py
+++ b/src/celery_app/config.py
@@ -25,4 +25,5 @@ def celery_config(app_config: AppConfig = injected) -> CeleryConfig:
             }
         },
         result_backend="rpc://",
+        worker_max_tasks_per_child=3,
     )


### PR DESCRIPTION
We found that both in local eval runs and in prod, memory gradually adds up on all autofix pods until a deploy happens. This means there's some memory leak in Autofix.

This setting to celery makes each child process of a celery worker only accept 3 tasks before being recreated, freeing memory.

This is a stopgap until we find the source of the memory leak, but we should be refreshing our celery workers anyways.