### PR TITLE
fix(autofix): Set temp to 0 for gemini flash

### DIFF
--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -78,7 +78,7 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
                         max_iterations=64,
                         memory_storage_key="root_cause_analysis",
                         run_name="Root Cause Discovery",
-                        temperature=1.0,
+                        temperature=0.0,
                         max_tokens=8192 if config.SENTRY_REGION == "de" else 32000,
                     ),
                 )

--- a/src/seer/automation/autofix/components/solution/component.py
+++ b/src/seer/automation/autofix/components/solution/component.py
@@ -160,7 +160,7 @@ class SolutionComponent(BaseComponent[SolutionRequest, SolutionOutput]):
                             memory_storage_key="solution",
                             run_name="Solution Discovery",
                             max_iterations=64,
-                            temperature=1.0,
+                            temperature=0.0,
                             max_tokens=8192 if config.SENTRY_REGION == "de" else 32000,
                         ),
                     )


### PR DESCRIPTION
For the context gathering step in the root cause and solution, switches the temperature from 1.0 (remnant from claude thinking) to 0.0. Seems to improve evals slightly by a few points.