### PR TITLE
fix(autofix): Fix memory leak due to functools caches

### DIFF
--- a/src/celery_app/config.py
+++ b/src/celery_app/config.py
@@ -25,5 +25,5 @@ def celery_config(app_config: AppConfig = injected) -> CeleryConfig:
             }
         },
         result_backend="rpc://",
-        worker_max_tasks_per_child=3,
+        worker_max_tasks_per_child=8,
     )


### PR DESCRIPTION
Turns out the memory leak we had in Autofix was due to us misusing `functools.cache`/`functools.lru_cache`. When it caches the arguments it caches _all_ the arguments. **This includes the instance of `self`** This means that we were maintaining a reference to instances of the repo client in this case as long as the cache persisted and if the instance isn't the exact same one we weren't even getting cache hits.

### Memory usage during an eval:

Before:
![CleanShot 2025-04-29 at 22 25 17@2x](https://github.com/user-attachments/assets/b75d6a6a-9b9a-4738-962c-16eebe257a8d)

After:
![CleanShot 2025-05-02 at 02 29 47@2x](https://github.com/user-attachments/assets/a29cfe93-9dc8-4cb0-b01c-b946fa4f286b)

(this also probably means Autofixes are slightly faster because we'll now be getting cache hits!)

### How to correctly use it:

To correctly use the cache on class instance methods you have to pass the "de-selfed" version within the constructor. 

Note: You can safely cache class methods because the `cls` instance is consistent.