### PR TITLE
feat(autofix): Better ripgrep option, response, and logging

### DIFF
--- a/src/seer/automation/autofix/tools/ripgrep_search.py
+++ b/src/seer/automation/autofix/tools/ripgrep_search.py
@@ -3,6 +3,7 @@ import subprocess
 from pathlib import Path
 
 from langfuse.decorators import observe
+import sentry_sdk
 
 MAX_RIPGREP_TIMEOUT_SECONDS = 20
 MAX_RIPGREP_LINE_CHARACTER_LENGTH = 1024
@@ -12,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 @observe(name="Run ripgrep in repo")
+@sentry_sdk.trace
 def run_ripgrep_in_repo(
     repo_dir: str, cmd: list[str], timeout: float = MAX_RIPGREP_TIMEOUT_SECONDS
 ) -> str:

--- a/src/seer/automation/autofix/tools/ripgrep_search.py
+++ b/src/seer/automation/autofix/tools/ripgrep_search.py
@@ -1,5 +1,5 @@
-import subprocess
 import logging
+import subprocess
 from pathlib import Path
 
 from langfuse.decorators import observe

--- a/src/seer/automation/autofix/tools/ripgrep_search.py
+++ b/src/seer/automation/autofix/tools/ripgrep_search.py
@@ -2,8 +2,8 @@ import logging
 import subprocess
 from pathlib import Path
 
-from langfuse.decorators import observe
 import sentry_sdk
+from langfuse.decorators import observe
 
 MAX_RIPGREP_TIMEOUT_SECONDS = 20
 MAX_RIPGREP_LINE_CHARACTER_LENGTH = 1024

--- a/src/seer/automation/autofix/tools/ripgrep_search.py
+++ b/src/seer/automation/autofix/tools/ripgrep_search.py
@@ -1,4 +1,6 @@
 import subprocess
+import logging
+from pathlib import Path
 
 from langfuse.decorators import observe
 
@@ -6,14 +8,17 @@ MAX_RIPGREP_TIMEOUT_SECONDS = 20
 MAX_RIPGREP_LINE_CHARACTER_LENGTH = 1024
 TOTAL_RIPGREP_RESULTS_CHARACTER_LENGTH = 16384
 
+logger = logging.getLogger(__name__)
+
 
 @observe(name="Run ripgrep in repo")
 def run_ripgrep_in_repo(
     repo_dir: str, cmd: list[str], timeout: float = MAX_RIPGREP_TIMEOUT_SECONDS
 ) -> str:
     try:
+        prepared_cmd = " ".join(cmd)
         result = subprocess.run(
-            " ".join(cmd),
+            prepared_cmd,
             cwd=repo_dir,
             shell=True,
             stdout=subprocess.PIPE,
@@ -26,14 +31,25 @@ def run_ripgrep_in_repo(
         # >1 for real errors (bad pattern, etc.)
         if result.returncode not in (0, 1):
             raise RuntimeError(
-                f"ripgrep error (exit {result.returncode}):\n{result.stderr.strip()}"
+                f"Ran ripgrep with command: `{prepared_cmd}`\n\nripgrep Error (exit {result.returncode}):\n{result.stderr.strip()}"
             )
 
-        if result.returncode == 1:
-            return "ripgrep returned: No results found."
+        output = result.stdout
+
+        if result.returncode == 1 or not output:
+            try:
+                list_directory_contents(
+                    repo_dir
+                )  # Debug log the repo directory contents and filetypes to langfuse
+            except Exception as e:
+                logger.exception(e)
+
+            return (
+                f"Ran ripgrep with command: `{prepared_cmd}`\n\nripgrep returned: No results found."
+            )
 
         # clean out all tmp dirs, we just do a simple replace because these tmp dir strings should be pretty unique.
-        output = result.stdout
+
         output = output.replace(repo_dir + "/", "./")
 
         lines = []
@@ -50,7 +66,32 @@ def run_ripgrep_in_repo(
         if len(output) > TOTAL_RIPGREP_RESULTS_CHARACTER_LENGTH:
             output = f"{output[:TOTAL_RIPGREP_RESULTS_CHARACTER_LENGTH]}...[RESULT TRUNCATED TO {TOTAL_RIPGREP_RESULTS_CHARACTER_LENGTH} CHARACTERS, RUN A MORE SPECIFIC QUERY TO SEE THE REMAINDER OF THE RESULT]"
 
-        return output
+        return f"Ran ripgrep with command: `{prepared_cmd}`\n\nResult:\n{output}"
 
     except subprocess.TimeoutExpired:
-        raise RuntimeError(f"ripgrep timed out after {timeout}s")
+        raise RuntimeError(
+            f"Ran ripgrep with command: `{prepared_cmd}`\n\nripgrep timed out after {timeout}s"
+        )
+
+
+@observe(name="DEBUG List directory contents")
+def list_directory_contents(directory="."):
+    # Get all entries in the directory
+    output = ""
+    for entry in Path(directory).iterdir():
+        # Get file type
+        if entry.is_symlink():
+            file_type = "symlink"
+        elif entry.is_dir():
+            file_type = "directory"
+        elif entry.is_file():
+            file_type = "file"
+        else:
+            file_type = "unknown"
+
+        # Get file name
+        name = entry.name
+
+        output += f"{file_type:<10} {name}\n"
+
+    return output

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -408,7 +408,7 @@ class BaseTools:
         exclude_pattern: str | None = None,
         case_sensitive: bool = False,
         repo_name: str | None = None,
-        fixed_strings: bool = True,
+        fixed_strings: bool = False,
     ) -> str:
         self._ensure_repos_downloaded(repo_name)
 
@@ -426,7 +426,7 @@ class BaseTools:
         # Add other common flags
         if fixed_strings:
             cmd.append("--fixed-strings")
-            
+
         if not case_sensitive:
             cmd.append("--ignore-case")
 
@@ -1059,11 +1059,6 @@ class BaseTools:
                         description="Runs a ripgrep command over the codebase to find what you're looking for. Use this as your main tool for searching codebases. Use the include and exclude patterns to narrow down the search to specific paths or file types.",
                         parameters=[
                             {
-                                "name": "query",
-                                "type": "string",
-                                "description": "The text pattern you're searching for.",
-                            },
-                            {
                                 "name": "include_pattern",
                                 "type": "string",
                                 "description": "Optional glob pattern for files to include. For example, '*.py' for Python files.",
@@ -1081,12 +1076,17 @@ class BaseTools:
                             {
                                 "name": "fixed_strings",
                                 "type": "boolean",
-                                "description": "If true (default), search for the literal text. If false, interpret the query as a regex pattern.",
+                                "description": "If true, search for the literal text. If false, interpret the query as a regex pattern.",
                             },
                             {
                                 "name": "repo_name",
                                 "type": "string",
                                 "description": "Optional name of the repository to search in. If not provided, all repositories will be searched.",
+                            },
+                            {
+                                "name": "query",
+                                "type": "string",
+                                "description": "The precise query you're searching for. If `fixed_strings` is true, this will be interpreted as a literal string, no escaping is needed. Otherwise, it will be interpreted as a regex pattern, and correct regex syntax must be used.",
                             },
                         ],
                         required=["query"],

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -408,6 +408,7 @@ class BaseTools:
         exclude_pattern: str | None = None,
         case_sensitive: bool = False,
         repo_name: str | None = None,
+        fixed_strings: bool = True,
     ) -> str:
         self._ensure_repos_downloaded(repo_name)
 
@@ -423,6 +424,9 @@ class BaseTools:
         cmd.extend(["--threads", "1"])
 
         # Add other common flags
+        if fixed_strings:
+            cmd.append("--fixed-strings")
+            
         if not case_sensitive:
             cmd.append("--ignore-case")
 
@@ -1057,7 +1061,7 @@ class BaseTools:
                             {
                                 "name": "query",
                                 "type": "string",
-                                "description": "The regex pattern you're searching for.",
+                                "description": "The text pattern you're searching for.",
                             },
                             {
                                 "name": "include_pattern",
@@ -1073,6 +1077,11 @@ class BaseTools:
                                 "name": "case_sensitive",
                                 "type": "boolean",
                                 "description": "Whether the search should be case sensitive.",
+                            },
+                            {
+                                "name": "fixed_strings",
+                                "type": "boolean",
+                                "description": "If true (default), search for the literal text. If false, interpret the query as a regex pattern.",
                             },
                             {
                                 "name": "repo_name",

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -421,7 +421,7 @@ class BaseTools:
         cmd.extend(["--max-columns", "1024"])
 
         # limit threads
-        cmd.extend(["--threads", "1"])
+        cmd.extend(["--threads", "2"])
 
         # Add other common flags
         if fixed_strings:

--- a/tests/test_ripgrep_search.py
+++ b/tests/test_ripgrep_search.py
@@ -42,7 +42,7 @@ def test_run_ripgrep_in_repo_no_results(monkeypatch):
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     result = run_ripgrep_in_repo("/repo", ["rg", '"q"'])
-    assert result == "ripgrep returned: No results found."
+    assert result == 'Ran ripgrep with command: `rg "q"`\n\nripgrep returned: No results found.'
 
 
 def test_run_ripgrep_in_repo_error_exit_code(monkeypatch):
@@ -54,7 +54,7 @@ def test_run_ripgrep_in_repo_error_exit_code(monkeypatch):
     with pytest.raises(RuntimeError) as excinfo:
         run_ripgrep_in_repo("/repo", ["rg", '"x"'])
     err = str(excinfo.value)
-    assert "ripgrep error (exit 2):" in err
+    assert "ripgrep Error (exit 2):" in err
     assert "bad pattern" in err
 
 


### PR DESCRIPTION
1. Add `fixed_strings` as an option to ripgrep as another search option
2. Better responses to show the command to the LLM for debugging purposes
3. Add logging in failure cases to `ls` the repo and the types
4. Bumps ripgrep threads to 2