### PR TITLE
fix(autofix): Fallback to local file reading if expand document fails

### DIFF
--- a/src/seer/automation/autofix/tools/read_file_contents.py
+++ b/src/seer/automation/autofix/tools/read_file_contents.py
@@ -2,8 +2,7 @@ import logging
 import os
 
 import sentry_sdk
-
-from seer.automation.autofix.tools.tools import observe
+from langfuse.decorators import observe
 
 logger = logging.getLogger(__name__)
 

--- a/src/seer/automation/autofix/tools/read_file_contents.py
+++ b/src/seer/automation/autofix/tools/read_file_contents.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 
 import sentry_sdk
 

--- a/src/seer/automation/autofix/tools/read_file_contents.py
+++ b/src/seer/automation/autofix/tools/read_file_contents.py
@@ -1,0 +1,29 @@
+import os
+import logging
+
+import sentry_sdk
+
+from seer.automation.autofix.tools.tools import observe
+
+logger = logging.getLogger(__name__)
+
+
+@observe(name="Read File Contents from File System")
+@sentry_sdk.trace
+def read_file_contents(repo_dir: str, file_path: str) -> tuple[str | None, str | None]:
+    path = os.path.join(repo_dir, file_path)
+
+    if not os.path.exists(path):
+        logger.warning(f"File does not exist: {file_path}")
+        return None, f"Error: File {file_path} does not exist"
+
+    if not os.path.isfile(path):
+        logger.warning(f"Path exists but is not a file: {file_path}")
+        return None, f"Error: Path {file_path} exists but is not a file"
+
+    try:
+        with open(path, "r") as f:
+            return f.read(), None
+    except Exception as e:
+        logger.exception(f"Error reading file {file_path}: {e}")
+        return None, f"Error reading file {file_path}: {e}"

--- a/tests/seer/automation/autofix/tools/test_read_file_contents.py
+++ b/tests/seer/automation/autofix/tools/test_read_file_contents.py
@@ -1,0 +1,73 @@
+import os
+import pytest
+from unittest.mock import patch, mock_open
+
+from seer.automation.autofix.tools.read_file_contents import read_file_contents
+
+
+class TestReadFileContents:
+    def test_successful_read(self, tmp_path):
+        # Create a temporary file with content
+        test_file = tmp_path / "test.txt"
+        test_content = "Hello, World!"
+        test_file.write_text(test_content)
+
+        # Test reading the file
+        content, error = read_file_contents(str(tmp_path), "test.txt")
+        assert content == test_content
+        assert error is None
+
+    def test_file_does_not_exist(self, tmp_path):
+        # Test reading a non-existent file
+        content, error = read_file_contents(str(tmp_path), "nonexistent.txt")
+        assert content is None
+        assert "does not exist" in error
+
+    def test_path_is_directory(self, tmp_path):
+        # Create a directory instead of a file
+        test_dir = tmp_path / "test_dir"
+        test_dir.mkdir()
+
+        # Test reading a directory
+        content, error = read_file_contents(str(tmp_path), "test_dir")
+        assert content is None
+        assert "exists but is not a file" in error
+
+    @patch("builtins.open", side_effect=PermissionError("Permission denied"))
+    @patch("os.path.exists", return_value=True)
+    @patch("os.path.isfile", return_value=True)
+    def test_permission_error(self, mock_isfile, mock_exists, mock_open, tmp_path):
+        # Test permission error when reading file
+        content, error = read_file_contents(str(tmp_path), "test.txt")
+        assert content is None
+        assert "Permission denied" in error
+
+    @patch("builtins.open", side_effect=UnicodeDecodeError("utf-8", b"test", 0, 1, "invalid utf-8"))
+    @patch("os.path.exists", return_value=True)
+    @patch("os.path.isfile", return_value=True)
+    def test_unicode_decode_error(self, mock_isfile, mock_exists, mock_open, tmp_path):
+        # Test unicode decode error when reading file
+        content, error = read_file_contents(str(tmp_path), "test.txt")
+        assert content is None
+        assert "invalid utf-8" in error
+
+    def test_empty_file(self, tmp_path):
+        # Create an empty file
+        test_file = tmp_path / "empty.txt"
+        test_file.write_text("")
+
+        # Test reading an empty file
+        content, error = read_file_contents(str(tmp_path), "empty.txt")
+        assert content == ""
+        assert error is None
+
+    def test_file_with_special_characters(self, tmp_path):
+        # Create a file with special characters
+        test_file = tmp_path / "special.txt"
+        test_content = "Hello\n世界\n🌍"
+        test_file.write_text(test_content)
+
+        # Test reading file with special characters
+        content, error = read_file_contents(str(tmp_path), "special.txt")
+        assert content == test_content
+        assert error is None

--- a/tests/seer/automation/autofix/tools/test_read_file_contents.py
+++ b/tests/seer/automation/autofix/tools/test_read_file_contents.py
@@ -1,7 +1,4 @@
-import os
-from unittest.mock import mock_open, patch
-
-import pytest
+from unittest.mock import patch
 
 from seer.automation.autofix.tools.read_file_contents import read_file_contents
 

--- a/tests/seer/automation/autofix/tools/test_read_file_contents.py
+++ b/tests/seer/automation/autofix/tools/test_read_file_contents.py
@@ -1,6 +1,7 @@
 import os
+from unittest.mock import mock_open, patch
+
 import pytest
-from unittest.mock import patch, mock_open
 
 from seer.automation.autofix.tools.read_file_contents import read_file_contents
 


### PR DESCRIPTION
We often get 404 errors from Github when reading files, when that happens, let's try reading the file locally that has better logging/error states