### PR TITLE
chore(trace summary): Reduce token count

### DIFF
--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -1375,12 +1375,14 @@ class EAPTrace(BaseModel):
             trace = self._get_transaction_spans(self.trace)
 
         def format_span_as_tag(span, depth=0):
-            indent = "    " * depth
+            indent = "  " * depth
 
             attrs = []
             for key, value in span.items():
                 # Ignore event_type since all events are marked as "span"
-                if key not in ["children", "event_type"]:
+                if key not in ["children", "event_type", "is_transaction"]:
+                    if key == "errors" and value == []:
+                        continue
                     attrs.append(f'{key}="{value}"')
             attrs_str = " ".join(attrs)
 

--- a/tests/automation/test_automation_models.py
+++ b/tests/automation/test_automation_models.py
@@ -1119,12 +1119,12 @@ def test_get_and_format_trace():
     trace = EAPTrace(trace_id="simple-trace", trace=trace_data, timestamp=datetime.datetime.now())
 
     result = trace.get_and_format_trace()
-    expected = """<txn id="span1" name="Transaction 1" is_transaction="True" />
-<span id="span2" name="Non-Transaction Span" is_transaction="False">
-    <span id="span2_1" name="Non-Transaction Span 1" is_transaction="False" />
-    <span id="span2_2" name="Non-Transaction Span 2" is_transaction="False" />
+    expected = """<txn id="span1" name="Transaction 1" />
+<span id="span2" name="Non-Transaction Span">
+  <span id="span2_1" name="Non-Transaction Span 1" />
+  <span id="span2_2" name="Non-Transaction Span 2" />
 </span>
-<txn id="span3" name="Transaction 2" is_transaction="True" />"""
+<txn id="span3" name="Transaction 2" />"""
     assert result == expected
 
     trace_data = [
@@ -1136,13 +1136,15 @@ def test_get_and_format_trace():
     trace = EAPTrace(trace_id="simple-trace", trace=trace_data, timestamp=datetime.datetime.now())
 
     result = trace.get_and_format_trace()
-    expected = """<txn id="span1" name="Transaction 1" is_transaction="True" />
-<span id="span2" name="Non-Transaction Span" is_transaction="False" />
-<txn id="span3" name="Transaction 2" is_transaction="True" />"""
+    expected = """<txn id="span1" name="Transaction 1" />
+<span id="span2" name="Non-Transaction Span" />
+<txn id="span3" name="Transaction 2" />"""
     assert result == expected
 
     result = trace.get_and_format_trace(only_transactions=True)
-    expected = """<txn id="span1" name="Transaction 1" is_transaction="True" />\n<txn id="span3" name="Transaction 2" is_transaction="True" />"""
+    expected = (
+        """<txn id="span1" name="Transaction 1" />\n<txn id="span3" name="Transaction 2" />"""
+    )
     assert result == expected
 
 


### PR DESCRIPTION
- Reduce token count by ignoring is_transaction and empty errors keys
- Reduce indent amount from 4 -> 2 spaces
- Should save 3-6 tokens per span which adds up over 100-1000s of spans

To Do Next:
- autogrouping spans (similar to the trace waterfall with some simple heuristics
- review if truncating descriptions or long keys impacts results