### PR TITLE
chore(autofix): Deletes errored steps when retrying

### DIFF
--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -395,6 +395,11 @@ class AutofixEventManager:
                 },
             )
 
+            if (
+                not should_completely_error
+            ):  # delete the last step so it's replaced with the new one upon retry
+                cur.steps = cur.steps[:-1]
+
     def clear_file_changes(self):
         with self.state.update() as cur:
             cur.clear_file_changes()

--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -396,7 +396,7 @@ class AutofixEventManager:
             )
 
             if (
-                not should_completely_error
+                not should_completely_error and cur.steps
             ):  # delete the last step so it's replaced with the new one upon retry
                 cur.steps = cur.steps[:-1]
 

--- a/src/seer/automation/autofix/steps/coding_step.py
+++ b/src/seer/automation/autofix/steps/coding_step.py
@@ -79,7 +79,9 @@ class AutofixCodingStep(AutofixPipelineStep):
         if not solution:
             raise ValueError("Solution must be found before coding")
 
-        if not self.request.initial_memory:
+        if self.request.is_retry:
+            self.context.event_manager.add_log("Something broke. Coding from scratch...")
+        elif not self.request.initial_memory:
             self.context.event_manager.add_log(
                 f"Coding up a {'fix' if coding_mode == 'fix' else 'test' if coding_mode == 'test' else 'fix and a test'} for this issue..."
             )

--- a/src/seer/automation/autofix/steps/root_cause_step.py
+++ b/src/seer/automation/autofix/steps/root_cause_step.py
@@ -69,7 +69,9 @@ class RootCauseStep(AutofixPipelineStep):
 
         self.context.event_manager.send_root_cause_analysis_start()
 
-        if not self.request.initial_memory:
+        if self.request.is_retry:
+            self.context.event_manager.add_log("Something broke. Re-analyzing from scratch...")
+        elif not self.request.initial_memory:
             self.context.event_manager.add_log("Figuring out the root cause...")
         else:
             self.context.event_manager.add_log("Going back to the drawing board...")

--- a/src/seer/automation/autofix/steps/solution_step.py
+++ b/src/seer/automation/autofix/steps/solution_step.py
@@ -59,7 +59,9 @@ class AutofixSolutionStep(AutofixPipelineStep):
 
         self.context.event_manager.send_solution_start()
 
-        if not self.request.initial_memory:
+        if self.request.is_retry:
+            self.context.event_manager.add_log("Something broke. Re-analyzing from scratch...")
+        elif not self.request.initial_memory:
             self.context.event_manager.add_log("Figuring out a solution...")
         else:
             self.context.event_manager.add_log("Going back to the drawing board...")

--- a/src/seer/automation/autofix/steps/steps.py
+++ b/src/seer/automation/autofix/steps/steps.py
@@ -157,14 +157,12 @@ class AutofixPipelineStep(PipelineChain, PipelineStep):
             self.logger.info(
                 f"Retrying {self.request.step_id}, {new_retry_index}/{self.max_retries} times"
             )
-
-            # Add a log to the current running step and also error it.
-            self.context.event_manager.add_log("**Something went wrong, let me try this again...**")
             self.context.event_manager.on_error(str(exception), should_completely_error=False)
 
             with self.context.state.update() as cur:
                 cur.signals.append(make_retry_signal(self.request.step_id, new_retry_index))
 
+            self.request.is_retry = True
             self.next(self.get_signature(self.request))
         else:
             self.logger.error(

--- a/src/seer/automation/pipeline.py
+++ b/src/seer/automation/pipeline.py
@@ -46,6 +46,7 @@ class PipelineContext(abc.ABC):
 class PipelineStepTaskRequest(BaseModel):
     run_id: int
     step_id: int = Field(default_factory=lambda: uuid.uuid4().int)
+    is_retry: bool = False
 
 
 def make_step_request_fields(context: PipelineContext):


### PR DESCRIPTION
Instead of preserving errored steps that are then retried, we delete the errored step. On the frontend, the content of the errored step disappears and the new one starts with a message like this:
<img width="636" alt="Screenshot 2025-05-06 at 7 29 05 PM" src="https://github.com/user-attachments/assets/34b2e9f4-9d72-46b2-9aa4-19f3ff17b8d9" />
