### PR TITLE
fix(autofix): Add None check for repo names in insight sharing

### DIFF
--- a/src/seer/automation/autofix/components/insight_sharing/component.py
+++ b/src/seer/automation/autofix/components/insight_sharing/component.py
@@ -156,6 +156,8 @@ def process_sources(sources: list, context: AutofixContext, trace_tree: TraceTre
                 )
         elif isinstance(source, CodeSource):
             repo_name = context.autocorrect_repo_name(source.repo_name)
+            if not repo_name:
+                continue
             repo_client = context.get_repo_client(repo_name)
             file_name = source.file_name
             snippet_to_find = source.code_snippet
@@ -182,6 +184,8 @@ def process_sources(sources: list, context: AutofixContext, trace_tree: TraceTre
                         final_sources.code_used_urls.append(code_url)
         elif isinstance(source, DiffSource):
             repo_name = context.autocorrect_repo_name(source.repo_name)
+            if not repo_name:
+                continue
             repo_client = context.get_repo_client(repo_name)
             if repo_client.provider == "github":
                 diff_url = f"https://github.com/{repo_name}/commit/{source.commit_sha}"


### PR DESCRIPTION
The problem was that if the repo name from the insight was invalid (e.g. "N/A" because the LLM knew there were no accessible repos), then autocorrect would return None. Passing None into get_repo_client would pick a non-accessible repo if that was the only one.

So we just make sure that we have a repo name before trying to get a repo client.