### PR TITLE
feat(autofix): Use a git client to clone and checkout repos

### DIFF
--- a/requirements-constraints.txt
+++ b/requirements-constraints.txt
@@ -118,3 +118,4 @@ httpx==0.27.2 # v0.28 is breaking OpenAI and Anthropic as of Dec 16 2024
 tsmoothie==1.0.*
 datadog==0.51.*
 flower==2.0.1
+GitPython==3.1.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ celery==5.3.6
     #   flower
 celery-stubs==0.1.3
     # via -r requirements-constraints.txt
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   -r requirements-constraints.txt
     #   httpcore
@@ -126,7 +126,7 @@ cython==3.0.2
     # via -r requirements-constraints.txt
 datadog==0.51.0
     # via -r requirements-constraints.txt
-datasets==3.5.0
+datasets==3.5.1
     # via optimum
 deprecated==1.2.18
     # via pygithub
@@ -184,6 +184,10 @@ fsspec==2023.6.0
     #   datasets
     #   huggingface-hub
     #   torch
+gitdb==4.0.12
+    # via gitpython
+gitpython==3.1.44
+    # via -r requirements-constraints.txt
 google-api-core==2.24.2
     # via
     #   google-cloud-aiplatform
@@ -192,7 +196,7 @@ google-api-core==2.24.2
     #   google-cloud-resource-manager
     #   google-cloud-secret-manager
     #   google-cloud-storage
-google-auth==2.39.0
+google-auth==2.40.0
     # via
     #   anthropic
     #   google-api-core
@@ -203,7 +207,7 @@ google-auth==2.39.0
     #   google-cloud-secret-manager
     #   google-cloud-storage
     #   google-genai
-google-cloud-aiplatform==1.90.0
+google-cloud-aiplatform==1.91.0
     # via -r requirements-constraints.txt
 google-cloud-bigquery==3.31.0
     # via google-cloud-aiplatform
@@ -238,7 +242,7 @@ grpc-google-iam-v1==0.14.2
     # via
     #   google-cloud-resource-manager
     #   google-cloud-secret-manager
-grpc-stubs==1.53.0.5
+grpc-stubs==1.53.0.6
     # via sentry-protos
 grpcio==1.71.0
     # via
@@ -259,7 +263,7 @@ grpcio-status==1.71.0
     # via google-api-core
 gunicorn==22.0.0
     # via -r requirements-constraints.txt
-h11==0.14.0
+h11==0.16.0
     # via
     #   httpcore
     #   uvicorn
@@ -267,7 +271,7 @@ holidays==0.31
     # via
     #   -r requirements-constraints.txt
     #   prophet
-httpcore==1.0.8
+httpcore==1.0.9
     # via httpx
 httptools==0.6.4
     # via uvicorn
@@ -286,7 +290,7 @@ huggingface-hub==0.30.2
     #   transformers
 humanfriendly==10.0
     # via coloredlogs
-humanize==4.12.2
+humanize==4.12.3
     # via flower
 idna==3.10
     # via
@@ -367,8 +371,6 @@ matplotlib==3.10.1
     #   seaborn
 mdurl==0.1.2
     # via markdown-it-py
-monotonic==1.6
-    # via posthog
 more-itertools==10.7.0
     # via openapi-core
 mpmath==1.3.0
@@ -430,7 +432,7 @@ onnx==1.16.0
     # via -r requirements-constraints.txt
 onnxruntime==1.21.1
     # via chromadb
-openai==1.76.0
+openai==1.77.0
     # via -r requirements-constraints.txt
 openapi-core==0.18.2
     # via -r requirements-constraints.txt
@@ -491,7 +493,7 @@ pip-tools==7.4.1
     # via -r requirements-constraints.txt
 pluggy==1.5.0
     # via pytest
-posthog==4.0.0
+posthog==4.0.1
     # via chromadb
 prometheus-client==0.21.1
     # via flower
@@ -531,7 +533,7 @@ psycopg==3.1.18
     # via -r requirements-constraints.txt
 pulsar-client==3.6.1
     # via chromadb
-pyarrow==19.0.1
+pyarrow==20.0.0
     # via datasets
 pyasn1==0.6.1
     # via
@@ -683,7 +685,7 @@ sentencepiece==0.2.0
     # via
     #   sentence-transformers
     #   transformers
-sentry-protos==0.1.72
+sentry-protos==0.1.74
     # via -r requirements-constraints.txt
 sentry-sdk==2.27.0
     # via -r requirements-constraints.txt
@@ -702,6 +704,8 @@ six==1.16.0
     #   posthog
     #   python-dateutil
     #   rfc3339-validator
+smmap==5.0.2
+    # via gitdb
 sniffio==1.3.1
     # via
     #   anthropic
@@ -720,7 +724,7 @@ starlette==0.46.2
     # via fastapi
 statsmodels==0.14.0
     # via -r requirements-constraints.txt
-structlog==25.2.0
+structlog==25.3.0
     # via -r requirements-constraints.txt
 stumpy==1.13.0
     # via -r requirements-constraints.txt
@@ -770,7 +774,7 @@ tree-sitter-languages==1.10.2
     # via -r requirements-constraints.txt
 tsmoothie==1.0.5
     # via -r requirements-constraints.txt
-typer==0.15.2
+typer==0.15.3
     # via chromadb
 types-colorama==0.4.15.12
     # via -r requirements-constraints.txt

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -39,7 +39,7 @@ REPO_WAIT_TIMEOUT_SECS = 120.0
 class BaseTools:
     context: AutofixContext | CodegenContext
     retrieval_top_k: int
-    repo_managers: Dict[str, RepoManager] = {}
+    repo_managers: dict[str, RepoManager] = {}
     repo_client_type: RepoClientType = RepoClientType.READ
 
     def __init__(
@@ -75,6 +75,7 @@ class BaseTools:
             # Do nothing, the state should self update updated_at
             pass
 
+    @sentry_sdk.trace
     def _ensure_repos_downloaded(self, repo_name: str | None = None):
         """
         Helper method to wait for repos to be downloaded.

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -5,7 +5,7 @@ import subprocess
 import textwrap
 import time
 from concurrent.futures import FIRST_EXCEPTION, ThreadPoolExecutor, as_completed, wait
-from typing import Any, Dict, cast
+from typing import Any, cast
 
 import sentry_sdk
 from langfuse.decorators import observe

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -119,10 +119,12 @@ class BaseTools:
 
             future = repo_manager.initialization_future
             if future in not_done:
+                repo_manager.mark_as_timed_out()
                 logger.warning(
                     f"Repository {repo_manager.repo_client.repo_full_name} timed out after {REPO_WAIT_TIMEOUT_SECS} seconds"
                 )
             elif future.exception():
+                repo_manager.mark_as_timed_out()
                 logger.exception(
                     f"Error initializing repository {repo_manager.repo_client.repo_full_name}: {future.exception()}"
                 )
@@ -206,7 +208,7 @@ class BaseTools:
         local_read_error = None
         if repo_name in self.repo_managers:
             if not self.repo_managers[repo_name].is_available:
-                return f"Error: We had an issue loading the repository {repo_name}."
+                return self._make_repo_unavailable_error_message(repo_name)
 
             repo_dir = self.repo_managers[repo_name].repo_path
 

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -75,7 +75,7 @@ class BaseTools:
 
     def _trigger_liveness_probe(self):
         with self.context.state.update() as state:
-            # Do nothing, the state should self toggle updated_at
+            # Do nothing, the state should self update updated_at
             pass
 
     def _ensure_repos_downloaded(self, repo_name: str | None = None):
@@ -206,6 +206,9 @@ class BaseTools:
 
         local_read_error = None
         if repo_name in self.repo_managers:
+            if not self.repo_managers[repo_name].is_available:
+                return f"Error: We had an issue loading the repository {repo_name}."
+
             repo_dir = self.repo_managers[repo_name].repo_path
 
             # try reading the actual file from file system
@@ -501,6 +504,8 @@ class BaseTools:
             # Single repository search
             if repo_name not in self.repo_managers:
                 return f"Error: Repository {repo_name} not found or not downloaded"
+            if not self.repo_managers[repo_name].is_available:
+                return f"Error: We had an issue loading the repository {repo_name}."
 
             tmp_repo_dir = self.repo_managers[repo_name].repo_path
 
@@ -516,6 +521,9 @@ class BaseTools:
             def search_repo(repo_name: str) -> tuple[str, str] | None:
                 if repo_name not in self.repo_managers:
                     return None
+                if not self.repo_managers[repo_name].is_available:
+                    return f"Error: We had an issue loading the repository {repo_name}.."
+
                 repo_dir = self.repo_managers[repo_name].repo_path
                 try:
                     result = run_ripgrep_in_repo(repo_dir, cmd)
@@ -566,6 +574,10 @@ class BaseTools:
         for repo_name in repo_names:
             if repo_name not in self.repo_managers:
                 continue
+            if not self.repo_managers[repo_name].is_available:
+                all_results.append(f"Error: We had an issue loading the repository {repo_name}.")
+                continue
+
             tmp_repo_dir = self.repo_managers[repo_name].repo_path
             if not tmp_repo_dir:
                 continue

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -3,10 +3,9 @@ import os
 import shlex
 import subprocess
 import textwrap
-from concurrent.futures import ThreadPoolExecutor, as_completed
 import time
+from concurrent.futures import FIRST_EXCEPTION, ThreadPoolExecutor, as_completed, wait
 from typing import Any, Dict, cast
-from concurrent.futures import wait, FIRST_EXCEPTION
 
 import sentry_sdk
 from langfuse.decorators import observe

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -72,7 +72,7 @@ class BaseTools:
             self.repo_managers[repo_name] = repo_manager
 
     def _trigger_liveness_probe(self):
-        with self.context.state.update() as state:
+        with self.context.state.update():
             # Do nothing, the state should self update updated_at
             pass
 
@@ -107,7 +107,7 @@ class BaseTools:
             if repo_manager.initialization_future
         ]
 
-        self.context.event_manager.add_log(f"Waiting for your repositories to download...")
+        self.context.event_manager.add_log("Waiting for your repositories to download...")
 
         # Use concurrent.futures.wait with a single timeout for all futures
         done_not_done: tuple[Set[Future[Any]], Set[Future[Any]]] = wait(

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -5,7 +5,7 @@ import subprocess
 import textwrap
 from concurrent.futures import Future, ThreadPoolExecutor, TimeoutError, as_completed
 from threading import Lock
-from typing import Any, cast, Dict
+from typing import Any, Dict, cast
 
 import sentry_sdk
 from langfuse.decorators import observe
@@ -21,9 +21,9 @@ from seer.automation.autofix.models import AutofixRequest
 from seer.automation.autofix.tools.read_file_contents import read_file_contents
 from seer.automation.autofix.tools.ripgrep_search import run_ripgrep_in_repo
 from seer.automation.codebase.file_patches import make_file_patches
-from seer.automation.codebase.repo_manager import RepoManager
 from seer.automation.codebase.models import BaseDocument
 from seer.automation.codebase.repo_client import RepoClientType
+from seer.automation.codebase.repo_manager import RepoManager
 from seer.automation.codebase.utils import cleanup_dir
 from seer.automation.codegen.codegen_context import CodegenContext
 from seer.automation.models import EventDetails, FileChange, Profile, SentryEventData

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -39,7 +39,7 @@ REPO_WAIT_TIMEOUT_SECS = 120.0
 class BaseTools:
     context: AutofixContext | CodegenContext
     retrieval_top_k: int
-    repo_managers: Dict[str, RepoManager] = {}  # Maps repo_name to RepoManager
+    repo_managers: Dict[str, RepoManager] = {}
     repo_client_type: RepoClientType = RepoClientType.READ
 
     def __init__(
@@ -60,7 +60,6 @@ class BaseTools:
         if not repo_names:
             return
 
-        # Create repo managers for all repos first
         for repo_name in repo_names:
             repo_client = self.context.get_repo_client(
                 repo_name=repo_name, type=self.repo_client_type
@@ -78,13 +77,11 @@ class BaseTools:
 
     def _ensure_repos_downloaded(self, repo_name: str | None = None):
         """
-        Helper method to ensure repositories are downloaded.
-        Simplified version that just checks if repos are already downloaded
-        and downloads them synchronously if needed.
+        Helper method to wait for repos to be downloaded.
 
         Args:
-            repo_name: If provided, only ensures this specific repo is downloaded.
-                      If None, ensures all repos are downloaded.
+            repo_name: If provided, only waits for this specific repo to be downloaded.
+                      If None, waits for all repos to be downloaded.
         """
         if repo_name:
             repo_names_to_download = [repo_name] if repo_name not in self.repo_managers else []

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -197,7 +197,14 @@ class RepoClient:
                 retry=retry,
             )
         else:
-            self.github_auth = get_github_token_auth()
+            token_auth = get_github_token_auth()
+
+            if not token_auth:
+                raise InitializationError(
+                    "No app credentials or token auth provided, please set GITHUB_APP_ID and GITHUB_PRIVATE_KEY or GITHUB_TOKEN"
+                )
+
+            self.github_auth = token_auth
             self.github = Github(auth=self.github_auth, retry=retry)
 
         try:

--- a/src/seer/automation/codebase/repo_manager.py
+++ b/src/seer/automation/codebase/repo_manager.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Callable
 
 import git
+import sentry_sdk
 
 from seer.automation.codebase.repo_client import RepoClient
 from seer.automation.codebase.utils import cleanup_dir
@@ -48,6 +49,7 @@ class RepoManager:
 
         self.initialization_future = ThreadPoolExecutor(1).submit(self.initialize)
 
+    @sentry_sdk.trace
     def initialize(self):
         logger.info(f"Initializing repo {self.repo_client.repo_full_name}")
 
@@ -66,6 +68,7 @@ class RepoManager:
             if self._has_timed_out:
                 self.cleanup()
 
+    @sentry_sdk.trace
     def _clone_repo(self) -> str:
         """
         Clone a repository to a local temporary directory.
@@ -95,6 +98,7 @@ class RepoManager:
             self.git_repo = None  # clear the repo to fail the available check
             raise
 
+    @sentry_sdk.trace
     def _sync_repo(self):
         """
         Ensure the repository is up to date with only the target commit.

--- a/src/seer/automation/codebase/repo_manager.py
+++ b/src/seer/automation/codebase/repo_manager.py
@@ -1,0 +1,256 @@
+import logging
+import os
+import tempfile
+import tarfile
+import time
+
+import git
+from google.cloud import storage
+
+from seer.automation.codebase.repo_client import RepoClient
+from seer.automation.codebase.utils import cleanup_dir
+
+logger = logging.getLogger(__name__)
+
+
+class RepoManager:
+    """
+    A client for interacting with local git repositories using GitPython.
+    """
+
+    def __init__(self, repo_client: RepoClient):
+        """
+        Initialize the local git client.
+        """
+        self.repo_client = repo_client
+        self.git_repo = None
+        self.tmp_dir = tempfile.mkdtemp(
+            prefix=f"{self.repo_client.repo_owner}-{self.repo_client.repo_name}_{self.repo_client.base_commit_sha}"
+        )
+        self.repo_path = os.path.join(self.tmp_dir, "repo")
+
+        if self.gcs_archive_exists():
+            self.download_from_gcs()
+        else:
+            self._clone_repo()
+
+        logger.info(f"Repo {self.repo_client.repo_full_name} ready at {self.repo_path}")
+
+        self._sync_repo()
+
+        # self.upload_to_gcs()
+
+    @property
+    def blob_name(self):
+        """
+        Get the blob name for the repository.
+        """
+        return f"repos/{self.repo_client.repo_owner}/{self.repo_client.repo_name}.tar.gz"
+
+    @property
+    def bucket_name(self):
+        """
+        Get the bucket name for the repository.
+        """
+        return os.environ.get("AUTOFIX_REPOS_GCS_BUCKET", "autofix-repositories-local")
+
+    def _clone_repo(self) -> str:
+        """
+        Clone a repository to a local temporary directory.
+
+        Args:
+            repo_clone_url: The URL of the repository to clone
+
+        Returns:
+            The path to the cloned repository
+        """
+
+        repo_clone_url = self.repo_client.get_clone_url_with_auth()
+
+        try:
+            logger.info(f"Cloning repository {repo_clone_url} to {self.repo_path} with depth=1")
+
+            cleanup_dir(self.repo_path)
+
+            start_time = time.time()
+            self.git_repo = git.Repo.clone_from(repo_clone_url, self.repo_path, depth=1)
+            end_time = time.time()
+            logger.info(f"Cloned repository in {end_time - start_time} seconds")
+
+            return self.repo_path
+        except git.GitCommandError as e:
+            self.cleanup()
+            logger.error(f"Failed to clone repository: {e}")
+            raise
+
+    def _sync_repo(self):
+        """
+        Ensure the repository is up to date with only the target commit.
+        """
+        logger.info(f"Syncing repository {self.repo_client.repo_full_name}")
+
+        start_time = time.time()
+        commit_sha = self.repo_client.base_commit_sha
+
+        # Fetch only the specific commit
+        self.git_repo.git.execute(["git", "fetch", "--depth=1", "origin", commit_sha])
+        self.git_repo.git.checkout(commit_sha)
+
+        end_time = time.time()
+        logger.info(
+            f"Checked out repo {self.repo_client.repo_full_name} to commit {commit_sha} in {end_time - start_time} seconds"
+        )
+
+    def _prune_repo(self):
+        """
+        Prune the repository to only include the target commit.
+        """
+        commit_sha = self.repo_client.base_commit_sha
+
+        # Remove all remote branches except the one we need
+        logger.info("Pruning unnecessary references")
+        for ref in self.git_repo.git.execute(["git", "show-ref"]).split("\n"):
+            if ref and commit_sha not in ref:
+                ref_name = ref.split()[1]
+                try:
+                    self.git_repo.git.execute(["git", "update-ref", "-d", ref_name])
+                except git.GitCommandError:
+                    logger.debug(f"Could not delete reference {ref_name}")
+
+        # Clean up completely - expire reflog, remove unreachable objects
+        logger.info("Cleaning Git repository to minimal state")
+        self.git_repo.git.execute(["git", "reflog", "expire", "--expire=now", "--all"])
+        self.git_repo.git.execute(["git", "gc", "--prune=now", "--aggressive"])
+
+    def upload_to_gcs(self):
+        """
+        Upload the repository from the cloned tmp directory to GCS.
+        """
+        self._prune_repo()
+
+        # Create a temporary tar.gz file of the repository
+        temp_tarfile = os.path.join(self.tmp_dir, "repo_archive.tar.gz")
+        try:
+            logger.info(f"Creating tar archive of repository at {self.repo_path}")
+            with tarfile.open(temp_tarfile, "w:gz") as tar:
+                tar.add(self.repo_path, arcname=os.path.basename(self.repo_path))
+
+            # Upload the tar file to GCS
+            logger.info(f"Uploading repository archive to GCS: {self.bucket_name}/{self.blob_name}")
+            storage_client = storage.Client()
+            bucket = storage_client.bucket(self.bucket_name)
+            blob = bucket.blob(self.blob_name)
+            blob.upload_from_filename(temp_tarfile)
+
+            logger.info(
+                f"Successfully uploaded repository to GCS: {self.bucket_name}/{self.blob_name}"
+            )
+        except Exception as e:
+            logger.error(f"Failed to upload repository to GCS: {e}")
+            raise
+        finally:
+            # Clean up the temporary tar file
+            if os.path.exists(temp_tarfile):
+                os.unlink(temp_tarfile)
+
+    def gcs_archive_exists(self):
+        """
+        Check if an archive exists in GCS for this repository.
+
+        Returns:
+            bool: True if the archive exists, False otherwise
+        """
+        try:
+            # Check if the archive exists in GCS
+            logger.info(
+                f"Checking if repository archive exists in GCS: {self.bucket_name}/{self.blob_name}"
+            )
+            storage_client = storage.Client()
+            bucket = storage_client.bucket(self.bucket_name)
+            blob = bucket.blob(self.blob_name)
+
+            exists = blob.exists()
+
+            if exists:
+                logger.info(f"Repository archive found in GCS: {self.bucket_name}/{self.blob_name}")
+            else:
+                logger.info(
+                    f"Repository archive not found in GCS: {self.bucket_name}/{self.blob_name}"
+                )
+
+            return exists
+        except Exception as e:
+            logger.error(f"Error checking if repository archive exists in GCS: {e}")
+            return False
+
+    def download_from_gcs(self):
+        """
+        Download the repository from GCS to the cloned tmp directory.
+
+        Args:
+            max_workers: Maximum number of concurrent extraction threads (default: 4)
+                         [No longer used as extraction is now sequential]
+        """
+
+        # Create a temporary file within self.tmp_dir to download the tar.gz
+        temp_tarfile = os.path.join(self.tmp_dir, "repo_archive.tar.gz")
+
+        try:
+            # Download the tar file from GCS
+            logger.info(
+                f"Downloading repository archive from GCS: {self.bucket_name}/{self.blob_name}"
+            )
+            storage_client = storage.Client()
+            bucket = storage_client.bucket(self.bucket_name)
+            blob = bucket.blob(self.blob_name)
+
+            if not blob.exists():
+                logger.error(
+                    f"Repository archive not found in GCS: {self.bucket_name}/{self.blob_name}"
+                )
+                raise FileNotFoundError(
+                    f"Repository archive not found in GCS: {self.bucket_name}/{self.blob_name}"
+                )
+
+            # Download the blob to the temporary file with larger chunk size for faster download
+            start_time = time.time()
+            blob.download_to_filename(temp_tarfile)
+            end_time = time.time()
+            logger.info(f"Downloaded repository archive in {end_time - start_time} seconds")
+
+            # Clean up existing repo path before extracting
+            cleanup_dir(self.repo_path)
+            os.makedirs(self.repo_path, exist_ok=True)
+
+            # Extract the tar file to the repo path using simple sequential extraction
+            logger.info(f"Extracting repository archive to {self.repo_path}")
+            with tarfile.open(temp_tarfile, "r:gz") as tar:
+                tar.extractall(path=os.path.dirname(self.repo_path))
+
+            self.git_repo = git.Repo(self.repo_path)
+
+            logger.info(f"Successfully downloaded repository from GCS to {self.repo_path}")
+        except Exception as e:
+            logger.error(f"Failed to download repository from GCS: {e}")
+            raise
+        finally:
+            # Clean up the temporary files
+            if os.path.exists(temp_tarfile):
+                os.unlink(temp_tarfile)
+
+    def cleanup(self):
+        """
+        Clean up the temporary directory if it exists.
+        """
+        if self.repo_path and os.path.exists(self.repo_path):
+            cleanup_dir(self.repo_path)
+            self.repo_path = None
+            self.git_repo = None
+
+        logger.info(f"Cleaned up local repo client for {self.repo_client.repo_full_name}")
+
+    def __del__(self):
+        """
+        Ensure cleanup happens when the object is garbage collected.
+        """
+        self.cleanup()

--- a/src/seer/automation/codebase/repo_manager.py
+++ b/src/seer/automation/codebase/repo_manager.py
@@ -1,14 +1,11 @@
-import asyncio
 import logging
 import os
-import tarfile
 import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Callable
 
 import git
-from google.cloud import storage
 
 from seer.automation.codebase.repo_client import RepoClient
 from seer.automation.codebase.utils import cleanup_dir
@@ -18,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 class RepoManager:
     """
-    A client for interacting with local git repositories using GitPython.
+    A client for downloading and syncing git repositories using GitPython.
     """
 
     def __init__(
@@ -40,38 +37,15 @@ class RepoManager:
     def is_available(self):
         return self.git_repo is not None and self.initialization_future is None
 
-    @property
-    def blob_name(self):
-        """
-        Get the blob name for the repository.
-        """
-        return f"repos/{self.repo_client.repo_owner}/{self.repo_client.repo_name}.tar.gz"
-
-    @property
-    def bucket_name(self):
-        """
-        Get the bucket name for the repository.
-        """
-        return os.environ.get("AUTOFIX_REPOS_GCS_BUCKET", "autofix-repositories-local")
-
-    def initialize_in_background(self, gcs_enabled: bool = False):
+    def initialize_in_background(self):
         logger.info(f"Creating initialize task for repo {self.repo_client.repo_full_name}")
-        self.initialization_future = ThreadPoolExecutor(1).submit(
-            self.initialize, gcs_enabled=gcs_enabled
-        )
+        self.initialization_future = ThreadPoolExecutor(1).submit(self.initialize)
 
-    def initialize(self, gcs_enabled: bool = False):
+    def initialize(self):
         logger.info(f"Initializing repo {self.repo_client.repo_full_name}")
 
         try:
-            if gcs_enabled and self.gcs_archive_exists():
-                self.download_from_gcs()
-            else:
-                self._clone_repo()
-
-                if gcs_enabled:
-                    # Only upload to GCS if this is a fresh new clone of the repo.
-                    self.upload_to_gcs()
+            self._clone_repo()
 
             logger.info(f"Repo {self.repo_client.repo_full_name} ready at {self.repo_path}")
 
@@ -137,166 +111,6 @@ class RepoManager:
         except Exception as e:
             logger.error(f"Failed to sync repository {self.repo_client.repo_full_name}: {e}")
             self.git_repo = None  # clear the repo to fail the available check
-            raise
-
-    def _prune_repo(self):
-        """
-        Prune the repository to only include the target commit.
-        """
-        commit_sha = self.repo_client.base_commit_sha
-
-        # Remove all remote branches except the one we need
-        logger.info("Pruning unnecessary references")
-        for ref in self.git_repo.git.execute(["git", "show-ref"]).split("\n"):
-            if ref and commit_sha not in ref:
-                ref_name = ref.split()[1]
-                try:
-                    self.git_repo.git.execute(["git", "update-ref", "-d", ref_name])
-                except git.GitCommandError:
-                    logger.debug(f"Could not delete reference {ref_name}")
-
-        # Clean up completely - expire reflog, remove unreachable objects
-        logger.info("Cleaning Git repository to minimal state")
-        self.git_repo.git.execute(["git", "reflog", "expire", "--expire=now", "--all"])
-        self.git_repo.git.execute(["git", "gc", "--prune=now", "--aggressive"])
-
-    def upload_to_gcs(self):
-        """
-        Upload the repository from the cloned tmp directory to GCS.
-        This method is a synchronous wrapper around the async _upload_to_gcs_async method.
-        """
-        self._prune_repo()
-
-        # Run the async upload in the asyncio event loop
-        asyncio.run(self._upload_to_gcs_async())
-
-    async def _upload_to_gcs_async(self):
-        """
-        Asynchronous implementation of the repository upload to GCS.
-        """
-        # Create a temporary tar.gz file of the repository
-        temp_tarfile = os.path.join(self.tmp_dir, "repo_archive.tar.gz")
-        try:
-            logger.info(f"Creating tar archive of repository at {self.repo_path}")
-            # Create tarfile synchronously since it's IO-bound and doesn't benefit much from async
-            with tarfile.open(temp_tarfile, "w:gz") as tar:
-                tar.add(self.repo_path, arcname=os.path.basename(self.repo_path))
-
-            # Upload the tar file to GCS asynchronously
-            logger.info(f"Uploading repository archive to GCS: {self.bucket_name}/{self.blob_name}")
-
-            # Run the GCS upload in a thread pool to avoid blocking
-            loop = asyncio.get_running_loop()
-            await loop.run_in_executor(None, self._do_gcs_upload, temp_tarfile)
-
-            logger.info(
-                f"Successfully uploaded repository to GCS: {self.bucket_name}/{self.blob_name}"
-            )
-        except Exception as e:
-            logger.error(f"Failed to upload repository to GCS: {e}")
-            raise
-        finally:
-            # Clean up the temporary tar file
-            if os.path.exists(temp_tarfile):
-                os.unlink(temp_tarfile)
-
-    def _do_gcs_upload(self, temp_tarfile):
-        """
-        Perform the actual GCS upload operation.
-        This method is designed to be run in a separate thread.
-
-        Args:
-            temp_tarfile: Path to the temporary tarfile to upload
-        """
-        storage_client = storage.Client()
-        bucket = storage_client.bucket(self.bucket_name)
-        blob = bucket.blob(self.blob_name)
-        blob.upload_from_filename(temp_tarfile)
-
-    def gcs_archive_exists(self):
-        """
-        Check if an archive exists in GCS for this repository.
-
-        Returns:
-            bool: True if the archive exists, False otherwise
-        """
-        try:
-            # Check if the archive exists in GCS
-            logger.info(
-                f"Checking if repository archive exists in GCS: {self.bucket_name}/{self.blob_name}"
-            )
-            storage_client = storage.Client()
-            bucket = storage_client.bucket(self.bucket_name)
-            blob = bucket.blob(self.blob_name)
-
-            exists = blob.exists()
-
-            if exists:
-                logger.info(f"Repository archive found in GCS: {self.bucket_name}/{self.blob_name}")
-            else:
-                logger.info(
-                    f"Repository archive not found in GCS: {self.bucket_name}/{self.blob_name}"
-                )
-
-            return exists
-        except Exception as e:
-            logger.error(f"Error checking if repository archive exists in GCS: {e}")
-            return False
-
-    def download_from_gcs(self):
-        """
-        Download the repository from GCS to the cloned tmp directory.
-
-        Args:
-            max_workers: Maximum number of concurrent extraction threads (default: 4)
-                         [No longer used as extraction is now sequential]
-        """
-
-        # Create a temporary file within self.tmp_dir to download the tar.gz
-        temp_tarfile = os.path.join(self.tmp_dir, "repo_archive.tar.gz")
-
-        try:
-            # Download the tar file from GCS
-            logger.info(
-                f"Downloading repository archive from GCS: {self.bucket_name}/{self.blob_name}"
-            )
-            storage_client = storage.Client()
-            bucket = storage_client.bucket(self.bucket_name)
-            blob = bucket.blob(self.blob_name)
-
-            if not blob.exists():
-                logger.error(
-                    f"Repository archive not found in GCS: {self.bucket_name}/{self.blob_name}"
-                )
-                raise FileNotFoundError(
-                    f"Repository archive not found in GCS: {self.bucket_name}/{self.blob_name}"
-                )
-
-            # Download the blob to the temporary file with larger chunk size for faster download
-            start_time = time.time()
-            blob.download_to_filename(temp_tarfile)
-            end_time = time.time()
-            logger.info(f"Downloaded repository archive in {end_time - start_time} seconds")
-
-            # Clean up existing repo path before extracting
-            cleanup_dir(self.repo_path)
-            os.makedirs(self.repo_path, exist_ok=True)
-
-            # Extract the tar file to the repo path using simple sequential extraction
-            logger.info(f"Extracting repository archive to {self.repo_path}")
-            with tarfile.open(temp_tarfile, "r:gz") as tar:
-                tar.extractall(path=os.path.dirname(self.repo_path))
-
-            self.git_repo = git.Repo(self.repo_path)
-
-            logger.info(f"Successfully downloaded repository from GCS to {self.repo_path}")
-        except Exception as e:
-            logger.error(f"Failed to download repository from GCS: {e}")
-            raise
-        finally:
-            # Clean up the temporary files
-            if os.path.exists(temp_tarfile):
-                os.unlink(temp_tarfile)
 
     def cleanup(self):
         """

--- a/src/seer/automation/codebase/repo_manager.py
+++ b/src/seer/automation/codebase/repo_manager.py
@@ -59,18 +59,13 @@ class RepoManager:
     def _clone_repo(self) -> str:
         """
         Clone a repository to a local temporary directory.
-
-        Args:
-            repo_clone_url: The URL of the repository to clone
-
-        Returns:
-            The path to the cloned repository
         """
-
         repo_clone_url = self.repo_client.get_clone_url_with_auth()
 
         try:
-            logger.info(f"Cloning repository {repo_clone_url} to {self.repo_path} with depth=1")
+            logger.info(
+                f"Cloning repository {self.repo_client.repo_full_name} to {self.repo_path} with depth=1"
+            )
 
             cleanup_dir(self.repo_path)
 

--- a/src/seer/automation/codebase/repo_manager.py
+++ b/src/seer/automation/codebase/repo_manager.py
@@ -1,9 +1,9 @@
+import asyncio
 import logging
 import os
 import tarfile
 import tempfile
 import time
-import asyncio
 from concurrent.futures import ThreadPoolExecutor
 
 import git

--- a/src/seer/automation/codebase/repo_manager.py
+++ b/src/seer/automation/codebase/repo_manager.py
@@ -1,7 +1,7 @@
 import logging
 import os
-import tempfile
 import tarfile
+import tempfile
 import time
 
 import git

--- a/src/seer/automation/codebase/repo_manager.py
+++ b/src/seer/automation/codebase/repo_manager.py
@@ -142,9 +142,3 @@ class RepoManager:
         self._has_timed_out = False
 
         logger.info(f"Cleaned up repo for {self.repo_client.repo_full_name}")
-
-    def __del__(self):
-        """
-        Ensure cleanup happens when the object is garbage collected.
-        """
-        self.cleanup()

--- a/src/seer/db.py
+++ b/src/seer/db.py
@@ -288,6 +288,22 @@ class DbSeerProjectPreference(Base):
     __table_args__ = (UniqueConstraint("organization_id", "project_id"),)
 
 
+class DbRepoArchive(Base):
+    __tablename__ = "repo_archives"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    repo_id: Mapped[str] = mapped_column(String, nullable=False)
+    provider: Mapped[str] = mapped_column(String, nullable=False)
+    project_id: Mapped[int] = mapped_column(BigInteger, nullable=False, primary_key=True)
+    organization_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    sha: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.datetime.utcnow
+    )
+    updated_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.datetime.utcnow
+    )
+
+
 def create_grouping_partition(target: Any, connection: Connection, **kw: Any) -> None:
     for i in range(100):
         connection.execute(

--- a/src/seer/db.py
+++ b/src/seer/db.py
@@ -288,22 +288,6 @@ class DbSeerProjectPreference(Base):
     __table_args__ = (UniqueConstraint("organization_id", "project_id"),)
 
 
-class DbRepoArchive(Base):
-    __tablename__ = "repo_archives"
-    id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    repo_id: Mapped[str] = mapped_column(String, nullable=False)
-    provider: Mapped[str] = mapped_column(String, nullable=False)
-    project_id: Mapped[int] = mapped_column(BigInteger, nullable=False, primary_key=True)
-    organization_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
-    sha: Mapped[str] = mapped_column(String, nullable=False)
-    created_at: Mapped[datetime.datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.datetime.utcnow
-    )
-    updated_at: Mapped[datetime.datetime] = mapped_column(
-        DateTime, nullable=False, default=datetime.datetime.utcnow
-    )
-
-
 def create_grouping_partition(target: Any, connection: Connection, **kw: Any) -> None:
     for i in range(100):
         connection.execute(

--- a/tests/automation/autofix/test_autofix_tools.py
+++ b/tests/automation/autofix/test_autofix_tools.py
@@ -1,11 +1,11 @@
+from concurrent.futures import Future
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
-from concurrent.futures import Future
 
 from seer.automation.autofix.autofix_context import AutofixContext
 from seer.automation.autofix.models import AutofixRequest
-from seer.automation.autofix.tools.tools import BaseTools, FIRST_EXCEPTION, RepoClientType
+from seer.automation.autofix.tools.tools import FIRST_EXCEPTION, BaseTools, RepoClientType
 from seer.automation.models import FileChange, FilePatch, Hunk, Line, RepoDefinition
 
 

--- a/tests/automation/codebase/test_repo_manager.py
+++ b/tests/automation/codebase/test_repo_manager.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from concurrent.futures import Future
 from unittest.mock import ANY, MagicMock, patch
 
@@ -8,7 +7,6 @@ import pytest
 
 from seer.automation.codebase.repo_client import RepoClient
 from seer.automation.codebase.repo_manager import RepoManager
-from seer.automation.codebase.utils import cleanup_dir
 
 
 @pytest.fixture
@@ -41,7 +39,7 @@ def test_clone_success(repo_manager, mock_repo_client, caplog):
 
     with (
         patch("git.Repo.clone_from", return_value=mock_git_repo) as mock_clone,
-        patch("seer.automation.codebase.repo_manager.cleanup_dir") as mock_cleanup,
+        patch("seer.automation.codebase.repo_manager.cleanup_dir"),
     ):
 
         repo_manager._clone_repo()

--- a/tests/automation/codebase/test_repo_manager.py
+++ b/tests/automation/codebase/test_repo_manager.py
@@ -1,0 +1,235 @@
+import logging
+import os
+from concurrent.futures import Future
+from unittest.mock import ANY, MagicMock, patch
+
+import git
+import pytest
+
+from seer.automation.codebase.repo_client import RepoClient
+from seer.automation.codebase.repo_manager import RepoManager
+from seer.automation.codebase.utils import cleanup_dir
+
+
+@pytest.fixture
+def mock_repo_client():
+    client = MagicMock(spec=RepoClient)
+    client.repo_owner = "test-owner"
+    client.repo_name = "test-repo"
+    client.base_commit_sha = "abcd123"
+    client.repo_full_name = "test-owner/test-repo"
+    return client
+
+
+@pytest.fixture
+def repo_manager(mock_repo_client, tmp_path):
+    """Create a RepoManager instance with a mock repo client."""
+    with patch("tempfile.mkdtemp", return_value=str(tmp_path)):
+        manager = RepoManager(repo_client=mock_repo_client)
+        yield manager
+
+
+def test_clone_success(repo_manager, mock_repo_client, caplog):
+    """Test successful repository cloning."""
+    caplog.set_level(logging.INFO)
+
+    # Setup mock repo client to return a local file URL
+    mock_repo_client.get_clone_url_with_auth.return_value = "file:///fake/repo.git"
+
+    # Create a mock git.Repo object
+    mock_git_repo = MagicMock(spec=git.Repo)
+
+    with (
+        patch("git.Repo.clone_from", return_value=mock_git_repo) as mock_clone,
+        patch("seer.automation.codebase.repo_manager.cleanup_dir") as mock_cleanup,
+    ):
+
+        repo_manager._clone_repo()
+
+        # Verify clone was called with correct arguments, using ANY for the progress callback
+        mock_clone.assert_called_once_with(
+            "file:///fake/repo.git",
+            repo_manager.repo_path,
+            progress=ANY,  # Use ANY to match any function
+            depth=1,
+        )
+
+        # Verify the repo was set
+        assert repo_manager.git_repo == mock_git_repo
+
+        # Check logging
+        assert "Cloning repository test-owner/test-repo" in caplog.text
+        assert "Cloned repository" in caplog.text
+
+
+def test_clone_failure_clears_repo(repo_manager, mock_repo_client, caplog):
+    """Test that clone failure clears the repo reference."""
+    caplog.set_level(logging.ERROR)
+
+    mock_repo_client.get_clone_url_with_auth.return_value = "file:///fake/repo.git"
+
+    # Make clone_from raise GitCommandError
+    error = git.GitCommandError("git clone", 128)
+    with (
+        patch("git.Repo.clone_from", side_effect=error),
+        patch("seer.automation.codebase.repo_manager.cleanup_dir"),
+    ):
+        with pytest.raises(git.GitCommandError):
+            repo_manager._clone_repo()
+
+        # Verify repo was cleared
+        assert repo_manager.git_repo is None
+
+        # Verify error was logged
+        assert "Failed to clone repository" in caplog.text
+
+
+def test_sync_success(repo_manager, mock_repo_client, caplog):
+    """Test successful repository sync."""
+    caplog.set_level(logging.INFO)
+
+    # Setup mock git repo
+    mock_git_repo = MagicMock(spec=git.Repo)
+    repo_manager.git_repo = mock_git_repo
+
+    repo_manager._sync_repo()
+
+    # Verify git commands were called
+    mock_git_repo.git.execute.assert_called_once_with(
+        ["git", "fetch", "--depth=1", "origin", mock_repo_client.base_commit_sha]
+    )
+    mock_git_repo.git.checkout.assert_called_once_with(mock_repo_client.base_commit_sha)
+
+    # Check logging
+    assert f"Syncing repository {mock_repo_client.repo_full_name}" in caplog.text
+    assert "Checked out repo" in caplog.text
+
+
+def test_sync_failure_clears_repo(repo_manager, mock_repo_client, caplog):
+    """Test that sync failure clears the repo reference."""
+    caplog.set_level(logging.ERROR)
+
+    # Setup mock git repo that raises on execute
+    mock_git_repo = MagicMock(spec=git.Repo)
+    mock_git_repo.git.execute.side_effect = Exception("Sync failed")
+    repo_manager.git_repo = mock_git_repo
+
+    repo_manager._sync_repo()
+
+    # Verify repo was cleared
+    assert repo_manager.git_repo is None
+
+    # Verify error was logged
+    assert f"Failed to sync repository {mock_repo_client.repo_full_name}" in caplog.text
+
+
+def test_mark_as_timed_out_before_init(repo_manager):
+    """Test marking as timed out before initialization."""
+    repo_path = repo_manager.repo_path
+
+    with (
+        patch("seer.automation.codebase.repo_manager.cleanup_dir") as mock_cleanup,
+        patch("os.path.exists", return_value=True),
+    ):
+        repo_manager.mark_as_timed_out()
+
+        # Verify cleanup was called
+        mock_cleanup.assert_called_once_with(repo_path)
+        assert repo_manager.git_repo is None
+        assert not repo_manager._has_timed_out
+
+
+def test_mark_as_timed_out_during_init(repo_manager):
+    """Test marking as timed out during initialization."""
+    repo_manager.initialization_future = Future()
+
+    with patch("seer.automation.codebase.repo_manager.cleanup_dir"):
+        repo_manager.mark_as_timed_out()
+
+        # Verify cleanup was deferred
+        assert repo_manager._has_timed_out
+        assert repo_manager.repo_path is not None
+
+
+def test_cleanup_idempotent(repo_manager):
+    """Test that cleanup can be called multiple times safely."""
+    repo_path = repo_manager.repo_path
+
+    with (
+        patch("seer.automation.codebase.repo_manager.cleanup_dir") as mock_cleanup,
+        patch("os.path.exists", return_value=True),
+    ):
+        # First cleanup
+        repo_manager.cleanup()
+        mock_cleanup.assert_called_once_with(repo_path)
+
+        # Reset the mock for second call
+        mock_cleanup.reset_mock()
+
+        # Second cleanup should not call cleanup_dir again since path is None
+        repo_manager.cleanup()
+        mock_cleanup.assert_not_called()
+
+
+def test_is_available_states(repo_manager):
+    """Test different states of the is_available property."""
+    # Initially should be False (no git_repo)
+    assert not repo_manager.is_available
+
+    # Set git_repo but with pending initialization
+    repo_manager.git_repo = MagicMock()
+    repo_manager.initialization_future = Future()
+    assert not repo_manager.is_available
+
+    # Clear initialization future
+    repo_manager.initialization_future = None
+    assert repo_manager.is_available
+
+    # Clear git_repo
+    repo_manager.git_repo = None
+    assert not repo_manager.is_available
+
+
+def test_initialize_in_background(repo_manager, caplog):
+    """Test background initialization."""
+    caplog.set_level(logging.INFO)
+
+    # First call should work
+    repo_manager.initialize_in_background()
+    assert repo_manager.initialization_future is not None
+    assert (
+        f"Creating initialize task for repo {repo_manager.repo_client.repo_full_name}"
+        in caplog.text
+    )
+
+    # Second call should raise
+    with pytest.raises(RuntimeError, match="is already being initialized"):
+        repo_manager.initialize_in_background()
+
+
+def test_initialize_success(repo_manager, mock_repo_client):
+    """Test successful initialization sequence."""
+    with (
+        patch.object(repo_manager, "_clone_repo") as mock_clone,
+        patch.object(repo_manager, "_sync_repo") as mock_sync,
+    ):
+        repo_manager.initialize()
+
+        # Verify sequence
+        mock_clone.assert_called_once()
+        mock_sync.assert_called_once()
+        assert repo_manager.initialization_future is None
+
+
+def test_initialize_cleans_up_on_timeout(repo_manager):
+    """Test that initialization cleans up when timed out."""
+    repo_manager._has_timed_out = True
+
+    with (
+        patch.object(repo_manager, "_clone_repo") as mock_clone,
+        patch.object(repo_manager, "cleanup") as mock_cleanup,
+    ):
+        repo_manager.initialize()
+
+        mock_clone.assert_called_once()
+        mock_cleanup.assert_called_once()


### PR DESCRIPTION
This PR changes how we download repos from downloading repo archives to cloning the repo with `depth=1` and then checking out a specific commit sha.

- This sets us up to be able to cache and load repos from GCS using this `RepoManager`
- As the repo is downloading, we also update the Autofix state to ensure that the state does not get timed out

## Implementation
Introduce the `RepoManager`, conceptually it's supposed to be the class that manages a repo's download, caching etc. It should encapsulate the entire lifecycle of a downloaded repo. It's also entirely source control provider agnostic, and instead relies on getting passed a `RepoClient` that it interacts with.

## How it works
1. The tools are initialized, the `RepoManager`s are created and then called to initialize each on its own thread in the background.
2. The repo is cloned with `depth=1`
3. The repo is fetched at a specific commit sha from the `RepoClient` and checked out at that specific sha.
4. Once a tool is called that needs to use the downloaded repo, via `BaseTools._ensure_repos_downloaded`, we wait for the futures with a `120s` timeout.
5. If a repo download times out, we tell the LLM that the repo is not usable and to not use that tool with the repo.

## Next Steps
1. Setup GCS buckets in the required regions
2. Implement the GCS upload/download in the `RepoManager`