### PR TITLE
fix(autofix): Smarter repo name autocorrect

### DIFF
--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -160,8 +160,10 @@ class AutofixContext(PipelineContext):
             if matching_names_without_owner:
                 repo_name_without_owner = matching_names_without_owner[0]
                 repo_name = next(
-                    (r for r in matching_full_names if f"/{repo_name_without_owner}" in r), None
+                    (r for r in matching_full_names if f"/{repo_name_without_owner}" in r), ""
                 )
+                if not repo_name:
+                    return None
             elif matching_full_names:
                 repo_name = min(
                     matching_full_names, key=lambda x: abs(len(x) - len(repo_name or ""))

--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -153,7 +153,7 @@ class AutofixContext(PipelineContext):
             matching_full_names = [r for r in repo_names if repo_name.lower() in r.lower()]
             names_without_owner = [
                 r.split("/")[-1] for r in matching_full_names if len(r.split("/")) > 1
-            ]  # the repo name, e.g. seer in getsentry/seer
+            ]  # the repo names without the orgs, e.g. "seer", not "getsentry/seer"
             matching_names_without_owner = [
                 r for r in names_without_owner if repo_name.lower() == r.lower()
             ]

--- a/tests/automation/autofix/test_autofix_context.py
+++ b/tests/automation/autofix/test_autofix_context.py
@@ -276,6 +276,13 @@ class TestAutofixContext(unittest.TestCase):
                 full_name="getsentry/snuba",
             ),
             RepoDefinition(
+                provider="github",
+                owner="getsentry",
+                name="getsentry",
+                external_id="3",
+                full_name="getsentry/getsentry",
+            ),
+            RepoDefinition(
                 provider="other_provider",
                 owner="test",
                 name="other",
@@ -300,7 +307,7 @@ class TestAutofixContext(unittest.TestCase):
         assert self.autofix_context.autocorrect_repo_name("GETSENTRY/SEER") == "getsentry/seer"
         assert self.autofix_context.autocorrect_repo_name("snuba") == "getsentry/snuba"
         assert self.autofix_context.autocorrect_repo_name("/snuba") == "getsentry/snuba"
-        assert self.autofix_context.autocorrect_repo_name("getsentry") == "getsentry/seer"
+        assert self.autofix_context.autocorrect_repo_name("getsentry") == "getsentry/getsentry"
         assert self.autofix_context.autocorrect_repo_name("bar") == "foo/bar"
         assert self.autofix_context.autocorrect_repo_name("nonexistent") is None
         assert self.autofix_context.autocorrect_repo_name("") is None


### PR DESCRIPTION
Prioritizes repo name over owner name in the autocorrect logic.