### PR TITLE
Fix GH retry backoff limit

### DIFF
--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -184,9 +184,8 @@ class RepoClient:
                 f"Unsupported repo provider: {repo_definition.provider}, only {', '.join(self.supported_providers)} are supported."
             )
 
-        retry = GithubRetry(total=5)
-        # Default total=10 exceeds autofix's soft time limit anyway
-        retry.DEFAULT_BACKOFF_MAX = 30
+        GithubRetry.DEFAULT_BACKOFF_MAX = 15  # On retries, new instances are created
+        retry = GithubRetry(total=5)  # Default total=10 exceeds autofix's soft time limit
 
         if app_id and private_key:
             self.github = Github(


### PR DESCRIPTION
When a `urllib3.Retry` object (which `GithubRetry` inherits from) hits a retryable exception, it creates a new instance. To configure the backoff limit across instances, need to set the class attribute, not the instance attribute.