### PR TITLE
fix(autofix): Use more file path autocorrect 

### DIFF
--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -220,6 +220,27 @@ class AutofixContext(PipelineContext):
         repo_client = self.get_repo_client(repo_name)
         return repo_client.get_commit_patch_for_file(path, commit_sha, autocorrect=True)
 
+    def attempt_fix_path(self, path: str, repo_name: str) -> str | None:
+        """
+        Attempts to fix a path by checking if it exists in the repository as a path or directory.
+        """
+        repo_client = self.get_repo_client(repo_name=repo_name)
+        all_files = repo_client.get_valid_file_paths()
+
+        normalized_path = path.lstrip("./").lstrip("/")
+        if not normalized_path:
+            return None
+
+        for p in all_files:
+            if p.endswith(normalized_path):
+                # is a valid file path
+                return p
+            if p.startswith(normalized_path):
+                # is a valid directory path
+                return normalized_path
+
+        return None
+
     def _process_stacktrace_paths(self, stacktrace: Stacktrace):
         """
         Annotate a stacktrace with the correct repo each frame is pointing to and fix the filenames

--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -220,7 +220,7 @@ class AutofixContext(PipelineContext):
         repo_client = self.get_repo_client(repo_name)
         return repo_client.get_commit_patch_for_file(path, commit_sha, autocorrect=True)
 
-    def attempt_fix_path(self, path: str, repo_name: str) -> str | None:
+    def autocorrect_file_path(self, path: str, repo_name: str) -> str | None:
         """
         Attempts to fix a path by checking if it exists in the repository as a path or directory.
         """

--- a/src/seer/automation/autofix/components/coding/component.py
+++ b/src/seer/automation/autofix/components/coding/component.py
@@ -70,7 +70,7 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
                 corrected_repo_name = self.context.autocorrect_repo_name(file["repo_name"])
                 if corrected_repo_name is None:
                     continue
-                corrected_file_path = self.context.attempt_fix_path(
+                corrected_file_path = self.context.autocorrect_file_path(
                     path=file["file_path"], repo_name=corrected_repo_name
                 )
                 if not corrected_file_path:

--- a/src/seer/automation/autofix/components/coding/component.py
+++ b/src/seer/automation/autofix/components/coding/component.py
@@ -70,9 +70,13 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
                 corrected_repo_name = self.context.autocorrect_repo_name(file["repo_name"])
                 if corrected_repo_name is None:
                     continue
-
-                file_content = self.context.get_file_contents(
+                corrected_file_path = self.context.attempt_fix_path(
                     path=file["file_path"], repo_name=corrected_repo_name
+                )
+                if not corrected_file_path:
+                    continue
+                file_content = self.context.get_file_contents(
+                    path=corrected_file_path, repo_name=corrected_repo_name
                 )
             except Exception as e:
                 logger.exception(f"Error getting file contents in memory prefill: {e}")
@@ -81,13 +85,13 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
             if file_content:
                 agent_message = Message(
                     role="tool_use",
-                    content=f"Expand document: {file['file_path']} in {file['repo_name']}",
+                    content=f"Expand document: {corrected_file_path} in {corrected_repo_name}",
                     tool_calls=[
                         ToolCall(
                             id=str(i),
                             function="expand_document",
                             args=json.dumps(
-                                {"file_path": file["file_path"], "repo_name": file["repo_name"]}
+                                {"file_path": corrected_file_path, "repo_name": corrected_repo_name}
                             ),
                         )
                     ],

--- a/src/seer/automation/autofix/components/insight_sharing/component.py
+++ b/src/seer/automation/autofix/components/insight_sharing/component.py
@@ -160,7 +160,7 @@ def process_sources(sources: list, context: AutofixContext, trace_tree: TraceTre
                 continue
             repo_client = context.get_repo_client(repo_name)
             file_name = source.file_name
-            file_name = context.attempt_fix_path(path=file_name, repo_name=repo_name)
+            file_name = context.autocorrect_file_path(path=file_name, repo_name=repo_name)
             if not file_name:
                 continue
             snippet_to_find = source.code_snippet

--- a/src/seer/automation/autofix/components/insight_sharing/component.py
+++ b/src/seer/automation/autofix/components/insight_sharing/component.py
@@ -160,6 +160,9 @@ def process_sources(sources: list, context: AutofixContext, trace_tree: TraceTre
                 continue
             repo_client = context.get_repo_client(repo_name)
             file_name = source.file_name
+            file_name = context.attempt_fix_path(path=file_name, repo_name=repo_name)
+            if not file_name:
+                continue
             snippet_to_find = source.code_snippet
 
             file_content = context.get_file_contents(file_name, repo_name)

--- a/src/seer/automation/autofix/components/insight_sharing/component.py
+++ b/src/seer/automation/autofix/components/insight_sharing/component.py
@@ -160,9 +160,10 @@ def process_sources(sources: list, context: AutofixContext, trace_tree: TraceTre
                 continue
             repo_client = context.get_repo_client(repo_name)
             file_name = source.file_name
-            file_name = context.autocorrect_file_path(path=file_name, repo_name=repo_name)
-            if not file_name:
+            corrected_file_name = context.autocorrect_file_path(path=file_name, repo_name=repo_name)
+            if not corrected_file_name:
                 continue
+            file_name = corrected_file_name
             snippet_to_find = source.code_snippet
 
             file_content = context.get_file_contents(file_name, repo_name)

--- a/src/seer/automation/autofix/components/solution/component.py
+++ b/src/seer/automation/autofix/components/solution/component.py
@@ -55,8 +55,14 @@ class SolutionComponent(BaseComponent[SolutionRequest, SolutionOutput]):
                 if corrected_repo_name is None:
                     continue
 
-                file_content = self.context.get_file_contents(
+                corrected_file_path = self.context.attempt_fix_path(
                     path=file["file_path"], repo_name=corrected_repo_name
+                )
+                if not corrected_file_path:
+                    continue
+
+                file_content = self.context.get_file_contents(
+                    path=corrected_file_path, repo_name=corrected_repo_name
                 )
             except Exception as e:
                 logger.exception(f"Error getting file contents in memory prefill: {e}")
@@ -65,13 +71,13 @@ class SolutionComponent(BaseComponent[SolutionRequest, SolutionOutput]):
             if file_content:
                 agent_message = Message(
                     role="tool_use",
-                    content=f"Expand document: {file['file_path']} in {file['repo_name']}",
+                    content=f"Expand document: {corrected_file_path} in {corrected_repo_name}",
                     tool_calls=[
                         ToolCall(
                             id=str(i),
                             function="expand_document",
                             args=json.dumps(
-                                {"file_path": file["file_path"], "repo_name": file["repo_name"]}
+                                {"file_path": corrected_file_path, "repo_name": corrected_repo_name}
                             ),
                         )
                     ],

--- a/src/seer/automation/autofix/components/solution/component.py
+++ b/src/seer/automation/autofix/components/solution/component.py
@@ -55,7 +55,7 @@ class SolutionComponent(BaseComponent[SolutionRequest, SolutionOutput]):
                 if corrected_repo_name is None:
                     continue
 
-                corrected_file_path = self.context.attempt_fix_path(
+                corrected_file_path = self.context.autocorrect_file_path(
                     path=file["file_path"], repo_name=corrected_repo_name
                 )
                 if not corrected_file_path:

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -203,6 +203,7 @@ class BaseTools:
         if valid_file_path is None:
             other_paths = self._get_potential_abs_paths(file_path, repo_name)
             return f"Error: The file path `{file_path}` doesn't exist in `{repo_name}`.\n{other_paths}".strip()
+        file_path = valid_file_path
 
         # At this point we have ensured the file path and the repo name are valid.
         file_contents = self.context.get_file_contents(file_path, repo_name=repo_name)

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -199,7 +199,7 @@ class BaseTools:
             return self._make_repo_not_found_error_message(repo_name)
         repo_name = fixed_repo_name
 
-        valid_file_path = self._attempt_fix_path(file_path, repo_name)
+        valid_file_path = self.context.attempt_fix_path(file_path, repo_name)
         if valid_file_path is None:
             other_paths = self._get_potential_abs_paths(file_path, repo_name)
             return f"Error: The file path `{file_path}` doesn't exist in `{repo_name}`.\n{other_paths}".strip()
@@ -328,27 +328,6 @@ class BaseTools:
 
         joined = "\n".join(unique_parents)
         return f"<did you mean>\n{joined}\n</did you mean>"
-
-    def _attempt_fix_path(self, path: str, repo_name: str) -> str | None:
-        """
-        Attempts to fix a path by checking if it exists in the repository as a path or directory.
-        """
-        repo_client = self.context.get_repo_client(repo_name=repo_name, type=self.repo_client_type)
-        all_files = repo_client.get_valid_file_paths()
-
-        normalized_path = path.lstrip("./").lstrip("/")
-        if not normalized_path:
-            return None
-
-        for p in all_files:
-            if p.endswith(normalized_path):
-                # is a valid file path
-                return p
-            if p.startswith(normalized_path):
-                # is a valid directory path
-                return normalized_path
-
-        return None
 
     def _normalize_path(self, path: str) -> str:
         """
@@ -662,7 +641,7 @@ class BaseTools:
             repo_name = repos[0]
             path = path_args
 
-        fixed_path = self._attempt_fix_path(path, repo_name)
+        fixed_path = self.context.attempt_fix_path(path, repo_name)
         if not fixed_path:
             if allow_nonexistent_paths:
                 return None, repo_name, path

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -199,7 +199,7 @@ class BaseTools:
             return self._make_repo_not_found_error_message(repo_name)
         repo_name = fixed_repo_name
 
-        valid_file_path = self.context.attempt_fix_path(file_path, repo_name)
+        valid_file_path = self._attempt_fix_path(file_path, repo_name)
         if valid_file_path is None:
             other_paths = self._get_potential_abs_paths(file_path, repo_name)
             return f"Error: The file path `{file_path}` doesn't exist in `{repo_name}`.\n{other_paths}".strip()
@@ -328,6 +328,27 @@ class BaseTools:
 
         joined = "\n".join(unique_parents)
         return f"<did you mean>\n{joined}\n</did you mean>"
+
+    def _attempt_fix_path(self, path: str, repo_name: str) -> str | None:
+        """
+        Attempts to fix a path by checking if it exists in the repository as a path or directory.
+        """
+        repo_client = self.context.get_repo_client(repo_name=repo_name, type=self.repo_client_type)
+        all_files = repo_client.get_valid_file_paths()
+
+        normalized_path = path.lstrip("./").lstrip("/")
+        if not normalized_path:
+            return None
+
+        for p in all_files:
+            if p.endswith(normalized_path):
+                # is a valid file path
+                return p
+            if p.startswith(normalized_path):
+                # is a valid directory path
+                return normalized_path
+
+        return None
 
     def _normalize_path(self, path: str) -> str:
         """
@@ -641,7 +662,7 @@ class BaseTools:
             repo_name = repos[0]
             path = path_args
 
-        fixed_path = self.context.attempt_fix_path(path, repo_name)
+        fixed_path = self._attempt_fix_path(path, repo_name)
         if not fixed_path:
             if allow_nonexistent_paths:
                 return None, repo_name, path

--- a/tests/automation/autofix/components/test_insight_sharing.py
+++ b/tests/automation/autofix/components/test_insight_sharing.py
@@ -20,6 +20,7 @@ from seer.automation.autofix.components.insight_sharing.models import (
 def mock_context():
     context = MagicMock()
     context.autocorrect_repo_name.side_effect = lambda x: x
+    context.autocorrect_file_path.side_effect = lambda path, repo_name: path
 
     repo_client = MagicMock()
     repo_client.provider = "github"


### PR DESCRIPTION
- Adds an autocorrect method for file paths in `autofix_context`. (not refactoring `attempt_fix_path` inside tools because then codecov can't use it)
- Then uses it to autocorrect the file name in the insight card sources so that we don't generate invalid links. 
- Also adds it to memory prefill steps.
- Also fixes autocorrect for file path in expand document not being used