### PR TITLE
fix(seer): Fix the logging

### DIFF
--- a/requirements-constraints.txt
+++ b/requirements-constraints.txt
@@ -46,7 +46,6 @@ sentry-sdk[flask]>=2.25.1
 simdkalman==1.0.2
 six==1.16.0
 statsmodels==0.14.0
-structlog>=22
 sympy==1.12
 threadpoolctl==3.2.0
 torch==2.2.0 # in Lightweight.Dockerfile, we have a specific command to install torch, update it there too.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ aiohappyeyeballs==2.6.1
 aiohttp==3.11.18
     # via
     #   -r requirements-constraints.txt
-    #   datasets
     #   fsspec
 aiosignal==1.3.2
     # via aiohttp
@@ -21,7 +20,7 @@ amqp==5.3.1
     # via kombu
 annotated-types==0.7.0
     # via pydantic
-anthropic==0.50.0
+anthropic==0.51.0
     # via -r requirements-constraints.txt
 anyio==4.9.0
     # via
@@ -126,7 +125,7 @@ cython==3.0.2
     # via -r requirements-constraints.txt
 datadog==0.51.0
     # via -r requirements-constraints.txt
-datasets==3.5.1
+datasets==3.6.0
     # via optimum
 deprecated==1.2.18
     # via pygithub
@@ -196,7 +195,7 @@ google-api-core==2.24.2
     #   google-cloud-resource-manager
     #   google-cloud-secret-manager
     #   google-cloud-storage
-google-auth==2.40.0
+google-auth==2.40.1
     # via
     #   anthropic
     #   google-api-core
@@ -207,7 +206,7 @@ google-auth==2.40.0
     #   google-cloud-secret-manager
     #   google-cloud-storage
     #   google-genai
-google-cloud-aiplatform==1.91.0
+google-cloud-aiplatform==1.92.0
     # via -r requirements-constraints.txt
 google-cloud-bigquery==3.31.0
     # via google-cloud-aiplatform
@@ -228,7 +227,9 @@ google-crc32c==1.7.1
     #   google-cloud-storage
     #   google-resumable-media
 google-genai==1.2.0
-    # via -r requirements-constraints.txt
+    # via
+    #   -r requirements-constraints.txt
+    #   google-cloud-aiplatform
 google-resumable-media==2.7.2
     # via
     #   google-cloud-bigquery
@@ -267,6 +268,8 @@ h11==0.16.0
     # via
     #   httpcore
     #   uvicorn
+hf-xet==1.1.0
+    # via huggingface-hub
 holidays==0.31
     # via
     #   -r requirements-constraints.txt
@@ -281,7 +284,7 @@ httpx==0.27.2
     #   anthropic
     #   langfuse
     #   openai
-huggingface-hub==0.30.2
+huggingface-hub==0.31.1
     # via
     #   datasets
     #   optimum
@@ -365,7 +368,7 @@ markupsafe==2.1.3
     #   mako
     #   sentry-sdk
     #   werkzeug
-matplotlib==3.10.1
+matplotlib==3.10.3
     # via
     #   prophet
     #   seaborn
@@ -432,7 +435,7 @@ onnx==1.16.0
     # via -r requirements-constraints.txt
 onnxruntime==1.21.1
     # via chromadb
-openai==1.77.0
+openai==1.78.0
     # via -r requirements-constraints.txt
 openapi-core==0.18.2
     # via -r requirements-constraints.txt
@@ -685,7 +688,7 @@ sentencepiece==0.2.0
     # via
     #   sentence-transformers
     #   transformers
-sentry-protos==0.1.74
+sentry-protos==0.2.0
     # via -r requirements-constraints.txt
 sentry-sdk==2.27.0
     # via -r requirements-constraints.txt
@@ -723,8 +726,6 @@ stanio==0.5.1
 starlette==0.46.2
     # via fastapi
 statsmodels==0.14.0
-    # via -r requirements-constraints.txt
-structlog==25.3.0
     # via -r requirements-constraints.txt
 stumpy==1.13.0
     # via -r requirements-constraints.txt

--- a/src/celery_app/app.py
+++ b/src/celery_app/app.py
@@ -87,13 +87,13 @@ def handle_task_failure(**kwargs):
     logger.error("Task failed", exc_info=kwargs["exception"])
 
 
-# 3) Patch Celery's worker logger
+# Patch Celery's worker logger
 @signals.after_setup_logger.connect
 def patch_worker_logger(logger: logging.Logger, **kwargs):
     setup_logger(logger)
 
 
-# 4) Patch Celery's per-task logger (if you want to catch task-level logs too)
+# Patch Celery's per-task logger (if you want to catch task-level logs too)
 @signals.after_setup_task_logger.connect
 def patch_task_logger(logger: logging.Logger, **kwargs):
     setup_logger(logger)

--- a/src/celery_app/app.py
+++ b/src/celery_app/app.py
@@ -2,7 +2,6 @@ import logging
 import os
 from typing import Any
 
-
 import billiard  # type: ignore[import-untyped]
 from celery import Celery, signals
 from sentry_sdk.integrations.celery import CeleryIntegration

--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -656,7 +656,7 @@ class AnthropicProvider:
         if isinstance(tool, ClaudeTool):
             return ToolParam(  # type: ignore
                 name=tool.name,
-                type=tool.type,
+                type=tool.type,  # type: ignore
             )
 
         return ToolParam(

--- a/src/seer/bootup.py
+++ b/src/seer/bootup.py
@@ -1,20 +1,17 @@
 import logging
 
-
 import sentry_sdk
 from psycopg import Connection
 from sentry_sdk.integrations import Integration
 from sentry_sdk.types import Event
 
+# Make sure this import is here
+import seer.logging  # noqa: F401
 from seer.automation.utils import AgentError
 from seer.configuration import AppConfig
 from seer.db import initialize_database
 from seer.dependency_injection import Module, inject, injected
 from seer.inference_models import initialize_models
-
-# Make sure this import is here
-import seer.logging  # noqa: F401
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/seer/bootup.py
+++ b/src/seer/bootup.py
@@ -1,5 +1,6 @@
 import logging
 
+
 import sentry_sdk
 from psycopg import Connection
 from sentry_sdk.integrations import Integration
@@ -10,7 +11,10 @@ from seer.configuration import AppConfig
 from seer.db import initialize_database
 from seer.dependency_injection import Module, inject, injected
 from seer.inference_models import initialize_models
-from seer.logging import initialize_logs
+
+# Make sure this import is here
+import seer.logging  # noqa: F401
+
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +41,6 @@ def bootup(
 ):
     initialize_sentry_sdk(integrations)
     with sentry_sdk.metrics.timing(key="seer_bootup_time"):
-        initialize_logs(["seer.", "celery_app."])
         config.do_validation()
         initialize_database()
         initialize_models(start_model_loading)

--- a/src/seer/logging.py
+++ b/src/seer/logging.py
@@ -1,12 +1,6 @@
 import logging
-import sys
-from typing import Annotated
 
-import structlog
 from gunicorn.glogging import Logger as GunicornBaseLogger  # type: ignore[import-untyped]
-from structlog import get_logger
-
-from seer.dependency_injection import Labeled, Module, inject, injected
 
 
 class SubstringFilter(logging.Filter):


### PR DESCRIPTION
Our logging was a mess with duplicated logs, hard to read json format, and complicated implementation.

This PR simplifies that by using the standard logger, with a substring filter that filters out noisy logs. Especially needed now that we show these logs in Sentry.

May the screenshots below be all the rest of what I have to say.

## Before:
![CleanShot 2025-05-09 at 15 25 19@2x](https://github.com/user-attachments/assets/69364ac7-ee7e-445b-9a07-64089f99c026)

## After:
![CleanShot 2025-05-09 at 15 23 33@2x](https://github.com/user-attachments/assets/1246b905-4eb9-481e-bcb7-66489543dfd1)

