### PR TITLE
chore: don't mock PrFiles when running evaluations

### DIFF
--- a/src/seer/automation/codegen/evals/evaluations.py
+++ b/src/seer/automation/codegen/evals/evaluations.py
@@ -46,14 +46,6 @@ def sync_run_evaluation_on_item(
         type=DbStateRunTypes.RELEVANT_WARNINGS,
     )
 
-    # Mock parts of the pipeline depending on the extra info saved in the EvalItem.
-    # If it's not mocked we will reach out to GitHub at evaluation time.
-    if item.pr_files:
-        # Mock the repo client to return the pr_files
-        mock_repo_client = mock.Mock()
-        mock_repo_client.repo.get_pull.return_value.get_files.return_value = item.pr_files
-        relevant_warnings_step.context.get_repo_client = mock.Mock(return_value=mock_repo_client)  # type: ignore [method-assign]
-
     # Mock FilterIssuesComponent to return the issues
     # Ignoring the filename_to_issues part of the output.
     mock.patch(

--- a/src/seer/automation/codegen/evals/models.py
+++ b/src/seer/automation/codegen/evals/models.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, field_validator
 from pydantic.fields import Field
 
-from seer.automation.codebase.models import PrFile, StaticAnalysisWarning
+from seer.automation.codebase.models import StaticAnalysisWarning
 from seer.automation.codegen.models import CodegenRelevantWarningsRequest
 from seer.automation.models import IssueDetails, RepoDefinition
 
@@ -23,7 +23,6 @@ class EvalItemInput(BaseModel):
     organization_id: int
     commit_sha: str
     warnings: list[StaticAnalysisWarning]
-    pr_files: list[PrFile] | None = None
     issues: list[IssueDetails] | None = None
 
     @field_validator("issues", mode="after")


### PR DESCRIPTION
The idea of mocking PrFiles in the evals was to allow us to run them without reaching out to GitHub. However with the move to the agentic approach this is useless. The agents have code searching capabilities, and are expected to communicate quite often with GitHub anyway.

So when running evaluations the GitHub token you have in `.env` needs to be able to access all the repos for which there are eval items.