### PR TITLE
Aiml 286 commitsha with autofix run

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
         types: [python]
       - id: prevent-push
         name: prevent pushing to main
-        stages: [push]
+        stages: [pre-push]
         entry: bash -c 'test "$PRE_COMMIT_REMOTE_BRANCH" != "refs/heads/main"'
         always_run: true
         pass_filenames: false

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -1007,6 +1007,7 @@ def run_autofix_evaluation_on_item(
     dataset_item_trace_id = None
     with dataset_item.observe(run_name=run_name, run_description=run_description) as trace_id:
         dataset_item_trace_id = trace_id
+        logger.info("Hi there -----------------------------------------------")
         try:
             final_state = sync_run_evaluation_on_item(dataset_item, langfuse_session_id=trace_id)  # type: ignore
         except Exception as e:

--- a/src/seer/automation/autofix/tasks.py
+++ b/src/seer/automation/autofix/tasks.py
@@ -1007,7 +1007,6 @@ def run_autofix_evaluation_on_item(
     dataset_item_trace_id = None
     with dataset_item.observe(run_name=run_name, run_description=run_description) as trace_id:
         dataset_item_trace_id = trace_id
-        logger.info("Hi there -----------------------------------------------")
         try:
             final_state = sync_run_evaluation_on_item(dataset_item, langfuse_session_id=trace_id)  # type: ignore
         except Exception as e:

--- a/src/seer/automation/codebase/repo_manager.py
+++ b/src/seer/automation/codebase/repo_manager.py
@@ -104,7 +104,6 @@ class RepoManager:
                 self.repo_path,
                 progress=lambda *args, **kwargs: self._throttled_liveness_probe(),
                 depth=1,
-                no_checkout=True,
             )
             # Fetch the specific commit
             try:
@@ -116,7 +115,7 @@ class RepoManager:
             self.git_repo.git.checkout(commit_sha)
             end_time = time.time()
             logger.info(
-                f"Cloned and checked out repository at commit {commit_sha} in {end_time - start_time} seconds"
+                f"Cloned and checked out repository at commit {commit_sha} in {end_time - start_time:.4f} seconds"
             )
 
             return self.repo_path

--- a/src/seer/automation/codebase/repo_manager.py
+++ b/src/seer/automation/codebase/repo_manager.py
@@ -102,8 +102,8 @@ class RepoManager:
             self.git_repo = git.Repo.clone_from(
                 repo_clone_url,
                 self.repo_path,
-                no_checkout=True,
                 depth=1,
+                progress=lambda *args, **kwargs: self._throttled_liveness_probe(),
             )
             # Fetch the specific commit if it's not present
             try:

--- a/src/seer/automation/codebase/repo_manager.py
+++ b/src/seer/automation/codebase/repo_manager.py
@@ -102,14 +102,16 @@ class RepoManager:
             self.git_repo = git.Repo.clone_from(
                 repo_clone_url,
                 self.repo_path,
-                depth=1,
                 progress=lambda *args, **kwargs: self._throttled_liveness_probe(),
+                depth=1,
+                no_checkout=True,
             )
-            # Fetch the specific commit if it's not present
+            # Fetch the specific commit
             try:
                 self.git_repo.git.fetch("origin", commit_sha, depth=1)
             except git.GitCommandError as e:
                 logger.error(f"Could not fetch specific commit {commit_sha}: {e}")
+                raise
             # Checkout the specific commit
             self.git_repo.git.checkout(commit_sha)
             end_time = time.time()

--- a/tests/automation/codebase/test_repo_manager.py
+++ b/tests/automation/codebase/test_repo_manager.py
@@ -33,7 +33,7 @@ def test_clone_success(repo_manager, mock_repo_client, caplog):
 
     # Setup mock repo client to return a local file URL and a fake commit sha
     mock_repo_client.get_clone_url_with_auth.return_value = "file:///fake/repo.git"
-    mock_repo_client.base_commit_sha = "deadbeef"
+    mock_repo_client.base_commit_sha = "fakecommit"
 
     # Create a mock git.Repo object with mock git attribute
     mock_git = MagicMock()
@@ -55,15 +55,15 @@ def test_clone_success(repo_manager, mock_repo_client, caplog):
         )
 
         # Verify fetch and checkout were called with correct arguments
-        mock_git.fetch.assert_called_once_with("origin", "deadbeef", depth=1)
-        mock_git.checkout.assert_called_once_with("deadbeef")
+        mock_git.fetch.assert_called_once_with("origin", "fakecommit", depth=1)
+        mock_git.checkout.assert_called_once_with("fakecommit")
 
         # Verify the repo was set
         assert repo_manager.git_repo == mock_git_repo
 
         # Check logging
         assert "Cloning repository test-owner/test-repo" in caplog.text
-        assert "Cloned and checked out repository at commit deadbeef" in caplog.text
+        assert "Cloned and checked out repository at commit fakecommit" in caplog.text
 
 
 def test_clone_failure_clears_repo(repo_manager, mock_repo_client, caplog):

--- a/tests/automation/codebase/test_repo_manager.py
+++ b/tests/automation/codebase/test_repo_manager.py
@@ -88,24 +88,6 @@ def test_clone_failure_clears_repo(repo_manager, mock_repo_client, caplog):
         assert "Failed to clone repository" in caplog.text
 
 
-def test_sync_failure_clears_repo(repo_manager, mock_repo_client, caplog):
-    """Test that sync failure clears the repo reference."""
-    caplog.set_level(logging.ERROR)
-
-    # Setup mock git repo that raises on execute
-    mock_git_repo = MagicMock(spec=git.Repo)
-    mock_git_repo.git.execute.side_effect = Exception("Sync failed")
-    repo_manager.git_repo = mock_git_repo
-
-    repo_manager._sync_repo()
-
-    # Verify repo was cleared
-    assert repo_manager.git_repo is None
-
-    # Verify error was logged
-    assert f"Failed to sync repository {mock_repo_client.repo_full_name}" in caplog.text
-
-
 def test_mark_as_timed_out_before_init(repo_manager):
     """Test marking as timed out before initialization."""
     repo_path = repo_manager.repo_path
@@ -192,15 +174,11 @@ def test_initialize_in_background(repo_manager, caplog):
 
 def test_initialize_success(repo_manager, mock_repo_client):
     """Test successful initialization sequence."""
-    with (
-        patch.object(repo_manager, "_clone_repo") as mock_clone,
-        patch.object(repo_manager, "_sync_repo") as mock_sync,
-    ):
+    with (patch.object(repo_manager, "_clone_repo") as mock_clone,):
         repo_manager.initialize()
 
         # Verify sequence
         mock_clone.assert_called_once()
-        mock_sync.assert_called_once()
         assert repo_manager.initialization_future is None
 
 


### PR DESCRIPTION
# PR Details
+ Ticket: [AIML-286](https://linear.app/getsentry/issue/AIML-286/fix-draft-pr-failing-due-to-changed-codebase)
+ I implemented this change by changing the _clone_repo function to clone the repo and checkout to a specific commit hash 
+ The commit hash it uses is the `base_commit_hash` from the `RepoClient` class. This commit hash is passed to the class at initialization or if it's not set, the commit of the branch HEAD is fetched.
+  I removed the _sync_repo method since that method is now rolled up into _clone_repo
  + I'm okay will adding _sync_repo back if anyone thinks we might need it in other functions. 
+ pre-commit file is updated too since "push" isn't a valid stage for the git hook. 