### PR TITLE
chore(trace queries): Reduce fields used in values query

### DIFF
--- a/src/seer/automation/assisted_query/assisted_query.py
+++ b/src/seer/automation/assisted_query/assisted_query.py
@@ -82,7 +82,6 @@ def create_query_from_natural_language(
     relevant_fields = (
         relevant_fields_response.parsed.fields if relevant_fields_response.parsed else []
     )
-    logger.info(f"Identified {len(relevant_fields)} relevant fields for query")
 
     # Step 2: Fetch values for relevant fields
     field_values_response = rpc_client.call(
@@ -94,8 +93,6 @@ def create_query_from_natural_language(
         limit=150,
     )
     field_values = field_values_response.get("field_values", {}) if field_values_response else {}
-    total_values = sum(len(values) for values in field_values.values())
-    logger.info(f"Fetched {total_values} values across {len(field_values)} fields")
 
     # Step 3: Generate final prompt based off of relevant fields and values
     fields_and_values_prompt = prompts.get_fields_and_values_prompt(

--- a/src/seer/automation/assisted_query/create_cache.py
+++ b/src/seer/automation/assisted_query/create_cache.py
@@ -64,7 +64,7 @@ def create_cache(data: CreateCacheRequest, client: RpcClient = injected) -> Crea
             if field not in filtered_fields:
                 filtered_fields.append(field)
 
-    field_values_response = client.call(
+    filtered_field_values_response = client.call(
         "get_attribute_values",
         fields=filtered_fields,
         org_id=org_id,
@@ -73,9 +73,13 @@ def create_cache(data: CreateCacheRequest, client: RpcClient = injected) -> Crea
         limit=5,
     )
 
-    field_values = field_values_response.get("field_values", {}) if field_values_response else {}
+    filtered_field_values = (
+        filtered_field_values_response.get("field_values", {})
+        if filtered_field_values_response
+        else {}
+    )
 
-    cache_prompt = get_cache_prompt(fields=all_fields, field_values=field_values)
+    cache_prompt = get_cache_prompt(fields=all_fields, field_values=filtered_field_values)
 
     cache_name = LlmClient().create_cache(
         display_name=cache_diplay_name, contents=cache_prompt, model=get_model_provider()

--- a/src/seer/automation/assisted_query/prompts.py
+++ b/src/seer/automation/assisted_query/prompts.py
@@ -244,7 +244,9 @@ def get_cache_prompt(fields: list[str], field_values: dict[str, list[str]]) -> s
 
         ## Available Field Values
 
-        For the string fields below, here are up to 5 possible values you can use. These are not fully exhaustive as some fields can have many more than 5 values, but should give you a good starting point especially when finding the right field to use or constructing wildcard string matches.
+        For the string fields below, here are up to 5 possible values you can use for up to 125 fields.
+        These are not fully exhaustive as some fields can have many more than 5 values, but should give you a good starting point especially when finding the right field to use or constructing wildcard string matches.
+        You will receive more values for specific string fields in the future. For numeric fields, you should use the comparison operators to find close or exact matches.
 
         <available_field_values>
         {json.dumps(field_values, indent=2)}

--- a/tests/automation/assisted_query/test_create_cache.py
+++ b/tests/automation/assisted_query/test_create_cache.py
@@ -74,3 +74,55 @@ class TestCreateCache(unittest.TestCase):
         )
 
         mock_llm_instance.create_cache.assert_called_once()
+
+    @patch("seer.automation.assisted_query.create_cache.LlmClient")
+    def test_create_cache_field_filtering(self, mock_llm_client, mock_rpc_client_call: Mock):
+        """Test creating cache with field filtering when there are too many fields"""
+        mock_llm_instance = MagicMock()
+        mock_llm_client.return_value = mock_llm_instance
+        mock_llm_instance.get_cache.return_value = None
+        mock_llm_instance.create_cache.return_value = "new-cache-name"
+
+        fields = []
+        fields.extend([f"span.field{i}" for i in range(25)])
+        fields.extend([f"transaction.field{i}" for i in range(25)])
+        fields.extend([f"user.field{i}" for i in range(25)])
+
+        # These fields should be filtered out
+        fields.extend([f"tags[field{i},number]" for i in range(50)])
+        fields.extend([f"other.field{i}" for i in range(50)])
+
+        mock_rpc_client_call.return_value = {
+            "fields": fields,
+            "field_values": {field: ["value1"] for field in fields},
+        }
+
+        response = create_cache(self.request)
+
+        assert isinstance(response, CreateCacheResponse)
+        assert response.success is True
+        assert response.message == "Cache created successfully"
+        assert response.cache_name == "new-cache-name"
+
+        mock_rpc_client_call.assert_any_call(
+            "get_attribute_names",
+            org_id=self.org_id,
+            project_ids=self.project_ids,
+            stats_period="48h",
+        )
+
+        get_attribute_values_call = next(
+            call
+            for call in mock_rpc_client_call.call_args_list
+            if call[0][0] == "get_attribute_values"
+        )
+
+        filtered_fields = get_attribute_values_call[1]["fields"]
+
+        assert len(filtered_fields) <= 125
+        assert any(field.startswith("span.") for field in filtered_fields)
+        assert any(field.startswith("transaction.") for field in filtered_fields)
+        assert any(field.startswith("user.") for field in filtered_fields)
+        assert not any("tags[" in field and ",number]" in field for field in filtered_fields)
+
+        mock_llm_instance.create_cache.assert_called_once()

--- a/tests/automation/assisted_query/test_create_cache.py
+++ b/tests/automation/assisted_query/test_create_cache.py
@@ -90,7 +90,7 @@ class TestCreateCache(unittest.TestCase):
 
         # These fields should be filtered out
         fields.extend([f"tags[field{i},number]" for i in range(50)])
-        fields.extend([f"other.field{i}" for i in range(50)])
+        fields.extend([f"other.field{i}" for i in range(150)])
 
         mock_rpc_client_call.return_value = {
             "fields": fields,


### PR DESCRIPTION
- Reduce amount of fields for the values query to max 125
- Ensure we query for some of the most important fields (spans, project, transaction, trace, etc)
- Should fix timeout issues for projects with lots of fields
- Also clean up some logs