### PR TITLE
chore: prompt change to evaluations (relevant-warnings)

### DIFF
--- a/src/seer/automation/codegen/evals/evaluations.py
+++ b/src/seer/automation/codegen/evals/evaluations.py
@@ -92,8 +92,12 @@ def evaluate_suggestions(
 
     <reasoning_rules>
     When evaluating the suggested bugs, consider:
-    1. is the suggestion a _good match_ for an actual bug? Focus on the core concepts that cause the bug.
-    2. is this suggestion not accurately describing the actual bug it was matched to?
+    1. is the suggestion a _good match_ for an actual bug?
+      - Focus on matching the content of the suggestion with the actual bug.
+    2. is this suggestion accurately describing the actual bug it was matched to?
+      - Focus on the core concepts that cause the bug.
+      - The suggestion should lead a developer reading it to be able to find the actual bug.
+      - If the content is not related to an actual bug, the suggestion should not be matched.
     </reasoning_rules>
 
     <output_format>


### PR DESCRIPTION
Based on [this deep dive](https://www.notion.so/sentry/4th-full-run-1f18b10e4b5d808ea1f3c68bb2661136) for one of the runs in the dataset it seems like the evaluator LLM was not so focused on the content when matching bugs, but would use the location as a criteria too

The small changes in the prompt make it focus more on the content when matching, and not so much on location. I noticed that 2 matched bugs with low content score were no longer matched, but we kept the one with a high content score (all 3 had pretty good location scores)

And that's all the 3 bugs we had matched :D so, there you go.