### PR TITLE
fix(autofix): Don't fetch original content for new files

### DIFF
--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -580,7 +580,7 @@ class AutofixContext(PipelineContext):
                     )
                 )
 
-        return make_file_patches(file_changes, changes_by_path.keys(), original_documents)
+        return make_file_patches(file_changes, list(changes_by_path.keys()), original_documents)
 
     def store_memory(self, key: str, memory: list[Message]):
         with Session() as session:


### PR DESCRIPTION
In `make_file_patches`, we fetched the original content from github for all files, even newly created files, causing `UnknownObjectException` (this error was handled just fine though, so no impact). This PR makes it so we only fetch the original file for edit and delete changes to avoid logging this error and avoid an unnecessary API call.

Root cause discovered by Autofix 🤯 :
# Root Cause of the Issue

Autofix attempted to fetch original content for a new file proposed in changes, which did not exist at the reference commit SHA.

### The Autofix change describer task starts processing proposed code changes.
The `autofix_change_describer_task` Celery task is the entry point for this part of the Autofix pipeline. It initializes the `AutofixChangeDescriberStep` and invokes its execution.
(See seer/automation/autofix/steps/change_describer_step.py)

### The step iterates through the proposed file changes for each codebase.
The `_invoke` method of `AutofixChangeDescriberStep` retrieves the current state, which includes `codebases` and their associated `file_changes`. It loops through these changes to prepare for generating descriptions and commits.
```python
        cur_state = self.context.state.get()

        for codebase_state in cur_state.codebases.values():
            if codebase_state.file_changes:
                # ... process changes ...
```
(See seer/automation/autofix/steps/change_describer_step.py)

### The system attempts to generate file patches (diffs) for the proposed changes.
For each codebase with `file_changes`, the step calls `self.context.make_file_patches`. This function requires the original content of the files to compute the diff.
```python
                diff, diff_str = self.context.make_file_patches(
                    codebase_state.file_changes, repo_definition.full_name
                )
```
(See seer/automation/autofix/steps/change_describer_step.py)

### The system tries to fetch the original content for each file involved in the changes.
Inside `make_file_patches`, a list comprehension iterates through the paths from `file_changes` and calls `self.get_file_contents(path, ..., ignore_local_changes=True)` to retrieve the content of the file as it exists in the repository at the branch head SHA.
```python
        original_documents = [
            BaseDocument(
                path=path,
                text=self.get_file_contents(path, repo_name=repo_name, ignore_local_changes=True)
                or "",
            )
            for path in document_paths
        ]
```
(See seer/automation/autofix/autofix_context.py)

### A call is made to the GitHub API to get the content of a specific file at a specific commit SHA.
The `get_file_contents` method calls `repo_client.get_file_content`, which in turn calls the underlying `github` library's `get_contents` method. This method makes an HTTP GET request to the GitHub API's `/repos/{owner}/{repo}/contents/{path}` endpoint, specifying the commit SHA via the `ref` parameter.

Breadcrumb 8 shows the specific failing request:
`{'http.method': 'GET', 'http.query': 'ref=eadf060b174573987c329c1e61bef3a8529e7109', 'http.response.status_code': 404, 'reason': 'Not Found', 'thread.id': '137196211414144', 'thread.name': 'MainThread', 'url': 'https://api.github.com/repos/Dopely/dopely-colors-backend/contents/palettes/tests/test_validators.py'}`
(See seer/automation/codebase/repo_client.py)

### The GitHub API returns a 404 Not Found error because the file does not exist at the requested commit SHA.
The file `palettes/tests/test_validators.py` is likely a *new* file that Autofix is proposing to add as part of the fix. Since it's new, it doesn't exist in the repository's history at the commit SHA `eadf060b174573987c329c1e61bef3a8529e7109` (the branch head used as the reference). The GitHub API correctly indicates that the resource was not found.

Exception 0 shows the response data:
`"data": { "documentation_url": 'https://docs.github.com/rest/repos/contents#get-repository-content', "message": 'Not Found', "status": '404' }`

### The github library raises an UnknownObjectException for the 404 response.
The `github` library's `__check` method detects the 400+ status code from the GitHub API response and raises an exception, in this case, `UnknownObjectException` for the 404 status.
```python
        if status >= 400:
            raise self.createException(status, responseHeaders, data)  # <-- SUSPECT LINE
```