### PR TITLE
fix(autofix): Still make repo manager work without org id

### DIFF
--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -70,8 +70,10 @@ class BaseTools:
             repo_manager = RepoManager(
                 repo_client,
                 trigger_liveness_probe=self._trigger_liveness_probe,
-                organization_id=request.organization_id,
-                project_id=request.project_id,
+                organization_id=(
+                    request.organization_id if isinstance(self.context, AutofixRequest) else None
+                ),
+                project_id=request.project_id if isinstance(self.context, AutofixRequest) else None,
             )
             repo_manager.initialize_in_background()
             self.repo_managers[repo_name] = repo_manager


### PR DESCRIPTION
The codegen request doesn't have an org id and for some reason linter didn't throw a fit??