### PR TITLE
feat(autofix): Generate urls for root cause and solution timeline items

### DIFF
--- a/src/seer/automation/autofix/components/insight_sharing/component.py
+++ b/src/seer/automation/autofix/components/insight_sharing/component.py
@@ -177,24 +177,21 @@ def process_sources(sources: list, context: AutofixContext, trace_tree: TraceTre
             if result:
                 start_line = result[1]
                 end_line = result[2]
-                if repo_client.provider == "github":
-                    code_url = f"https://github.com/{repo_name}/blob/{repo_client.base_commit_sha}/{file_name}#L{start_line}-L{end_line}"
-                    if code_url not in final_sources.code_used_urls:
-                        final_sources.code_used_urls.append(code_url)
+                code_url = repo_client.get_file_url(file_name, start_line, end_line)
+                if code_url not in final_sources.code_used_urls:
+                    final_sources.code_used_urls.append(code_url)
             else:
-                if repo_client.provider == "github":
-                    code_url = f"https://github.com/{repo_name}/blob/{repo_client.base_commit_sha}/{file_name}"
-                    if code_url not in final_sources.code_used_urls:
-                        final_sources.code_used_urls.append(code_url)
+                code_url = repo_client.get_file_url(file_name)
+                if code_url not in final_sources.code_used_urls:
+                    final_sources.code_used_urls.append(code_url)
         elif isinstance(source, DiffSource):
             repo_name = context.autocorrect_repo_name(source.repo_name)
             if not repo_name:
                 continue
             repo_client = context.get_repo_client(repo_name)
-            if repo_client.provider == "github":
-                diff_url = f"https://github.com/{repo_name}/commit/{source.commit_sha}"
-                if diff_url not in final_sources.diff_urls:
-                    final_sources.diff_urls.append(diff_url)
+            diff_url = repo_client.get_commit_url(source.commit_sha)
+            if diff_url not in final_sources.diff_urls:
+                final_sources.diff_urls.append(diff_url)
 
     return final_sources
 

--- a/src/seer/automation/autofix/components/root_cause/models.py
+++ b/src/seer/automation/autofix/components/root_cause/models.py
@@ -35,6 +35,7 @@ class RootCauseAnalysisItem(BaseModel):
     description: str | None = (
         None  # TODO: this is for backwards compatability with old runs, should remove soon
     )
+    reproduction_urls: list[str | None] = []
 
     def to_markdown_string(self) -> str:
         markdown = "# Root Cause\n\n"

--- a/src/seer/automation/autofix/components/solution/models.py
+++ b/src/seer/automation/autofix/components/solution/models.py
@@ -9,15 +9,16 @@ from seer.automation.models import EventDetails, Profile, TraceTree
 from seer.automation.summarize.issue import IssueSummary
 
 
-class RelevantCodeFile(BaseModel):
+class RelevantCodeFileWithUrl(BaseModel):
     file_path: str
     repo_name: str
+    url: str | None = None
 
 
 class SolutionTimelineEvent(BaseModel):
     title: str
     code_snippet_and_analysis: str | None = None
-    relevant_code_file: RelevantCodeFile | None = None
+    relevant_code_file: RelevantCodeFileWithUrl | None = None
     is_most_important_event: bool = False
     timeline_item_type: Literal["internal_code", "human_instruction", "repro_test"] = (
         "internal_code"
@@ -40,6 +41,11 @@ class SolutionTimelineEvent(BaseModel):
         ):
             data["timeline_item_type"] = "internal_code"
         return data
+
+
+class RelevantCodeFile(BaseModel):
+    file_path: str
+    repo_name: str
 
 
 class SolutionPlanStep(BaseModel):

--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -210,10 +210,14 @@ class AutofixEventManager:
                 SolutionTimelineEvent(
                     title=solution_step.title,
                     code_snippet_and_analysis=solution_step.code_snippet_and_analysis,
-                    relevant_code_file=RelevantCodeFileWithUrl(
-                        file_path=solution_step.relevant_code_file.file_path,
-                        repo_name=solution_step.relevant_code_file.repo_name,
-                        url=reproduction_urls[i] if i < len(reproduction_urls) else None,
+                    relevant_code_file=(
+                        RelevantCodeFileWithUrl(
+                            file_path=solution_step.relevant_code_file.file_path,
+                            repo_name=solution_step.relevant_code_file.repo_name,
+                            url=reproduction_urls[i] if i < len(reproduction_urls) else None,
+                        )
+                        if solution_step.relevant_code_file
+                        else None
                     ),
                     is_most_important_event=solution_step.is_most_important,
                 )

--- a/src/seer/automation/autofix/event_manager.py
+++ b/src/seer/automation/autofix/event_manager.py
@@ -4,7 +4,11 @@ import time
 
 from seer.automation.autofix.components.insight_sharing.models import InsightSharingOutput
 from seer.automation.autofix.components.root_cause.models import RootCauseAnalysisOutput
-from seer.automation.autofix.components.solution.models import SolutionOutput, SolutionTimelineEvent
+from seer.automation.autofix.components.solution.models import (
+    RelevantCodeFileWithUrl,
+    SolutionOutput,
+    SolutionTimelineEvent,
+)
 from seer.automation.autofix.models import (
     AutofixContinuation,
     AutofixRootCauseUpdatePayload,
@@ -193,7 +197,9 @@ class AutofixEventManager:
                 log_payload,
             )
 
-    def send_solution_result(self, solution_output: SolutionOutput):
+    def send_solution_result(
+        self, solution_output: SolutionOutput, reproduction_urls: list[str | None]
+    ):
         log_payload = None
         with self.state.update() as cur:
             solution_processing_step = cur.find_or_add(self.solution_processing_step)
@@ -204,10 +210,14 @@ class AutofixEventManager:
                 SolutionTimelineEvent(
                     title=solution_step.title,
                     code_snippet_and_analysis=solution_step.code_snippet_and_analysis,
-                    relevant_code_file=solution_step.relevant_code_file,
+                    relevant_code_file=RelevantCodeFileWithUrl(
+                        file_path=solution_step.relevant_code_file.file_path,
+                        repo_name=solution_step.relevant_code_file.repo_name,
+                        url=reproduction_urls[i] if i < len(reproduction_urls) else None,
+                    ),
                     is_most_important_event=solution_step.is_most_important,
                 )
-                for solution_step in solution_output.solution_steps
+                for i, solution_step in enumerate(solution_output.solution_steps)
             ]
             solution_step.solution.append(  # type: ignore[union-attr]
                 SolutionTimelineEvent(

--- a/src/seer/automation/autofix/steps/root_cause_step.py
+++ b/src/seer/automation/autofix/steps/root_cause_step.py
@@ -185,17 +185,20 @@ class RootCauseStep(AutofixPipelineStep):
 
     def _get_reproduction_urls(self, root_cause_output: RootCauseAnalysisOutput):
         reproduction_urls: list[str | None] = []
-        for i, timeline_item in enumerate(root_cause_output.causes[0].root_cause_reproduction):
+        repro_timeline = root_cause_output.causes[0].root_cause_reproduction
+        if not repro_timeline:
+            return []
+        for i, timeline_item in enumerate(repro_timeline):
             reproduction_urls.append(None)
             relevant_code = timeline_item.relevant_code_file
             if not relevant_code:
                 continue
-            repo_name: str | None = relevant_code.repo_name
-            repo_name = self.context.autocorrect_repo_name(repo_name)
+            repo_name = self.context.autocorrect_repo_name(relevant_code.repo_name)
             if not repo_name:
                 continue
-            file_name: str | None = relevant_code.file_path
-            file_name = self.context.autocorrect_file_path(path=file_name, repo_name=repo_name)
+            file_name = self.context.autocorrect_file_path(
+                path=relevant_code.file_path, repo_name=repo_name
+            )
             if not file_name:
                 continue
 

--- a/src/seer/automation/autofix/steps/root_cause_step.py
+++ b/src/seer/automation/autofix/steps/root_cause_step.py
@@ -107,7 +107,8 @@ class RootCauseStep(AutofixPipelineStep):
 
         # create URLs to relevant code snippets
         reproduction_urls = self._get_reproduction_urls(root_cause_output)
-        root_cause_output.causes[0].reproduction_urls = reproduction_urls
+        if root_cause_output.causes and reproduction_urls:
+            root_cause_output.causes[0].reproduction_urls = reproduction_urls
 
         self.context.event_manager.send_root_cause_analysis_result(root_cause_output)
 
@@ -185,6 +186,8 @@ class RootCauseStep(AutofixPipelineStep):
 
     def _get_reproduction_urls(self, root_cause_output: RootCauseAnalysisOutput):
         reproduction_urls: list[str | None] = []
+        if not root_cause_output.causes:
+            return []
         repro_timeline = root_cause_output.causes[0].root_cause_reproduction
         if not repro_timeline:
             return []

--- a/src/seer/automation/autofix/steps/root_cause_step.py
+++ b/src/seer/automation/autofix/steps/root_cause_step.py
@@ -184,7 +184,7 @@ class RootCauseStep(AutofixPipelineStep):
         )
 
     def _get_reproduction_urls(self, root_cause_output: RootCauseAnalysisOutput):
-        reproduction_urls = []
+        reproduction_urls: list[str | None] = []
         for i, timeline_item in enumerate(root_cause_output.causes[0].root_cause_reproduction):
             reproduction_urls.append(None)
             relevant_code = timeline_item.relevant_code_file

--- a/src/seer/automation/autofix/steps/root_cause_step.py
+++ b/src/seer/automation/autofix/steps/root_cause_step.py
@@ -190,11 +190,11 @@ class RootCauseStep(AutofixPipelineStep):
             relevant_code = timeline_item.relevant_code_file
             if not relevant_code:
                 continue
-            repo_name = relevant_code.repo_name
+            repo_name: str | None = relevant_code.repo_name
             repo_name = self.context.autocorrect_repo_name(repo_name)
             if not repo_name:
                 continue
-            file_name = relevant_code.file_path
+            file_name: str | None = relevant_code.file_path
             file_name = self.context.autocorrect_file_path(path=file_name, repo_name=repo_name)
             if not file_name:
                 continue

--- a/src/seer/automation/autofix/steps/root_cause_step.py
+++ b/src/seer/automation/autofix/steps/root_cause_step.py
@@ -8,7 +8,10 @@ from celery_app.app import celery_app
 from seer.automation.agent.models import Message
 from seer.automation.autofix.components.confidence import ConfidenceComponent, ConfidenceRequest
 from seer.automation.autofix.components.root_cause.component import RootCauseAnalysisComponent
-from seer.automation.autofix.components.root_cause.models import RootCauseAnalysisRequest
+from seer.automation.autofix.components.root_cause.models import (
+    RootCauseAnalysisOutput,
+    RootCauseAnalysisRequest,
+)
 from seer.automation.autofix.config import (
     AUTOFIX_ROOT_CAUSE_HARD_TIME_LIMIT_SECS,
     AUTOFIX_ROOT_CAUSE_SOFT_TIME_LIMIT_SECS,
@@ -23,6 +26,7 @@ from seer.automation.autofix.steps.solution_step import (
     AutofixSolutionStepRequest,
 )
 from seer.automation.autofix.steps.steps import AutofixPipelineStep
+from seer.automation.autofix.utils import find_original_snippet
 from seer.automation.models import EventDetails
 from seer.automation.pipeline import PipelineStepTaskRequest
 from seer.automation.utils import make_kill_signal
@@ -101,6 +105,10 @@ class RootCauseStep(AutofixPipelineStep):
         if make_kill_signal() in state.signals:
             return
 
+        # create URLs to relevant code snippets
+        reproduction_urls = self._get_reproduction_urls(root_cause_output)
+        root_cause_output.causes[0].reproduction_urls = reproduction_urls
+
         self.context.event_manager.send_root_cause_analysis_result(root_cause_output)
 
         # confidence evaluation
@@ -174,3 +182,47 @@ class RootCauseStep(AutofixPipelineStep):
             ),
             queue=app_config.CELERY_WORKER_QUEUE,
         )
+
+    def _get_reproduction_urls(self, root_cause_output: RootCauseAnalysisOutput):
+        reproduction_urls = []
+        for i, timeline_item in enumerate(root_cause_output.causes[0].root_cause_reproduction):
+            reproduction_urls.append(None)
+            relevant_code = timeline_item.relevant_code_file
+            if not relevant_code:
+                continue
+            repo_name = relevant_code.repo_name
+            repo_name = self.context.autocorrect_repo_name(repo_name)
+            if not repo_name:
+                continue
+            file_name = relevant_code.file_path
+            file_name = self.context.autocorrect_file_path(path=file_name, repo_name=repo_name)
+            if not file_name:
+                continue
+
+            repo_client = self.context.get_repo_client(repo_name)
+
+            full_snippet = timeline_item.code_snippet_and_analysis
+            # Extract code snippet between triple backticks
+            code_snippet = None
+            parts = full_snippet.split("```")
+            if len(parts) > 2:
+                code_snippet = parts[1].split("```")[0]
+                if "\n" in code_snippet:
+                    code_snippet = "\n".join(
+                        code_snippet.split("\n")[1:]
+                    )  # remove the first line because it's often something like ```python
+            start_line = None
+            end_line = None
+            if code_snippet:
+                file_content = self.context.get_file_contents(file_name, repo_name)
+                if file_content:
+                    result = find_original_snippet(
+                        code_snippet, file_content, initial_line_threshold=0.5, threshold=0.5
+                    )
+                    if result:
+                        start_line = result[1]
+                        end_line = result[2]
+            code_url = repo_client.get_file_url(file_name, start_line, end_line)
+            reproduction_urls[i] = code_url
+
+        return reproduction_urls

--- a/src/seer/automation/autofix/steps/solution_step.py
+++ b/src/seer/automation/autofix/steps/solution_step.py
@@ -141,14 +141,17 @@ class AutofixSolutionStep(AutofixPipelineStep):
         for solution_step in solution_output.solution_steps:
             relevant_code = solution_step.relevant_code_file
             if not relevant_code:
+                reproduction_urls.append(None)
                 continue
             repo_name = relevant_code.repo_name
             repo_name = self.context.autocorrect_repo_name(repo_name)
             if not repo_name:
+                reproduction_urls.append(None)
                 continue
             file_name = relevant_code.file_path
             file_name = self.context.autocorrect_file_path(path=file_name, repo_name=repo_name)
             if not file_name:
+                reproduction_urls.append(None)
                 continue
             repo_client = self.context.get_repo_client(repo_name)
             code_url = repo_client.get_file_url(file_name)

--- a/src/seer/automation/autofix/steps/solution_step.py
+++ b/src/seer/automation/autofix/steps/solution_step.py
@@ -143,13 +143,13 @@ class AutofixSolutionStep(AutofixPipelineStep):
             if not relevant_code:
                 reproduction_urls.append(None)
                 continue
-            repo_name: str | None = relevant_code.repo_name
-            repo_name = self.context.autocorrect_repo_name(repo_name)
+            repo_name = self.context.autocorrect_repo_name(relevant_code.repo_name)
             if not repo_name:
                 reproduction_urls.append(None)
                 continue
-            file_name: str | None = relevant_code.file_path
-            file_name = self.context.autocorrect_file_path(path=file_name, repo_name=repo_name)
+            file_name = self.context.autocorrect_file_path(
+                path=relevant_code.file_path, repo_name=repo_name
+            )
             if not file_name:
                 reproduction_urls.append(None)
                 continue

--- a/src/seer/automation/autofix/steps/solution_step.py
+++ b/src/seer/automation/autofix/steps/solution_step.py
@@ -137,7 +137,7 @@ class AutofixSolutionStep(AutofixPipelineStep):
                         )
 
     def _get_reproduction_urls(self, solution_output: SolutionOutput):
-        reproduction_urls = []
+        reproduction_urls: list[str | None] = []
         for solution_step in solution_output.solution_steps:
             relevant_code = solution_step.relevant_code_file
             if not relevant_code:

--- a/src/seer/automation/autofix/steps/solution_step.py
+++ b/src/seer/automation/autofix/steps/solution_step.py
@@ -143,12 +143,12 @@ class AutofixSolutionStep(AutofixPipelineStep):
             if not relevant_code:
                 reproduction_urls.append(None)
                 continue
-            repo_name = relevant_code.repo_name
+            repo_name: str | None = relevant_code.repo_name
             repo_name = self.context.autocorrect_repo_name(repo_name)
             if not repo_name:
                 reproduction_urls.append(None)
                 continue
-            file_name = relevant_code.file_path
+            file_name: str | None = relevant_code.file_path
             file_name = self.context.autocorrect_file_path(path=file_name, repo_name=repo_name)
             if not file_name:
                 reproduction_urls.append(None)

--- a/src/seer/automation/autofix/steps/solution_step.py
+++ b/src/seer/automation/autofix/steps/solution_step.py
@@ -8,7 +8,7 @@ from celery_app.app import celery_app
 from seer.automation.agent.models import Message
 from seer.automation.autofix.components.confidence import ConfidenceComponent, ConfidenceRequest
 from seer.automation.autofix.components.solution.component import SolutionComponent
-from seer.automation.autofix.components.solution.models import SolutionRequest
+from seer.automation.autofix.components.solution.models import SolutionOutput, SolutionRequest
 from seer.automation.autofix.config import (
     AUTOFIX_EXECUTION_HARD_TIME_LIMIT_SECS,
     AUTOFIX_EXECUTION_SOFT_TIME_LIMIT_SECS,
@@ -98,8 +98,11 @@ class AutofixSolutionStep(AutofixPipelineStep):
         if make_kill_signal() in state.signals:
             return
 
+        # create URLs to relevant code snippets
+        reproduction_urls = self._get_reproduction_urls(solution_output)
+
         # send solution result
-        self.context.event_manager.send_solution_result(solution_output)
+        self.context.event_manager.send_solution_result(solution_output, reproduction_urls)
         self.context.event_manager.add_log("Here is Autofix's proposed solution.")
 
         # confidence evaluation
@@ -132,3 +135,22 @@ class AutofixSolutionStep(AutofixPipelineStep):
                                 Message(role="assistant", content=confidence_output.question)
                             ],
                         )
+
+    def _get_reproduction_urls(self, solution_output: SolutionOutput):
+        reproduction_urls = []
+        for solution_step in solution_output.solution_steps:
+            relevant_code = solution_step.relevant_code_file
+            if not relevant_code:
+                continue
+            repo_name = relevant_code.repo_name
+            repo_name = self.context.autocorrect_repo_name(repo_name)
+            if not repo_name:
+                continue
+            file_name = relevant_code.file_path
+            file_name = self.context.autocorrect_file_path(path=file_name, repo_name=repo_name)
+            if not file_name:
+                continue
+            repo_client = self.context.get_repo_client(repo_name)
+            code_url = repo_client.get_file_url(file_name)
+            reproduction_urls.append(code_url)
+        return reproduction_urls

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -1092,3 +1092,16 @@ class RepoClient:
         branch_ref = self.repo.get_git_ref(f"heads/{branch_name}")
         branch_ref.edit(sha=new_commit.sha)
         return new_commit
+
+    def get_file_url(
+        self, file_path: str, start_line: int | None = None, end_line: int | None = None
+    ):
+        url = f"https://github.com/{self.repo_full_name}/blob/{self.base_commit_sha}/{file_path}"
+        if start_line:
+            url += f"#L{start_line}"
+        if end_line:
+            url += f"-L{end_line}"
+        return url
+
+    def get_commit_url(self, commit_sha: str):
+        return f"https://github.com/{self.repo_full_name}/commit/{commit_sha}"

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -1099,8 +1099,10 @@ class RepoClient:
         url = f"https://github.com/{self.repo_full_name}/blob/{self.base_commit_sha}/{file_path}"
         if start_line:
             url += f"#L{start_line}"
-        if end_line:
+        if start_line and end_line:
             url += f"-L{end_line}"
+        elif end_line:
+            url += f"#L{end_line}"
         return url
 
     def get_commit_url(self, commit_sha: str):

--- a/tests/automation/autofix/components/test_insight_sharing.py
+++ b/tests/automation/autofix/components/test_insight_sharing.py
@@ -14,6 +14,7 @@ from seer.automation.autofix.components.insight_sharing.models import (
     StacktraceSource,
     TraceEventSource,
 )
+from seer.automation.codebase.repo_client import RepoClient
 
 
 @pytest.fixture
@@ -26,6 +27,16 @@ def mock_context():
     repo_client.provider = "github"
     repo_client.base_branch = "main"
     repo_client.base_commit_sha = "abcd1234"
+    repo_client.repo_full_name = "test-repo"
+
+    repo_client.get_file_url.side_effect = (
+        lambda file_path, start_line=None, end_line=None: RepoClient.get_file_url(
+            repo_client, file_path, start_line, end_line
+        )
+    )
+    repo_client.get_commit_url.side_effect = lambda commit_sha: RepoClient.get_commit_url(
+        repo_client, commit_sha
+    )
 
     context.get_repo_client.return_value = repo_client
     context.get_file_contents.return_value = "sample file content"

--- a/tests/automation/autofix/test_autofix_event_manager.py
+++ b/tests/automation/autofix/test_autofix_event_manager.py
@@ -356,8 +356,14 @@ class TestAutofixEventManager:
     def test_send_solution_result(self, event_manager, state):
         # Create a mock solution output
         mock_solution_output = next(generate(SolutionOutput))
+        mock_code_urls = []
+        for step in mock_solution_output.solution_steps:
+            if step.relevant_code_file:
+                mock_code_urls.append(next(generate(str)))
+            else:
+                mock_code_urls.append(None)
 
-        event_manager.send_solution_result(mock_solution_output)
+        event_manager.send_solution_result(mock_solution_output, mock_code_urls)
 
         state_obj = state.get()
         # Check solution processing step
@@ -379,7 +385,14 @@ class TestAutofixEventManager:
         )
         assert solution_step is not None
         assert solution_step.status == AutofixStatus.COMPLETED
-        assert len(solution_step.solution) > 0
+        assert len(solution_step.solution) == len(mock_solution_output.solution_steps) + 1
+        for i, timeline_item in enumerate(solution_step.solution):
+            if i < len(mock_solution_output.solution_steps):
+                assert timeline_item.title == mock_solution_output.solution_steps[i].title
+                if not mock_solution_output.solution_steps[i].relevant_code_file:
+                    assert mock_code_urls[i] is None
+                else:
+                    assert timeline_item.relevant_code_file.url == mock_code_urls[i]
         assert state_obj.status == AutofixStatus.NEED_MORE_INFORMATION
 
     def test_set_selected_solution(self, event_manager, state):
@@ -392,7 +405,7 @@ class TestAutofixEventManager:
             ]
         )
 
-        event_manager.send_solution_result(SolutionOutput(solution_steps=[], summary=""))
+        event_manager.send_solution_result(SolutionOutput(solution_steps=[], summary=""), [])
         event_manager.set_selected_solution(payload)
 
         state_obj = state.get()


### PR DESCRIPTION
Generates urls for root cause and solution timeline items:
- in root cause, if there's a relevant code file, generates a url. If there seems to be a code snippet, try to fuzzy match it to the file content to get the line numbers
- in solution, if there's a relevant code file, generates a url. Does not attempt to match because this is mostly new code.