### PR TITLE
fix(autofix): Create preferences object on an Autofix run

### DIFF
--- a/src/seer/automation/preferences.py
+++ b/src/seer/automation/preferences.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 
-from seer.automation.models import SeerProjectPreference
+from seer.automation.models import RepoDefinition, SeerProjectPreference
 from seer.db import DbSeerProjectPreference, Session
 
 
@@ -40,3 +40,20 @@ def set_seer_project_preference(
         session.commit()
 
     return SetSeerProjectPreferenceResponse(preference=data.preference)
+
+
+def create_initial_seer_project_preference_from_repos(
+    *,
+    organization_id: int,
+    project_id: int,
+    repos: list[RepoDefinition],
+) -> SeerProjectPreference:
+    preference = SeerProjectPreference(
+        organization_id=organization_id,
+        project_id=project_id,
+        repositories=repos,
+    )
+    with Session() as session:
+        session.add(preference.to_db_model())
+        session.commit()
+    return preference

--- a/tests/automation/autofix/test_runs.py
+++ b/tests/automation/autofix/test_runs.py
@@ -9,6 +9,8 @@ from seer.automation.autofix.models import (
     IssueDetails,
 )
 from seer.automation.autofix.runs import create_initial_autofix_run
+from seer.automation.models import RepoDefinition, SeerProjectPreference
+from seer.automation.preferences import GetSeerProjectPreferenceRequest
 
 
 @pytest.fixture
@@ -33,6 +35,13 @@ class TestRuns:
         ).start()
         self.mock_autofix_continuation = patch(
             "seer.automation.autofix.runs.AutofixContinuation"
+        ).start()
+        # Patch preference retrieval and creation
+        self.mock_get_pref = patch(
+            "seer.automation.autofix.runs.get_seer_project_preference"
+        ).start()
+        self.mock_create_initial_pref = patch(
+            "seer.automation.autofix.runs.create_initial_seer_project_preference_from_repos"
         ).start()
         yield
         patch.stopall()
@@ -68,3 +77,48 @@ class TestRuns:
 
         # Assert that the event manager was not called due to the exception
         self.mock_event_manager.assert_not_called()
+
+    def test_create_initial_autofix_run_creates_preference_when_none(self, mock_request):
+        # Setup mock state
+        mock_state = MagicMock()
+        self.mock_continuation_state.new.return_value = mock_state
+
+        # No existing preference
+        self.mock_get_pref.return_value = MagicMock(preference=None)
+        # Prepare sample repos
+        sample_repos = [
+            RepoDefinition(
+                owner="ownerX",
+                name="repoX",
+                external_id="extX",
+                provider="github",
+            )
+        ]
+        # Ensure request.repos is initial list
+        mock_request.repos = [
+            RepoDefinition(owner="initial", name="repo", external_id="extInit", provider="github")
+        ]
+        # Setup creation return
+        pref = SeerProjectPreference(
+            organization_id=mock_request.organization_id,
+            project_id=mock_request.project_id,
+            repositories=sample_repos,
+        )
+        self.mock_create_initial_pref.return_value = pref
+
+        # Call the function
+        create_initial_autofix_run(mock_request)
+
+        # Verify preference retrieval was attempted
+        self.mock_get_pref.assert_called_once_with(
+            GetSeerProjectPreferenceRequest(project_id=mock_request.project_id)
+        )
+        # Verify new preference creation was called
+        self.mock_create_initial_pref.assert_called_once_with(
+            organization_id=mock_request.organization_id,
+            project_id=mock_request.project_id,
+            repos=mock_request.repos,
+        )
+        # Verify that state.update was used to set repos to created preference
+        ctx = mock_state.update.return_value.__enter__.return_value
+        assert ctx.request.repos == sample_repos


### PR DESCRIPTION
When you never visit the seer settings page or you have disabled integrations, the seer preferences object is never created. This means we just keep using the code mappings repos even when on the seer settings page there are no repos listed.

This PR makes sure the preferences object is created, even if the repo list is empty. This way what you see in settings matches the actual repos Autofix runs on. Code Mappings from now on will only be used on the first run only.


Fixes https://linear.app/getsentry/issue/AIML-395/fix-seer-preferences-creation