### PR TITLE
fix(autofix): Fix fetch auth + remove origin when pruning

### DIFF
--- a/src/seer/automation/codebase/repo_manager.py
+++ b/src/seer/automation/codebase/repo_manager.py
@@ -232,8 +232,10 @@ class RepoManager:
             # Clean any untracked files
             self.git_repo.git.clean("-fdx")
 
+            auth_url = self.repo_client.get_clone_url_with_auth()
+
             # Fetch only the specific commit
-            self.git_repo.git.execute(["git", "fetch", "--depth=1", "origin", commit_sha])
+            self.git_repo.git.execute(["git", "fetch", "--depth=1", auth_url, commit_sha])
 
             # Force checkout to avoid the "local changes" error
             self.git_repo.git.checkout(commit_sha, force=True)
@@ -361,6 +363,9 @@ class RepoManager:
         logger.info("Cleaning Git repository to minimal state")
         git_repo.git.execute(["git", "reflog", "expire", "--expire=now", "--all"])
         git_repo.git.execute(["git", "gc", "--prune=now", "--aggressive"])
+
+        # Remove all remotes
+        git_repo.git.execute(["git", "remote", "remove", "origin"])
 
     @sentry_sdk.trace
     def upload_to_gcs(self):

--- a/tests/automation/codebase/test_repo_manager.py
+++ b/tests/automation/codebase/test_repo_manager.py
@@ -86,11 +86,21 @@ def test_sync_success(repo_manager, mock_repo_client):
     mock_git_repo = MagicMock(spec=git.Repo)
     repo_manager.git_repo = mock_git_repo
 
+    mock_repo_client.get_clone_url_with_auth.return_value = (
+        "https://auth-token@github.com/test-owner/test-repo.git"
+    )
+
     repo_manager._sync_repo()
 
     # Verify git commands were called
     mock_git_repo.git.execute.assert_called_once_with(
-        ["git", "fetch", "--depth=1", "origin", mock_repo_client.base_commit_sha]
+        [
+            "git",
+            "fetch",
+            "--depth=1",
+            "https://auth-token@github.com/test-owner/test-repo.git",
+            mock_repo_client.base_commit_sha,
+        ]
     )
     mock_git_repo.git.checkout.assert_called_once_with(mock_repo_client.base_commit_sha, force=True)
 
@@ -699,6 +709,7 @@ def test_prune_repo_delete_refs(repo_manager):
         None,  # update-ref delete1
         None,  # reflog expire
         None,  # gc
+        None,  # remote remove
     ]
     mock_git.git = MagicMock()
     mock_git.git.execute.side_effect = side_effects
@@ -717,6 +728,7 @@ def test_prune_repo_show_ref_error(repo_manager):
         error,  # show-ref raises
         None,  # reflog expire
         None,  # gc
+        None,  # remote remove
     ]
     mock_git.git = MagicMock()
     mock_git.git.execute.side_effect = side_effects


### PR DESCRIPTION
Make an authenticated fetch when syncing. Also, remove the origin url when archiving during pruning.

Fixes SEER-15E