### PR TITLE
fix(autofix): Cap number of repos in prefs

### DIFF
--- a/src/seer/automation/autofix/runs.py
+++ b/src/seer/automation/autofix/runs.py
@@ -8,6 +8,8 @@ from seer.automation.autofix.state import ContinuationState
 from seer.automation.codebase.repo_client import RepoClient
 from seer.automation.models import RepoDefinition
 from seer.automation.preferences import (
+    MAX_REPOS_PER_PROJECT,
+    MAX_REPOS_TOTAL,
     GetSeerProjectPreferenceRequest,
     create_initial_seer_project_preference_from_repos,
     get_seer_project_preference,
@@ -54,15 +56,17 @@ def create_initial_autofix_run(request: AutofixRequest) -> DbState[AutofixContin
         preference = create_initial_seer_project_preference_from_repos(
             organization_id=request.organization_id,
             project_id=main_project_id,
-            repos=request.repos,
+            repos=request.repos[:MAX_REPOS_PER_PROJECT],
         )
 
     with state.update() as cur:
         if preference:
-            cur.request.repos = preference.repositories
+            cur.request.repos = preference.repositories[:MAX_REPOS_PER_PROJECT]
 
         try:
             for trace_connected_preference in trace_connected_preferences:
+                if len(cur.request.repos) >= MAX_REPOS_TOTAL:
+                    break
                 if trace_connected_preference:
                     for repo in trace_connected_preference.repositories:
                         if not any(

--- a/src/seer/automation/autofix/runs.py
+++ b/src/seer/automation/autofix/runs.py
@@ -8,7 +8,6 @@ from seer.automation.autofix.state import ContinuationState
 from seer.automation.codebase.repo_client import RepoClient
 from seer.automation.models import RepoDefinition
 from seer.automation.preferences import (
-    MAX_REPOS_PER_PROJECT,
     MAX_REPOS_TOTAL,
     GetSeerProjectPreferenceRequest,
     create_initial_seer_project_preference_from_repos,
@@ -56,12 +55,12 @@ def create_initial_autofix_run(request: AutofixRequest) -> DbState[AutofixContin
         preference = create_initial_seer_project_preference_from_repos(
             organization_id=request.organization_id,
             project_id=main_project_id,
-            repos=request.repos[:MAX_REPOS_PER_PROJECT],
+            repos=request.repos,
         )
 
     with state.update() as cur:
         if preference:
-            cur.request.repos = preference.repositories[:MAX_REPOS_PER_PROJECT]
+            cur.request.repos = preference.repositories
 
         try:
             for trace_connected_preference in trace_connected_preferences:

--- a/src/seer/automation/preferences.py
+++ b/src/seer/automation/preferences.py
@@ -3,6 +3,9 @@ from pydantic import BaseModel
 from seer.automation.models import RepoDefinition, SeerProjectPreference
 from seer.db import DbSeerProjectPreference, Session
 
+MAX_REPOS_PER_PROJECT = 8
+MAX_REPOS_TOTAL = 12
+
 
 class GetSeerProjectPreferenceRequest(BaseModel):
     project_id: int
@@ -19,6 +22,13 @@ def get_seer_project_preference(
         preference = session.get(DbSeerProjectPreference, data.project_id)
         if preference is None:
             return GetSeerProjectPreferenceResponse(preference=None)
+
+        # correct prefs saved with too many repos; should only affect old prefs before we added a check before saving
+        if len(preference.repositories) > MAX_REPOS_PER_PROJECT:
+            preference.repositories = preference.repositories[:MAX_REPOS_PER_PROJECT]
+            session.merge(preference)
+            session.commit()
+
         return GetSeerProjectPreferenceResponse(
             preference=SeerProjectPreference.from_db_model(preference)
         )

--- a/src/seer/automation/preferences.py
+++ b/src/seer/automation/preferences.py
@@ -46,6 +46,8 @@ def set_seer_project_preference(
     data: SetSeerProjectPreferenceRequest,
 ) -> SetSeerProjectPreferenceResponse:
     with Session() as session:
+        if len(data.preference.repositories) > MAX_REPOS_PER_PROJECT:
+            data.preference.repositories = data.preference.repositories[:MAX_REPOS_PER_PROJECT]
         session.merge(data.preference.to_db_model())
         session.commit()
 
@@ -61,7 +63,7 @@ def create_initial_seer_project_preference_from_repos(
     preference = SeerProjectPreference(
         organization_id=organization_id,
         project_id=project_id,
-        repositories=repos,
+        repositories=repos[:MAX_REPOS_PER_PROJECT],
     )
     with Session() as session:
         session.add(preference.to_db_model())


### PR DESCRIPTION
Cap number of repos per project on the backend to 8.
Including trace-connected repos, cap it at 12.