### PR TITLE
ci: Make the main branch check named differently

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -168,7 +168,7 @@ jobs:
           verbose: true
 
   finish:
-    name: Finish Tests
+    name: ${{ github.event_name == 'push' && 'Finish Tests (Main)' || 'Finish Tests' }}
     needs: [test, typecheck]
     runs-on: ubuntu-latest
     if: always()

--- a/gocd/templates/bash/check-github.sh
+++ b/gocd/templates/bash/check-github.sh
@@ -3,4 +3,4 @@
 /devinfra/scripts/checks/githubactions/checkruns.py \
   getsentry/seer \
   "${GO_REVISION_SEER_REPO}" \
-  "Finish Tests"
+  "Finish Tests (Main)"


### PR DESCRIPTION
The main branch's CI `Finish Tests` step will be named uniquely, and have GoCD check for it.