### PR TITLE
fix(assisted queries): Key name and log failures

### DIFF
--- a/src/seer/automation/assisted_query/assisted_query.py
+++ b/src/seer/automation/assisted_query/assisted_query.py
@@ -99,7 +99,17 @@ def create_query_from_natural_language(
         stats_period="48h",
         limit=200,
     )
-    field_values = field_values_response.get("field_values", {}) if field_values_response else {}
+
+    field_values = {}
+    if not field_values_response:
+        logger.warning("No response received from get_attribute_values call")
+    elif "values" not in field_values_response:
+        logger.warning(
+            "Response from get_attribute_values missing 'values' key. Response: %s",
+            field_values_response,
+        )
+    else:
+        field_values = field_values_response["values"]
 
     # Step 3: Generate final prompt based off of relevant fields and values
     fields_and_values_prompt = prompts.get_fields_and_values_prompt(

--- a/tests/automation/assisted_query/test_assisted_query.py
+++ b/tests/automation/assisted_query/test_assisted_query.py
@@ -215,3 +215,120 @@ class TestAssistedQuery:
             stats_period="48h",
             limit=200,
         )
+
+    @patch("seer.automation.assisted_query.assisted_query.RpcClient")
+    @patch("seer.automation.agent.client.LlmClient")
+    def test_create_query_from_natural_language_no_field_values(
+        self, mock_rpc_client_class, mock_llm_client_class
+    ):
+        mock_rpc_client = MagicMock()
+        mock_llm_client = MagicMock()
+
+        # Create responses for both test cases
+        first_call_response = LlmGenerateStructuredResponse(
+            RelevantFieldsResponse(fields=["span.op", "span.description"]),
+            metadata=LlmResponseMetadata(
+                model="gemini-2.0-flash-001",
+                provider_name=LlmProviderType.GEMINI,
+                usage=Usage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+            ),
+        )
+
+        second_call_response = LlmGenerateStructuredResponse(
+            ModelResponse(
+                explanation="This is a test explanation",
+                query="error",
+                stats_period="24h",
+                group_by=["project"],
+                visualization=[
+                    Chart(
+                        chart_type=1,
+                        y_axes=["Test y-axis 1", "Test y-axis 2"],
+                    )
+                ],
+                sort="-count",
+                confidence_score=0.95,
+            ),
+            metadata=LlmResponseMetadata(
+                model="gemini-2.0-flash-001",
+                provider_name=LlmProviderType.GEMINI,
+                usage=Usage(prompt_tokens=10, completion_tokens=10, total_tokens=20),
+            ),
+        )
+
+        # Set up responses for both test cases (4 total calls)
+        mock_llm_client.generate_structured.side_effect = [
+            first_call_response,
+            second_call_response,
+            first_call_response,
+            second_call_response,
+        ]
+
+        mock_llm_client_class.return_value = mock_llm_client
+        mock_rpc_client_class.return_value = mock_rpc_client
+
+        # Test case 1: field_values_response is None
+        mock_rpc_client.call.return_value = None
+
+        response = create_query_from_natural_language(
+            natural_language_query="Show me the slowest database operations in the last 24 hours",
+            cache_name="test-cache",
+            org_id=1,
+            project_ids=[1, 2],
+            rpc_client=mock_rpc_client,
+            llm_client=mock_llm_client,
+        )
+
+        assert isinstance(response, LlmGenerateStructuredResponse)
+        assert response.parsed == ModelResponse(
+            explanation="This is a test explanation",
+            query="error",
+            stats_period="24h",
+            group_by=["project"],
+            visualization=[
+                Chart(
+                    chart_type=1,
+                    y_axes=["Test y-axis 1", "Test y-axis 2"],
+                )
+            ],
+            sort="-count",
+            confidence_score=0.95,
+        )
+
+        # Verify that get_attribute_values was called with correct parameters
+        mock_rpc_client.call.assert_any_call(
+            "get_attribute_values",
+            org_id=1,
+            fields=["span.op", "span.description", "transaction"],
+            project_ids=[1, 2],
+            stats_period="48h",
+            limit=200,
+        )
+
+        # Test case 2: field_values_response is missing 'values' key
+        mock_rpc_client.call.return_value = {"some_other_key": "value"}
+
+        response = create_query_from_natural_language(
+            natural_language_query="Show me the slowest database operations in the last 24 hours",
+            cache_name="test-cache",
+            org_id=1,
+            project_ids=[1, 2],
+            rpc_client=mock_rpc_client,
+            llm_client=mock_llm_client,
+        )
+
+        assert isinstance(response, LlmGenerateStructuredResponse)
+        assert response.parsed == ModelResponse(
+            explanation="This is a test explanation",
+            query="error",
+            stats_period="24h",
+            group_by=["project"],
+            visualization=[
+                Chart(
+                    chart_type=1,
+                    y_axes=["Test y-axis 1", "Test y-axis 2"],
+                )
+            ],
+            sort="-count",
+            confidence_score=0.95,
+        )


### PR DESCRIPTION
- Used the wrong key name when reviewing response from seer_rpc
  - Used "fields_values" instead of "values"
- Previously was silently failing (defaults to {} or [] if the key is incorrect)
  - Now if it is the wrong key, then we log the issue rather than failing silently
    - Also if there are other issues with the RPC response
  - Note: we _can_ receive responses with no results depending on the keys passed in, but now we log them so we at least know if its a failure or not