### PR TITLE
fix(autofix-evals): Fix evals not using passed repo config

### DIFF
--- a/src/seer/automation/autofix/evaluations.py
+++ b/src/seer/automation/autofix/evaluations.py
@@ -75,7 +75,7 @@ def sync_run_evaluation_on_item(item: DatasetItemClient) -> AutofixContinuation:
     request = AutofixRequest.model_validate(input_data["request"])
 
     request.options = AutofixRequestOptions(
-        disable_codebase_indexing=True, disable_interactivity=True
+        disable_codebase_indexing=True, disable_interactivity=True, force_use_repos=True
     )
 
     state = create_initial_autofix_run(request)

--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -321,6 +321,7 @@ class AutofixRequestOptions(BaseModel):
     comment_on_pr_with_url: str | None = None
     disable_interactivity: bool = False
     auto_run_source: str | None = None
+    force_use_repos: bool = False
 
 
 class AutofixRequest(BaseModel):

--- a/src/seer/automation/autofix/runs.py
+++ b/src/seer/automation/autofix/runs.py
@@ -50,7 +50,7 @@ def create_initial_autofix_run(request: AutofixRequest) -> DbState[AutofixContin
     except Exception as e:
         logger.exception(e)
 
-    if not preference:
+    if not request.options.force_use_repos and not preference:
         # No preference found, create one from our list of code mapping repos.
         preference = create_initial_seer_project_preference_from_repos(
             organization_id=request.organization_id,
@@ -58,23 +58,24 @@ def create_initial_autofix_run(request: AutofixRequest) -> DbState[AutofixContin
             repos=request.repos,
         )
 
-    with state.update() as cur:
-        if preference:
-            cur.request.repos = preference.repositories
+    if not request.options.force_use_repos:
+        with state.update() as cur:
+            if preference:
+                cur.request.repos = preference.repositories
 
-        try:
-            for trace_connected_preference in trace_connected_preferences:
-                if len(cur.request.repos) >= MAX_REPOS_TOTAL:
-                    break
-                if trace_connected_preference:
-                    for repo in trace_connected_preference.repositories:
-                        if not any(
-                            existing_repo.external_id == repo.external_id
-                            for existing_repo in cur.request.repos
-                        ):
-                            cur.request.repos.append(repo)
-        except Exception as e:
-            logger.exception(e)
+            try:
+                for trace_connected_preference in trace_connected_preferences:
+                    if len(cur.request.repos) >= MAX_REPOS_TOTAL:
+                        break
+                    if trace_connected_preference:
+                        for repo in trace_connected_preference.repositories:
+                            if not any(
+                                existing_repo.external_id == repo.external_id
+                                for existing_repo in cur.request.repos
+                            ):
+                                cur.request.repos.append(repo)
+            except Exception as e:
+                logger.exception(e)
 
     continuation_state = ContinuationState(state.id)
 

--- a/tests/automation/autofix/test_autofix_evaluations.py
+++ b/tests/automation/autofix/test_autofix_evaluations.py
@@ -159,6 +159,7 @@ class TestSyncRunEvaluationOnItem:
         request_copy.options = request_copy.options.model_copy()
         request_copy.options.disable_codebase_indexing = True
         request_copy.options.disable_interactivity = True
+        request_copy.options.force_use_repos = True
         self.mock_create_initial_run.assert_called_once_with(request_copy)
 
         assert self.mock_root_cause_step.get_signature.called


### PR DESCRIPTION
This is so when we run evals we don't save the repo configuration nor read from it