### PR TITLE
fix(trace-queries): include thinking budget in llmclient

### DIFF
--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -1481,6 +1481,7 @@ class LlmClient:
         timeout: float | None = None,
         reasoning_effort: str | None = None,
         cache_name: str | None = None,
+        thinking_budget: int | None = None,
         use_local_endpoint: bool = False,
     ) -> LlmGenerateStructuredResponse[StructuredOutputType]:
         try:
@@ -1527,6 +1528,7 @@ class LlmClient:
                     temperature=temperature,
                     tools=cast(list[FunctionTool], tools),
                     cache_name=cache_name,
+                    thinking_budget=thinking_budget,
                     use_local_endpoint=use_local_endpoint,
                 )
             else:


### PR DESCRIPTION
- Include thinking budget param in LlmClient.generate_structured()

Tested locally again too:
<img width="822" alt="Screenshot 2025-05-16 at 10 58 35 AM" src="https://github.com/user-attachments/assets/e9c23137-c6ea-400b-94c4-b0f0bdf7bf39" />
