### PR TITLE
fix(autofix): Fix freezing LLM stream freezing the timeout check

### DIFF
--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -421,8 +421,8 @@ class OpenAiProvider:
         max_tokens: int | None = None,
         timeout: float | None = None,
         reasoning_effort: str | None = None,
-        first_token_timeout: float = 40.0,
-        inactivity_timeout: float = 20.0,
+        first_token_timeout: float,
+        inactivity_timeout: float,
     ) -> Iterator[Tuple[str, str] | ToolCall | Usage]:
         message_dicts, tool_dicts = self._prep_message_and_tools(
             messages=messages,
@@ -812,8 +812,8 @@ class AnthropicProvider:
         max_tokens: int | None = None,
         timeout: float | None = None,
         reasoning_effort: str | None = None,
-        first_token_timeout: float = 40.0,
-        inactivity_timeout: float = 20.0,
+        first_token_timeout: float,
+        inactivity_timeout: float,
     ) -> Iterator[Tuple[str, str] | ToolCall | Usage]:
         message_dicts, tool_dicts, system_prompt_block = self._prep_message_and_tools(
             messages=messages,
@@ -1135,8 +1135,8 @@ class GeminiProvider:
         tools: list[FunctionTool] | None = None,
         temperature: float | None = None,
         max_tokens: int | None = None,
-        first_token_timeout: float = 40.0,
-        inactivity_timeout: float = 20.0,
+        first_token_timeout: float,
+        inactivity_timeout: float,
     ) -> Iterator[str | ToolCall | Usage]:
         message_dicts, tool_dicts, system_prompt = self._prep_message_and_tools(
             messages=messages,

--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -108,16 +108,13 @@ def _iterate_with_timeouts(
             timeout_to_use = first_token_timeout if not first_token_received else inactivity_timeout
             try:
                 msg_type, item = q.get(timeout=timeout_to_use)
-
             except queue.Empty:
                 cancel_event.set()
                 if first_token_received:
-
                     raise LlmStreamInactivityTimeoutError(
                         f"Stream inactivity timeout after {timeout_to_use} seconds"
                     )
                 else:
-
                     raise LlmStreamFirstTokenTimeoutError(
                         f"Stream time to first token timeout after {timeout_to_use} seconds"
                     )


### PR DESCRIPTION
Handles the stream output in a separate "producer" thread for each llm text stream generator. This allows langfuse to still work as normal because the `@observe` decorator is outside the thread.

Tested locally with both pre-first token and post-first-token timeouts

![CleanShot 2025-05-17 at 02 14 42@2x](https://github.com/user-attachments/assets/5dec6e89-1f9f-4e8e-ad24-5dab1c1e0bfb)
![CleanShot 2025-05-17 at 02 15 08@2x](https://github.com/user-attachments/assets/17b9b600-407d-46c1-aee4-0428c56ed8ae)
