### PR TITLE
fix(repo client): Fix get git tree

### DIFF
--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -686,7 +686,7 @@ class RepoClient:
             return CompleteGitTree(tree)
 
         # Helper to hold file info with full path
-        TreeItem = namedtuple("TreeItem", ["path", "type", "size", "_orig"])
+        TreeItem = namedtuple("TreeItem", ["path", "type", "size", "orig"])
 
         def get_subtree_items(sha, parent_path=""):
             subtree = self.repo.get_git_tree(sha=sha, recursive=True)
@@ -729,7 +729,7 @@ class RepoClient:
         # by creating shallow copies with the correct path if needed
         fixed_elements = []
         for ti in all_items:
-            orig = ti._orig
+            orig = ti.orig
             # Only fix path if needed
             if getattr(orig, "path", None) != ti.path:
                 # Create a shallow copy with the correct path


### PR DESCRIPTION
The method to get the full git tree was broken on large repos. This was because when building the tree recursively, turns out tree items from that point only return paths relative to the subdirectory you made the request for. We needed to reconstruct the full path from the root of the repo. Previous testing of this method only compared the count of files, so this slipped through.

This should fix the bug where expand document (and other things like autocorrect, stack trace validation, and more) were breaking on large repos 🙏 

Tested with a script that compared git tree results and cloned repo results. Tried on `getsentry/seer` and `torvalds/linux`.