### PR TITLE
chore(anomaly-detection): separate out the AD null value error to track it separately with lower priority

### DIFF
--- a/src/seer/anomaly_detection/anomaly_detection.py
+++ b/src/seer/anomaly_detection/anomaly_detection.py
@@ -222,6 +222,12 @@ class AnomalyDetection(BaseModel):
         logger.info(f"Detecting anomalies for alert ID: {alert.id}")
         ts_external: List[TimeSeriesPoint] = []
         if alert.cur_window:
+            if alert.cur_window.value is None:
+                sentry_sdk.capture_message(
+                    "time_series_point_has_none_value",
+                    level="warning",
+                )
+                raise ClientError("Time series point has None value")
             ts_external.append(
                 TimeSeriesPoint(
                     timestamp=alert.cur_window.timestamp,

--- a/src/seer/anomaly_detection/models/external.py
+++ b/src/seer/anomaly_detection/models/external.py
@@ -20,7 +20,7 @@ class Anomaly(BaseModel):
 
 class TimeSeriesPoint(BaseModel):
     timestamp: float
-    value: float
+    value: Optional[float]
     anomaly: Optional[Anomaly] = None
 
 

--- a/tests/seer/anomaly_detection/test_anomaly_detection.py
+++ b/tests/seer/anomaly_detection/test_anomaly_detection.py
@@ -408,6 +408,18 @@ class TestAnomalyDetection(unittest.TestCase):
         assert isinstance(response.timeseries[0], TimeSeriesPoint)
         assert response.timeseries[0].timestamp == new_timestamp
 
+    def test_detect_anomalies_online_none_value(self):
+
+        new_timestamp = len(self.ts_values) + datetime.now().timestamp() + 1
+        context = AlertInSeer(id=0, cur_window=TimeSeriesPoint(timestamp=new_timestamp, value=None))
+
+        request = DetectAnomaliesRequest(
+            organization_id=0, project_id=0, config=self.config_15, context=context
+        )
+        with self.assertRaises(ClientError) as e:
+            AnomalyDetection().detect_anomalies(request=request)
+        assert "Time series point has None value" in str(e.exception)
+
     def test_detect_anomalies_combo(self):
 
         loaded_synthetic_data = convert_synthetic_ts(


### PR DESCRIPTION
The value error is too generic and overloaded as any of our end points can throw this error without any context. Also, the error from anomaly detection endpoint is high volume and low priority. So separating it out.