### PR TITLE
chore(autofix): Don't log error when creating file

### DIFF
--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -368,12 +368,6 @@ class BaseTools:
 
         return None
 
-    def _does_file_exist(self, path: str, repo_name: str) -> bool:
-        repo_client = self.context.get_repo_client(repo_name=repo_name, type=self.repo_client_type)
-        all_files = repo_client.get_valid_file_paths()
-        normalized_path = path.lstrip("./").lstrip("/")
-        return any(p == normalized_path for p in all_files)
-
     def _normalize_path(self, path: str) -> str:
         """
         Ensures paths don't start with a slash, but do end in one, such as example/path/
@@ -917,7 +911,8 @@ class BaseTools:
         if not file_text:
             return "Error: file_text is required for create command"
 
-        already_exists = self._does_file_exist(path=path, repo_name=repo_name)
+        repo_client = self.context.get_repo_client(repo_name=repo_name)
+        already_exists = repo_client.does_file_exist(path)
         if already_exists:
             return f"Error: Cannot create file '{path}' because it already exists."
 

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -368,6 +368,12 @@ class BaseTools:
 
         return None
 
+    def _does_file_exist(self, path: str, repo_name: str) -> bool:
+        repo_client = self.context.get_repo_client(repo_name=repo_name, type=self.repo_client_type)
+        all_files = repo_client.get_valid_file_paths()
+        normalized_path = path.lstrip("./").lstrip("/")
+        return any(p == normalized_path for p in all_files)
+
     def _normalize_path(self, path: str) -> str:
         """
         Ensures paths don't start with a slash, but do end in one, such as example/path/
@@ -911,8 +917,8 @@ class BaseTools:
         if not file_text:
             return "Error: file_text is required for create command"
 
-        existing_content = self.context.get_file_contents(path, repo_name=repo_name)
-        if existing_content is not None:
+        already_exists = self._does_file_exist(path=path, repo_name=repo_name)
+        if already_exists:
             return f"Error: Cannot create file '{path}' because it already exists."
 
         file_change = self._create_file_change(

--- a/src/seer/automation/codebase/repo_client.py
+++ b/src/seer/automation/codebase/repo_client.py
@@ -510,6 +510,14 @@ class RepoClient:
 
         return valid_file_paths
 
+    def does_file_exist(self, path: str, sha: str | None = None) -> bool:
+        if sha is None:
+            sha = self.base_commit_sha
+
+        all_files = self.get_valid_file_paths(sha)
+        normalized_path = path.lstrip("./").lstrip("/")
+        return normalized_path in all_files
+
     def get_example_commit_titles(self, max_commits: int = 5) -> list[str]:
         commits = self.repo.get_commits(sha=self.base_commit_sha)
         commit_list = list(commits[:max_commits])

--- a/tests/automation/autofix/test_autofix_event_manager.py
+++ b/tests/automation/autofix/test_autofix_event_manager.py
@@ -178,6 +178,7 @@ class TestAutofixEventManager:
         # Test case 4: Timeout while waiting for steps to be killed
         with patch.object(state, "get", wraps=state.get) as mock_get:
             mock_get.return_value = MagicMock(signals=[make_kill_signal()])
+            mock_time.reset_mock()
             mock_time.side_effect = [None] * 6  # Simulate timeout
             result = event_manager.reset_steps_to_point(0, None)
 

--- a/tests/automation/autofix/test_autofix_tools.py
+++ b/tests/automation/autofix/test_autofix_tools.py
@@ -970,7 +970,7 @@ class TestClaudeTools:
     def test_handle_create_command(self, autofix_tools: BaseTools):
         # Setup
         mock_repo_client = MagicMock()
-        mock_repo_client.get_valid_file_paths.return_value = ["a_different_file.py", "not_test.py"]
+        mock_repo_client.does_file_exist.return_value = False
         autofix_tools.context.get_repo_client.return_value = mock_repo_client
         kwargs = {"file_text": "new file content"}
 
@@ -1244,7 +1244,7 @@ class TestClaudeTools:
         file_text = "This is the new file content."
         kwargs = {"command": "create", "path": new_path, "file_text": file_text}
         mock_repo_client = MagicMock()
-        mock_repo_client.get_valid_file_paths.return_value = []
+        mock_repo_client.does_file_exist.return_value = False
         autofix_tools.context.get_repo_client.return_value = mock_repo_client
 
         # Mock autocorrect_repo_name to return the repo name
@@ -1254,8 +1254,6 @@ class TestClaudeTools:
         # Mock _attempt_fix_path to return None, simulating the path not existing
         # Note: This mock is on the context, as that's where _get_repo_name_and_path calls it
         autofix_tools._attempt_fix_path = MagicMock(return_value=None)
-        # Mock get_valid_file_paths to return an empty list (as the file shouldn't exist yet)
-        autofix_tools.context.get_valid_file_paths = MagicMock(return_value=[])
         # Mock _append_file_change to simulate successful application
         autofix_tools._append_file_change = MagicMock(return_value=True)
         # Mock make_file_patches to return a proper FilePatch for file creation
@@ -1292,10 +1290,7 @@ class TestClaudeTools:
 
             # Assert
             autofix_tools._attempt_fix_path.assert_called_once_with(new_path, repo_name)
-            autofix_tools.context.get_repo_client.assert_called_once_with(
-                repo_name=repo_name,
-                type=autofix_tools.repo_client_type,
-            )
+            autofix_tools.context.get_repo_client.assert_called_once_with(repo_name=repo_name)
             mock_make_patches.assert_called_once()
             autofix_tools._append_file_change.assert_called_once()
             assert "Change applied successfully" in result

--- a/tests/automation/autofix/test_autofix_tools.py
+++ b/tests/automation/autofix/test_autofix_tools.py
@@ -969,8 +969,10 @@ class TestClaudeTools:
 
     def test_handle_create_command(self, autofix_tools: BaseTools):
         # Setup
+        mock_repo_client = MagicMock()
+        mock_repo_client.get_valid_file_paths.return_value = ["a_different_file.py", "not_test.py"]
+        autofix_tools.context.get_repo_client.return_value = mock_repo_client
         kwargs = {"file_text": "new file content"}
-        autofix_tools.context.get_file_contents.return_value = None
 
         # Setup proper request.repos structure
         mock_repo = MagicMock(full_name="test/repo", external_id="123")
@@ -1241,6 +1243,9 @@ class TestClaudeTools:
         new_path = "new/path/to/create.py"
         file_text = "This is the new file content."
         kwargs = {"command": "create", "path": new_path, "file_text": file_text}
+        mock_repo_client = MagicMock()
+        mock_repo_client.get_valid_file_paths.return_value = []
+        autofix_tools.context.get_repo_client.return_value = mock_repo_client
 
         # Mock autocorrect_repo_name to return the repo name
         autofix_tools.context.autocorrect_repo_name.return_value = repo_name
@@ -1249,8 +1254,8 @@ class TestClaudeTools:
         # Mock _attempt_fix_path to return None, simulating the path not existing
         # Note: This mock is on the context, as that's where _get_repo_name_and_path calls it
         autofix_tools._attempt_fix_path = MagicMock(return_value=None)
-        # Mock get_file_contents to return None (as the file shouldn't exist yet)
-        autofix_tools.context.get_file_contents = MagicMock(return_value=None)
+        # Mock get_valid_file_paths to return an empty list (as the file shouldn't exist yet)
+        autofix_tools.context.get_valid_file_paths = MagicMock(return_value=[])
         # Mock _append_file_change to simulate successful application
         autofix_tools._append_file_change = MagicMock(return_value=True)
         # Mock make_file_patches to return a proper FilePatch for file creation
@@ -1286,19 +1291,14 @@ class TestClaudeTools:
             result = autofix_tools.handle_claude_tools(**kwargs)
 
             # Assert
-            # 1. Check that _attempt_fix_path was called for the new path (it should be)
             autofix_tools._attempt_fix_path.assert_called_once_with(new_path, repo_name)
-            # 2. Check that get_file_contents was called (by _handle_create_command)
-            autofix_tools.context.get_file_contents.assert_called_once_with(
-                new_path, repo_name=repo_name
+            autofix_tools.context.get_repo_client.assert_called_once_with(
+                repo_name=repo_name,
+                type=autofix_tools.repo_client_type,
             )
-            # 3. Check that make_file_patches was called
             mock_make_patches.assert_called_once()
-            # 4. Check that _append_file_change was called
             autofix_tools._append_file_change.assert_called_once()
-            # 5. Check that the result indicates success (not a path error)
             assert "Change applied successfully" in result
-            # 6. Check event manager logs and insights were called
             autofix_tools.context.event_manager.add_log.assert_called()
             autofix_tools.context.event_manager.send_insight.assert_called_once()
 

--- a/tests/automation/codebase/test_repo_client.py
+++ b/tests/automation/codebase/test_repo_client.py
@@ -988,3 +988,18 @@ class TestRepoClient:
         file_paths = sorted([item.path for item in tree.tree if item.type == "blob"])
         # Should include all files with correct full paths
         assert file_paths == ["dir1/dir2/file3.py", "dir1/file2.py", "file1.py"]
+
+    def test_does_file_exist(self, repo_client, mock_github):
+        repo_client.get_valid_file_paths = MagicMock(
+            return_value=["file1.py", "dir1/file2.py", "dir1/dir2/file3.py"]
+        )
+
+        file_path_1 = "file1.py"
+        file_path_2 = "/dir1/file2.py"
+        file_path_3 = "./dir1/dir2/file3.py"
+        file_path_4 = "dir1/dir2/file4.py"
+
+        assert repo_client.does_file_exist(file_path_1)
+        assert repo_client.does_file_exist(file_path_2)
+        assert repo_client.does_file_exist(file_path_3)
+        assert not repo_client.does_file_exist(file_path_4)


### PR DESCRIPTION
When creating a file via a tool, we called get_file_content to validate that the file didn't already exist. This had the disadvantages of:
1. Making an API call
2. Throwing an error to Sentry

This PR switches to get_valid_file_paths, which should already be cached in the coding step.