### PR TITLE
fix(autofix): Fix claude tools file creation logic

### DIFF
--- a/src/seer/automation/autofix/autofix_context.py
+++ b/src/seer/automation/autofix/autofix_context.py
@@ -148,6 +148,32 @@ class AutofixContext(PipelineContext):
 
         return file_contents
 
+    def does_file_exist(
+        self, path: str, repo_name: str | None = None, ignore_local_changes: bool = False
+    ) -> bool:
+        if len(self.repos) > 1:
+            if not repo_name:
+                raise ValueError("Repo name is required when there are multiple repos.")
+
+            if repo_name not in [repo.full_name for repo in self.repos]:
+                raise ValueError(f"Repo '{repo_name}' not found in the list of repos.")
+
+        repo_client = self.get_repo_client(repo_name)
+        does_exist_on_remote = repo_client.does_file_exist(path)
+        if does_exist_on_remote:
+            return True
+
+        if not ignore_local_changes:
+            cur_state = self.state.get()
+            repo_file_changes = cur_state.codebases[repo_client.repo_external_id].file_changes
+            current_file_changes = list(
+                filter(lambda x: x.path == path and x.change_type == "create", repo_file_changes)
+            )
+            if current_file_changes:
+                return True
+
+        return False
+
     def get_commit_history_for_file(
         self, path: str, repo_name: str | None = None, max_commits: int = 10
     ) -> list[str]:

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -359,8 +359,8 @@ class BaseTools:
         if not ignore_local_changes:
             cur_state = self.context.state.get()
             repo_file_changes = cur_state.codebases[repo_client.repo_external_id].file_changes
-            new_file_paths = [x.path for x in repo_file_changes if x.change_type == "create"]
-            all_files.extend(new_file_paths)
+            new_file_paths = {x.path for x in repo_file_changes if x.change_type == "create"}
+            all_files.update(new_file_paths)
 
         normalized_path = path.lstrip("./").lstrip("/")
         if not normalized_path:

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -17,7 +17,7 @@ from seer.automation.autofix.components.insight_sharing.models import (
     InsightSharingOutput,
     InsightSharingType,
 )
-from seer.automation.autofix.models import AutofixRequest
+from seer.automation.autofix.models import AutofixContinuation, AutofixRequest
 from seer.automation.autofix.tools.read_file_contents import read_file_contents
 from seer.automation.autofix.tools.ripgrep_search import run_ripgrep_in_repo
 from seer.automation.codebase.file_patches import make_file_patches
@@ -358,7 +358,11 @@ class BaseTools:
 
         if not ignore_local_changes:
             cur_state = self.context.state.get()
-            repo_file_changes = cur_state.codebases[repo_client.repo_external_id].file_changes
+            repo_file_changes = (
+                cur_state.codebases[repo_client.repo_external_id].file_changes
+                if isinstance(cur_state, AutofixContinuation)
+                else cur_state.file_changes
+            )
             new_file_paths = {x.path for x in repo_file_changes if x.change_type == "create"}
             all_files.update(new_file_paths)
 

--- a/src/seer/automation/codegen/codegen_context.py
+++ b/src/seer/automation/codegen/codegen_context.py
@@ -94,13 +94,6 @@ class CodegenContext(PipelineContext):
     def does_file_exist(
         self, path: str, repo_name: str | None = None, ignore_local_changes: bool = False
     ) -> bool:
-        if len(self.repos) > 1:
-            if not repo_name:
-                raise ValueError("Repo name is required when there are multiple repos.")
-
-            if repo_name not in [repo.full_name for repo in self.repos]:
-                raise ValueError(f"Repo '{repo_name}' not found in the list of repos.")
-
         repo_client = self.get_repo_client(repo_name)
         does_exist_on_remote = repo_client.does_file_exist(path)
         if does_exist_on_remote:
@@ -108,9 +101,10 @@ class CodegenContext(PipelineContext):
 
         if not ignore_local_changes:
             cur_state = self.state.get()
-            repo_file_changes = cur_state.codebases[repo_client.repo_external_id].file_changes
             current_file_changes = list(
-                filter(lambda x: x.path == path and x.change_type == "create", repo_file_changes)
+                filter(
+                    lambda x: x.path == path and x.change_type == "create", cur_state.file_changes
+                )
             )
             if current_file_changes:
                 return True

--- a/tests/automation/autofix/test_autofix_tools.py
+++ b/tests/automation/autofix/test_autofix_tools.py
@@ -1290,7 +1290,9 @@ class TestClaudeTools:
             result = autofix_tools.handle_claude_tools(**kwargs)
 
             # Assert
-            autofix_tools._attempt_fix_path.assert_called_once_with(new_path, repo_name)
+            autofix_tools._attempt_fix_path.assert_called_once_with(
+                new_path, repo_name, ignore_local_changes=False
+            )
             autofix_tools.context.does_file_exist.assert_called_once_with(
                 path=new_path, repo_name=repo_name, ignore_local_changes=False
             )
@@ -1317,7 +1319,9 @@ class TestClaudeTools:
 
         # Assert
         # Check that _attempt_fix_path was called
-        autofix_tools._attempt_fix_path.assert_called_once_with(nonexistent_path, repo_name)
+        autofix_tools._attempt_fix_path.assert_called_once_with(
+            nonexistent_path, repo_name, ignore_local_changes=False
+        )
         # Check that the result is the expected path error message
         assert (
             f"Error: The path you provided '{nonexistent_path}' does not exist in the repository '{repo_name}'."

--- a/tests/automation/autofix/test_autofix_tools.py
+++ b/tests/automation/autofix/test_autofix_tools.py
@@ -1145,8 +1145,13 @@ class TestClaudeTools:
 
     def test_handle_claude_tools_with_error(self, autofix_tools: BaseTools):
         # Setup
-        autofix_tools.context._get_repo_names = MagicMock(return_value=["test/repo"])
-        autofix_tools.context._attempt_fix_path = MagicMock(return_value=None)
+        mock_repo_client = MagicMock()
+        mock_repo_client.get_valid_file_paths.return_value = set()
+        autofix_tools.context.get_repo_client.return_value = mock_repo_client
+        autofix_tools.context.state.get.return_value = MagicMock(
+            request=MagicMock(codebases={"123": MagicMock(file_changes=[])}),
+            readable_repos=[MagicMock(full_name="test/repo")],
+        )
 
         # Test
         result = autofix_tools.handle_claude_tools(command="view", path="invalid/path")

--- a/tests/automation/autofix/test_autofix_tools.py
+++ b/tests/automation/autofix/test_autofix_tools.py
@@ -972,6 +972,7 @@ class TestClaudeTools:
         mock_repo_client = MagicMock()
         mock_repo_client.does_file_exist.return_value = False
         autofix_tools.context.get_repo_client.return_value = mock_repo_client
+        autofix_tools.context.does_file_exist.return_value = False
         kwargs = {"file_text": "new file content"}
 
         # Setup proper request.repos structure
@@ -1246,7 +1247,7 @@ class TestClaudeTools:
         mock_repo_client = MagicMock()
         mock_repo_client.does_file_exist.return_value = False
         autofix_tools.context.get_repo_client.return_value = mock_repo_client
-
+        autofix_tools.context.does_file_exist.return_value = False
         # Mock autocorrect_repo_name to return the repo name
         autofix_tools.context.autocorrect_repo_name.return_value = repo_name
         # Mock _get_repo_names to return a single repo
@@ -1290,7 +1291,9 @@ class TestClaudeTools:
 
             # Assert
             autofix_tools._attempt_fix_path.assert_called_once_with(new_path, repo_name)
-            autofix_tools.context.get_repo_client.assert_called_once_with(repo_name=repo_name)
+            autofix_tools.context.does_file_exist.assert_called_once_with(
+                path=new_path, repo_name=repo_name, ignore_local_changes=False
+            )
             mock_make_patches.assert_called_once()
             autofix_tools._append_file_change.assert_called_once()
             assert "Change applied successfully" in result


### PR DESCRIPTION
Two problems:
- we didn't read newly created files in `_attempt_fix_path`, so the agent could not edit its own files
- `does_file_exist` didn't take into account newly created files either, so we ended up with duplicates sometimes