### PR TITLE
fix(autofix): Help agent get root tree

### DIFF
--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -384,6 +384,10 @@ class BaseTools:
         """
         Ensures paths don't start with a slash, but do end in one, such as example/path/
         """
+        if (
+            path == "." or path == "./" or path == ""
+        ):  # different ways to represent the root directory
+            return ""
         normalized_path = path.strip("/") + "/" if path.strip("/") else ""
         return normalized_path
 


### PR DESCRIPTION
Sometimes the agent will call the tree tool with ".." to get the root tree, but we error out. We should just interpret it as the root (empty path)