### PR TITLE
Support multi-repo search in evals

### DIFF
--- a/src/seer/automation/codegen/evals/models.py
+++ b/src/seer/automation/codegen/evals/models.py
@@ -45,14 +45,9 @@ class EvalItemInput(BaseModel):
         if isinstance(self.repo, RepoDefinition):
             repo_definition = self.repo
         else:
-            repo_definition = RepoDefinition(
-                provider=self.repo.provider,
-                owner=self.repo.owner,
-                name=self.repo.name,
-                external_id=self.repo.external_id,
-            )
+            repo_definition = repo_info_to_repo_definition(self.repo)
         more_readable_repos = [
-            (repo_info_to_repo_definition(repo) if isinstance(repo, RepoInfo) else repo)
+            repo_info_to_repo_definition(repo) if isinstance(repo, RepoInfo) else repo
             for repo in self.more_readable_repos
         ]
         return CodegenRelevantWarningsRequest(


### PR DESCRIPTION
if `more_readable_repos` is in the input of the dataset item, the agent can search across the PR repo and these repos. would like to add getsentry/sentry for the seer PRs in our dataset