### PR TITLE
feat(autofix): Make duplicate tool call check order invariant for ags

### DIFF
--- a/src/seer/automation/autofix/autofix_agent.py
+++ b/src/seer/automation/autofix/autofix_agent.py
@@ -308,7 +308,13 @@ class AutofixAgent(LlmAgent):
                     if msg.tool_calls:
                         if any(
                             tool_call.function == existing_tool_call.function
-                            and tool_call.args == existing_tool_call.args
+                            and self.parse_tool_arguments(
+                                self.get_tool_by_name(tool_call.function), tool_call.args
+                            )
+                            == self.parse_tool_arguments(
+                                self.get_tool_by_name(existing_tool_call.function),
+                                existing_tool_call.args,
+                            )
                             and tool_call.id != existing_tool_call.id
                             for existing_tool_call in msg.tool_calls
                         ):

--- a/tests/automation/autofix/test_autofix_agent.py
+++ b/tests/automation/autofix/test_autofix_agent.py
@@ -391,6 +391,14 @@ def test_run_iteration_skips_duplicate_tool_calls(autofix_agent, run_config):
     If a tool call with the same function and args was already called, AutofixAgent should not call it again,
     and should append a message indicating the tool was not called again.
     """
+    autofix_agent.tools = [
+        FunctionTool(
+            name="fix_bug",
+            description="Fix the bug",
+            parameters=[],
+            fn=lambda: None,
+        )
+    ]
     # Prepare memory with a previous tool call result
     prev_tool_call = ToolCall(id="t1", function="fix_bug", args='{"line": 42}')
     autofix_agent.memory = [


### PR DESCRIPTION
When we check for duplicate tool calls, the order of the args shouldn't matter