### PR TITLE
feat(repo-manager): Scaling backfill time limit to repo size

### DIFF
--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -158,7 +158,7 @@ class BaseTools:
 
         end_time = time.time()
         logger.info(
-            f"Repositories became ready in {end_time - start_time} seconds for {len(self.repo_managers)} repositories"
+            f"Repositories were waited on for {end_time - start_time} seconds, {len(done)} ready, {len(not_done)} not ready"
         )
 
     def __enter__(self):


### PR DESCRIPTION
Scale the time limit for a repo according to it's size on metadata. So for example, a 5GB repo would have a `15 + (5 - 1) * 7 = 43 min` timeout. Any repo less than 1GB would have the default 15 minute timeout.