### PR TITLE
fix(autofix): Handle view directory in claude tools

### DIFF
--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -342,7 +342,12 @@ class BaseTools:
         return f"<did you mean>\n{joined}\n</did you mean>"
 
     def _attempt_fix_path(
-        self, path: str, repo_name: str, files_only: bool = False, ignore_local_changes: bool = True
+        self,
+        path: str,
+        repo_name: str,
+        files_only: bool = False,
+        directories_only: bool = False,
+        ignore_local_changes: bool = True,
     ) -> str | None:
         """
         Attempts to fix a path by checking if it exists in the repository as a path or directory.
@@ -351,6 +356,7 @@ class BaseTools:
             path: The path to autocorrect
             repo_name: The name of the repository to use for validation
             files_only: If True, only return valid file paths, not directory paths
+            directories_only: If True, only return valid directory paths, not file paths
         """
         repo_client = self.context.get_repo_client(repo_name=repo_name, type=self.repo_client_type)
         all_files = repo_client.get_valid_file_paths()
@@ -370,11 +376,12 @@ class BaseTools:
             return None
 
         for p in all_files:
-            if p.endswith(normalized_path):
-                # is a valid file path
+            is_valid_file_path = p.endswith(normalized_path)
+            is_valid_directory_path = p.startswith(normalized_path) and not is_valid_file_path
+
+            if not directories_only and is_valid_file_path:
                 return p
-            if not files_only and p.startswith(normalized_path):
-                # is a valid directory path
+            elif not files_only and is_valid_directory_path:
                 return normalized_path
 
         return None
@@ -841,7 +848,7 @@ class BaseTools:
             )
             if not does_file_exist:
                 directory_path = self._attempt_fix_path(
-                    path, repo_name, files_only=False, ignore_local_changes=False
+                    path, repo_name, directories_only=True, ignore_local_changes=False
                 )
                 if directory_path:
                     if view_range:

--- a/tests/automation/autofix/test_autofix_tools.py
+++ b/tests/automation/autofix/test_autofix_tools.py
@@ -943,6 +943,27 @@ class TestClaudeTools:
         # Assert
         assert "File not found" in result
 
+    def test_handle_view_command_directory(self, autofix_tools: BaseTools):
+        # Setup: simulate that the path is a directory, not a file
+        repo_name = "test/repo"
+        dir_path = "src/"
+        kwargs = {}  # no view_range
+
+        # Mock does_file_exist to return False (so it checks for directory)
+        autofix_tools.context.does_file_exist.return_value = False
+        # Mock _attempt_fix_path to return the directory path (indicating it's a valid directory)
+        autofix_tools._attempt_fix_path = MagicMock(return_value=dir_path)
+        # Mock tree to return a known value
+        expected_tree_output = "<directory_tree>\nmock tree\n</directory_tree>"
+        autofix_tools.tree = MagicMock(return_value=expected_tree_output)
+
+        # Test
+        result = autofix_tools._handle_view_command(kwargs, repo_name, dir_path)
+
+        # Assert
+        autofix_tools.tree.assert_called_once_with(dir_path, repo_name)
+        assert result == expected_tree_output
+
     def test_handle_str_replace_command(self, autofix_tools: BaseTools, test_state, test_repos):
         # Setup
         autofix_tools.context.get_file_contents.return_value = "old text"


### PR DESCRIPTION
If the claude view command was called with a directory path, our check was not working correctly. This should fix it and return the tree for the path. Should fix [SEER-145](https://sentry.sentry.io/issues/6593399718/).

Tacking on: modify `get_file_contents` in `AutofixContext` to not unnecessarily call GitHub if the file is a locally created file. Should fix [SEER-EB](https://sentry.sentry.io/issues/6045489887/).


