### PR TITLE
[ft] Add overwatch request endpoint

### DIFF
--- a/src/integrations/overwatch/overwatch_auth.py
+++ b/src/integrations/overwatch/overwatch_auth.py
@@ -1,0 +1,40 @@
+import hashlib
+import hmac
+import json
+
+import requests
+
+from seer.configuration import AppConfig
+from seer.dependency_injection import inject, injected
+
+
+def get_overwatch_auth_header(
+    request_data: bytes, signature_header: str, signature_secret: str
+) -> dict[str, str]:
+    """
+    `request_data` is expected to be utf-8 encoded.
+    """
+    hmac_ = hmac.new(signature_secret.encode("utf-8"), request_data, hashlib.sha256).hexdigest()
+    signature = f"sha256={hmac_}"
+    return {"Content-Type": "application/json", signature_header: signature}
+
+
+class OverwatchAuthentication:
+    @staticmethod
+    @inject
+    def authenticate_overwatch_app_install(
+        external_owner_id: str, config: AppConfig = injected
+    ) -> bool:
+        request = {"external_owner_id": external_owner_id}
+        request_data = json.dumps(request).encode("utf-8")
+        headers = get_overwatch_auth_header(
+            request_data,
+            signature_header="HTTP-X-GEN-AI-AUTH-SIGNATURE",
+            signature_secret=config.OVERWATCH_OUTGOING_SIGNATURE_SECRET,
+        )
+        response = requests.post(
+            url="https://overwatch.codecov.io/api/github/installation/check",
+            headers=headers,
+            data=request_data,
+        )
+        return response.json().get("is_valid", False) if response.status_code == 200 else False

--- a/src/seer/app.py
+++ b/src/seer/app.py
@@ -371,6 +371,7 @@ def codegen_pr_review_state_endpoint(
     raise NotImplementedError("PR Review state is not implemented yet.")
 
 
+# TODO: Remove this endpoint once we migrate all codecov requests to overwatch
 @json_api(blueprint, "/v1/automation/codecov-request")
 def codecov_request_endpoint(
     data: CodecovTaskRequest,
@@ -383,13 +384,23 @@ def codecov_request_endpoint(
         raise ConsentError(f"Invalid permissions for org {data.external_owner_id}.")
 
     if data.request_type == "pr-review":
-        return codegen_pr_review_endpoint(data.data)
+        return codegen_pr_review(data.data, is_codecov_request=True)
     elif data.request_type == "unit-tests":
         return codegen_unittest(data.data, is_codecov_request=True)
     elif data.request_type == "pr-closed":
         return codegen_pr_closed_endpoint(data.data)
     elif data.request_type == "retry-unit-tests":
         return codegen_retry_unittest(data.data)
+
+    raise ValueError(f"Unsupported request_type: {data.request_type}")
+
+
+@json_api(blueprint, "/v1/automation/overwatch-request")
+def overwatch_request_endpoint(
+    data: CodecovTaskRequest,
+) -> CodegenBaseResponse:
+    if data.request_type == "pr-review":
+        return codegen_pr_review(data.data, is_codecov_request=False)
 
     raise ValueError(f"Unsupported request_type: {data.request_type}")
 

--- a/src/seer/automation/codegen/pr_review_step.py
+++ b/src/seer/automation/codegen/pr_review_step.py
@@ -83,6 +83,7 @@ class PrReviewStep(CodegenStep):
                 CodePrReviewRequest(
                     diff=diff_content,
                 ),
+                is_codecov_request=self.request.is_codecov_request,
             )
         except ValueError as e:
             self.logger.error(f"Error generating pr review for {pr.url}: {e}")
@@ -91,8 +92,13 @@ class PrReviewStep(CodegenStep):
             publisher.publish_no_changes_required()
             return
 
+        # Handle None response
+        if generated_pr_review is None:
+            publisher.publish_no_changes_required()
+            return
+
         try:
-            publisher.publish_generated_pr_review(pr_review=generated_pr_review),
+            publisher.publish_generated_pr_review(pr_review=generated_pr_review)
         except ValueError as e:
             self.logger.error(f"Error publishing pr review for {pr.url}: {e}")
             return

--- a/src/seer/automation/codegen/tasks.py
+++ b/src/seer/automation/codegen/tasks.py
@@ -141,7 +141,9 @@ def get_unittest_state(request: CodegenUnitTestsStateRequest):
 
 
 @inject
-def codegen_pr_review(request: CodegenBaseRequest, app_config: AppConfig = injected):
+def codegen_pr_review(
+    request: CodegenBaseRequest, app_config: AppConfig = injected, is_codecov_request: bool = True
+):
     state = create_initial_pr_review_run(request)
 
     cur_state = state.get()
@@ -150,6 +152,7 @@ def codegen_pr_review(request: CodegenBaseRequest, app_config: AppConfig = injec
         run_id=cur_state.run_id,
         pr_id=request.pr_id,
         repo_definition=request.repo,
+        is_codecov_request=is_codecov_request,
     )
 
     PrReviewStep.get_signature(

--- a/src/seer/configuration.py
+++ b/src/seer/configuration.py
@@ -72,7 +72,7 @@ class AppConfig(BaseModel):
     LANGFUSE_HOST: str = ""
 
     API_PUBLIC_KEY_SECRET_ID: str = ""
-    JSON_API_SHARED_SECRETS: ParseList = ["some-secret-to-seer", "some-secret-from-seer"]
+    JSON_API_SHARED_SECRETS: ParseList = Field(default_factory=list)
     IGNORE_API_AUTH: ParseBool = False  # Used for both API Tokens and RPC Secrets
 
     TORCH_NUM_THREADS: ParseInt = 0

--- a/src/seer/configuration.py
+++ b/src/seer/configuration.py
@@ -72,7 +72,7 @@ class AppConfig(BaseModel):
     LANGFUSE_HOST: str = ""
 
     API_PUBLIC_KEY_SECRET_ID: str = ""
-    JSON_API_SHARED_SECRETS: ParseList = Field(default_factory=list)
+    JSON_API_SHARED_SECRETS: ParseList = ["some-secret-to-seer", "some-secret-from-seer"]
     IGNORE_API_AUTH: ParseBool = False  # Used for both API Tokens and RPC Secrets
 
     TORCH_NUM_THREADS: ParseInt = 0

--- a/tests/automation/codegen/test_pr_review.py
+++ b/tests/automation/codegen/test_pr_review.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from seer.automation.codebase.repo_client import RepoClientType
-from seer.automation.codegen.models import CodePrReviewOutput, CodePrReviewRequest
+from seer.automation.codegen.models import CodePrReviewRequest
 from seer.automation.codegen.pr_review_step import PrReviewStep, PrReviewStepRequest
 from seer.automation.models import RepoDefinition
 
@@ -48,8 +48,7 @@ class TestPrReview(unittest.TestCase):
 
         # Verify is_codecov_request is passed correctly
         mock_invoke_pr_review_component.assert_called_once()
-        is_codecov_param = mock_invoke_pr_review_component.call_args[1].get("is_codecov_request")
-        assert is_codecov_param is False
+        mock_invoke_pr_review_component.assert_called_with(actual_request, is_codecov_request=False)
 
     @patch("seer.automation.codegen.pr_review_coding_component.PrReviewCodingComponent.invoke")
     @patch("seer.automation.pipeline.PipelineStep", new_callable=MagicMock)
@@ -91,114 +90,4 @@ class TestPrReview(unittest.TestCase):
 
         # Verify is_codecov_request is passed correctly
         mock_invoke_pr_review_component.assert_called_once()
-        is_codecov_param = mock_invoke_pr_review_component.call_args[1].get("is_codecov_request")
-        assert is_codecov_param is True
-
-    @patch("seer.automation.codegen.pr_review_coding_component.PrReviewCodingComponent.invoke")
-    @patch("seer.automation.pipeline.PipelineStep", new_callable=MagicMock)
-    @patch("seer.automation.codegen.step.CodegenStep._instantiate_context", new_callable=MagicMock)
-    def test_handle_no_changes_required_when_value_error(
-        self, mock_instantiate_context, _, mock_invoke_pr_review_component
-    ):
-        mock_repo_client = MagicMock()
-        mock_pr = MagicMock()
-        mock_diff_content = "diff content"
-        mock_context = MagicMock()
-        mock_context.get_repo_client.return_value = mock_repo_client
-        mock_repo_client.repo.get_pull.return_value = mock_pr
-        mock_repo_client.get_pr_diff_content.return_value = mock_diff_content
-
-        # Have the component invoke raise a ValueError
-        mock_invoke_pr_review_component.side_effect = ValueError("Test error")
-
-        request_data = {
-            "run_id": 1,
-            "pr_id": 123,
-            "repo_definition": RepoDefinition(
-                name="repo1", owner="owner1", provider="github", external_id="123123"
-            ),
-            "is_codecov_request": False,
-        }
-        request = PrReviewStepRequest(**request_data)
-        step = PrReviewStep(request=request)
-        step.context = mock_context
-
-        step.invoke()
-
-        # Verify that publish_no_changes_required is called
-        mock_repo_client.publish_no_changes_required.assert_called_once()
-
-    @patch("seer.automation.codegen.pr_review_coding_component.PrReviewCodingComponent.invoke")
-    @patch("seer.automation.pipeline.PipelineStep", new_callable=MagicMock)
-    @patch("seer.automation.codegen.step.CodegenStep._instantiate_context", new_callable=MagicMock)
-    def test_handle_empty_generated_output(
-        self, mock_instantiate_context, _, mock_invoke_pr_review_component
-    ):
-        mock_repo_client = MagicMock()
-        mock_pr = MagicMock()
-        mock_diff_content = "diff content"
-        mock_context = MagicMock()
-        mock_context.get_repo_client.return_value = mock_repo_client
-        mock_repo_client.repo.get_pull.return_value = mock_pr
-        mock_repo_client.get_pr_diff_content.return_value = mock_diff_content
-
-        # Component returns None (no changes required)
-        mock_invoke_pr_review_component.return_value = None
-
-        request_data = {
-            "run_id": 1,
-            "pr_id": 123,
-            "repo_definition": RepoDefinition(
-                name="repo1", owner="owner1", provider="github", external_id="123123"
-            ),
-            "is_codecov_request": False,
-        }
-        request = PrReviewStepRequest(**request_data)
-        step = PrReviewStep(request=request)
-        step.context = mock_context
-
-        step.invoke()
-
-        # Verify that publish_no_changes_required is called
-        mock_repo_client.publish_no_changes_required.assert_called_once()
-
-    @patch("seer.automation.codegen.pr_review_coding_component.PrReviewCodingComponent.invoke")
-    @patch("seer.automation.pipeline.PipelineStep", new_callable=MagicMock)
-    @patch("seer.automation.codegen.step.CodegenStep._instantiate_context", new_callable=MagicMock)
-    def test_successful_pr_review_publication(
-        self, mock_instantiate_context, _, mock_invoke_pr_review_component
-    ):
-        mock_repo_client = MagicMock()
-        mock_pr = MagicMock()
-        mock_diff_content = "diff content"
-        mock_context = MagicMock()
-        mock_context.get_repo_client.return_value = mock_repo_client
-        mock_repo_client.repo.get_pull.return_value = mock_pr
-        mock_repo_client.get_pr_diff_content.return_value = mock_diff_content
-
-        # Component returns a valid PR review
-        mock_generated_review = MagicMock(spec=CodePrReviewOutput)
-        mock_invoke_pr_review_component.return_value = mock_generated_review
-
-        request_data = {
-            "run_id": 1,
-            "pr_id": 123,
-            "repo_definition": RepoDefinition(
-                name="repo1", owner="owner1", provider="github", external_id="123123"
-            ),
-            "is_codecov_request": False,
-        }
-        request = PrReviewStepRequest(**request_data)
-        step = PrReviewStep(request=request)
-        step.context = mock_context
-
-        step.invoke()
-
-        # Verify that publish_generated_pr_review is called with the correct review
-        mock_repo_client.publish_generated_pr_review.assert_called_once_with(
-            pr_review=mock_generated_review
-        )
-
-        # Verify event manager methods were called
-        mock_context.event_manager.mark_running.assert_called_once()
-        mock_context.event_manager.mark_completed.assert_called_once()
+        mock_invoke_pr_review_component.assert_called_with(actual_request, is_codecov_request=True)

--- a/tests/automation/codegen/test_pr_review.py
+++ b/tests/automation/codegen/test_pr_review.py
@@ -1,7 +1,8 @@
 import unittest
 from unittest.mock import MagicMock, patch
 
-from seer.automation.codegen.models import CodePrReviewRequest
+from seer.automation.codebase.repo_client import RepoClientType
+from seer.automation.codegen.models import CodePrReviewOutput, CodePrReviewRequest
 from seer.automation.codegen.pr_review_step import PrReviewStep, PrReviewStepRequest
 from seer.automation.models import RepoDefinition
 
@@ -10,7 +11,9 @@ class TestPrReview(unittest.TestCase):
     @patch("seer.automation.codegen.pr_review_coding_component.PrReviewCodingComponent.invoke")
     @patch("seer.automation.pipeline.PipelineStep", new_callable=MagicMock)
     @patch("seer.automation.codegen.step.CodegenStep._instantiate_context", new_callable=MagicMock)
-    def test_invoke_happy_path(self, mock_instantiate_context, _, mock_invoke_unit_test_component):
+    def test_invoke_with_non_codecov_request(
+        self, mock_instantiate_context, _, mock_invoke_pr_review_component
+    ):
         mock_repo_client = MagicMock()
         mock_pr = MagicMock()
         mock_diff_content = "diff content"
@@ -25,6 +28,7 @@ class TestPrReview(unittest.TestCase):
             "repo_definition": RepoDefinition(
                 name="repo1", owner="owner1", provider="github", external_id="123123"
             ),
+            "is_codecov_request": False,
         }
         request = PrReviewStepRequest(**request_data)
         step = PrReviewStep(request=request)
@@ -32,11 +36,169 @@ class TestPrReview(unittest.TestCase):
 
         step.invoke()
 
-        mock_context.get_repo_client.assert_called_once()
+        mock_context.get_repo_client.assert_called_once_with(
+            repo_name="owner1/repo1", type=RepoClientType.WRITE
+        )
         mock_repo_client.repo.get_pull.assert_called_once_with(request.pr_id)
         mock_repo_client.get_pr_diff_content.assert_called_once_with(mock_pr.url)
 
-        actual_request = mock_invoke_unit_test_component.call_args[0][0]
-
+        actual_request = mock_invoke_pr_review_component.call_args[0][0]
         assert isinstance(actual_request, CodePrReviewRequest)
         assert actual_request.diff == mock_diff_content
+
+        # Verify is_codecov_request is passed correctly
+        mock_invoke_pr_review_component.assert_called_once()
+        is_codecov_param = mock_invoke_pr_review_component.call_args[1].get("is_codecov_request")
+        assert is_codecov_param is False
+
+    @patch("seer.automation.codegen.pr_review_coding_component.PrReviewCodingComponent.invoke")
+    @patch("seer.automation.pipeline.PipelineStep", new_callable=MagicMock)
+    @patch("seer.automation.codegen.step.CodegenStep._instantiate_context", new_callable=MagicMock)
+    def test_invoke_with_codecov_request(
+        self, mock_instantiate_context, _, mock_invoke_pr_review_component
+    ):
+        mock_repo_client = MagicMock()
+        mock_pr = MagicMock()
+        mock_diff_content = "diff content"
+        mock_context = MagicMock()
+        mock_context.get_repo_client.return_value = mock_repo_client
+        mock_repo_client.repo.get_pull.return_value = mock_pr
+        mock_repo_client.get_pr_diff_content.return_value = mock_diff_content
+
+        request_data = {
+            "run_id": 1,
+            "pr_id": 123,
+            "repo_definition": RepoDefinition(
+                name="repo1", owner="owner1", provider="github", external_id="123123"
+            ),
+            "is_codecov_request": True,
+        }
+        request = PrReviewStepRequest(**request_data)
+        step = PrReviewStep(request=request)
+        step.context = mock_context
+
+        step.invoke()
+
+        mock_context.get_repo_client.assert_called_once_with(
+            repo_name="owner1/repo1", type=RepoClientType.CODECOV_PR_REVIEW
+        )
+        mock_repo_client.repo.get_pull.assert_called_once_with(request.pr_id)
+        mock_repo_client.get_pr_diff_content.assert_called_once_with(mock_pr.url)
+
+        actual_request = mock_invoke_pr_review_component.call_args[0][0]
+        assert isinstance(actual_request, CodePrReviewRequest)
+        assert actual_request.diff == mock_diff_content
+
+        # Verify is_codecov_request is passed correctly
+        mock_invoke_pr_review_component.assert_called_once()
+        is_codecov_param = mock_invoke_pr_review_component.call_args[1].get("is_codecov_request")
+        assert is_codecov_param is True
+
+    @patch("seer.automation.codegen.pr_review_coding_component.PrReviewCodingComponent.invoke")
+    @patch("seer.automation.pipeline.PipelineStep", new_callable=MagicMock)
+    @patch("seer.automation.codegen.step.CodegenStep._instantiate_context", new_callable=MagicMock)
+    def test_handle_no_changes_required_when_value_error(
+        self, mock_instantiate_context, _, mock_invoke_pr_review_component
+    ):
+        mock_repo_client = MagicMock()
+        mock_pr = MagicMock()
+        mock_diff_content = "diff content"
+        mock_context = MagicMock()
+        mock_context.get_repo_client.return_value = mock_repo_client
+        mock_repo_client.repo.get_pull.return_value = mock_pr
+        mock_repo_client.get_pr_diff_content.return_value = mock_diff_content
+
+        # Have the component invoke raise a ValueError
+        mock_invoke_pr_review_component.side_effect = ValueError("Test error")
+
+        request_data = {
+            "run_id": 1,
+            "pr_id": 123,
+            "repo_definition": RepoDefinition(
+                name="repo1", owner="owner1", provider="github", external_id="123123"
+            ),
+            "is_codecov_request": False,
+        }
+        request = PrReviewStepRequest(**request_data)
+        step = PrReviewStep(request=request)
+        step.context = mock_context
+
+        step.invoke()
+
+        # Verify that publish_no_changes_required is called
+        mock_repo_client.publish_no_changes_required.assert_called_once()
+
+    @patch("seer.automation.codegen.pr_review_coding_component.PrReviewCodingComponent.invoke")
+    @patch("seer.automation.pipeline.PipelineStep", new_callable=MagicMock)
+    @patch("seer.automation.codegen.step.CodegenStep._instantiate_context", new_callable=MagicMock)
+    def test_handle_empty_generated_output(
+        self, mock_instantiate_context, _, mock_invoke_pr_review_component
+    ):
+        mock_repo_client = MagicMock()
+        mock_pr = MagicMock()
+        mock_diff_content = "diff content"
+        mock_context = MagicMock()
+        mock_context.get_repo_client.return_value = mock_repo_client
+        mock_repo_client.repo.get_pull.return_value = mock_pr
+        mock_repo_client.get_pr_diff_content.return_value = mock_diff_content
+
+        # Component returns None (no changes required)
+        mock_invoke_pr_review_component.return_value = None
+
+        request_data = {
+            "run_id": 1,
+            "pr_id": 123,
+            "repo_definition": RepoDefinition(
+                name="repo1", owner="owner1", provider="github", external_id="123123"
+            ),
+            "is_codecov_request": False,
+        }
+        request = PrReviewStepRequest(**request_data)
+        step = PrReviewStep(request=request)
+        step.context = mock_context
+
+        step.invoke()
+
+        # Verify that publish_no_changes_required is called
+        mock_repo_client.publish_no_changes_required.assert_called_once()
+
+    @patch("seer.automation.codegen.pr_review_coding_component.PrReviewCodingComponent.invoke")
+    @patch("seer.automation.pipeline.PipelineStep", new_callable=MagicMock)
+    @patch("seer.automation.codegen.step.CodegenStep._instantiate_context", new_callable=MagicMock)
+    def test_successful_pr_review_publication(
+        self, mock_instantiate_context, _, mock_invoke_pr_review_component
+    ):
+        mock_repo_client = MagicMock()
+        mock_pr = MagicMock()
+        mock_diff_content = "diff content"
+        mock_context = MagicMock()
+        mock_context.get_repo_client.return_value = mock_repo_client
+        mock_repo_client.repo.get_pull.return_value = mock_pr
+        mock_repo_client.get_pr_diff_content.return_value = mock_diff_content
+
+        # Component returns a valid PR review
+        mock_generated_review = MagicMock(spec=CodePrReviewOutput)
+        mock_invoke_pr_review_component.return_value = mock_generated_review
+
+        request_data = {
+            "run_id": 1,
+            "pr_id": 123,
+            "repo_definition": RepoDefinition(
+                name="repo1", owner="owner1", provider="github", external_id="123123"
+            ),
+            "is_codecov_request": False,
+        }
+        request = PrReviewStepRequest(**request_data)
+        step = PrReviewStep(request=request)
+        step.context = mock_context
+
+        step.invoke()
+
+        # Verify that publish_generated_pr_review is called with the correct review
+        mock_repo_client.publish_generated_pr_review.assert_called_once_with(
+            pr_review=mock_generated_review
+        )
+
+        # Verify event manager methods were called
+        mock_context.event_manager.mark_running.assert_called_once()
+        mock_context.event_manager.mark_completed.assert_called_once()

--- a/tests/automation/codegen/test_pr_review_coding_component.py
+++ b/tests/automation/codegen/test_pr_review_coding_component.py
@@ -62,8 +62,12 @@ class TestPrReviewCodingComponent(unittest.TestCase):
         mock_pr_description = MagicMock()
         mock_pr_description.parsed = MagicMock(spec=CodePrReviewOutput.PrDescription)
 
+        # Create mock comment with suggestion attribute
+        mock_comment = MagicMock(spec=CodePrReviewOutput.Comment)
+        mock_comment.suggestion = None
+
         mock_formatted_response = MagicMock()
-        mock_formatted_response.parsed = [MagicMock(spec=CodePrReviewOutput.Comment)]
+        mock_formatted_response.parsed = [mock_comment]
 
         mock_llm_client.generate_structured.side_effect = [
             mock_pr_description,
@@ -93,8 +97,12 @@ class TestPrReviewCodingComponent(unittest.TestCase):
         mock_pr_description = MagicMock()
         mock_pr_description.parsed = MagicMock(spec=CodePrReviewOutput.PrDescription)
 
+        # Create mock comment with suggestion attribute
+        mock_comment = MagicMock(spec=CodePrReviewOutput.Comment)
+        mock_comment.suggestion = None
+
         mock_formatted_response = MagicMock()
-        mock_formatted_response.parsed = [MagicMock(spec=CodePrReviewOutput.Comment)]
+        mock_formatted_response.parsed = [mock_comment]
 
         mock_llm_client.generate_structured.side_effect = [
             mock_pr_description,

--- a/tests/integrations/test_overwatch_auth.py
+++ b/tests/integrations/test_overwatch_auth.py
@@ -1,0 +1,78 @@
+import hashlib
+import hmac
+import json
+import unittest
+from unittest.mock import MagicMock, patch
+
+from integrations.overwatch.overwatch_auth import OverwatchAuthentication, get_overwatch_auth_header
+
+
+class DummyConfigOutgoing:
+    OVERWATCH_OUTGOING_SIGNATURE_SECRET = "secret_outgoing"
+
+
+class TestOverwatchAuth(unittest.TestCase):
+    def test_get_overwatch_auth_header(self):
+        request_data = json.dumps({"test": "data"}).encode("utf-8")
+        signature_header = "X-Test-Signature"
+        signature_secret = "test_secret"
+
+        # Calculate expected signature
+        expected_hmac = hmac.new(
+            signature_secret.encode("utf-8"), request_data, hashlib.sha256
+        ).hexdigest()
+        expected_signature = f"sha256={expected_hmac}"
+
+        # Get actual header
+        header = get_overwatch_auth_header(request_data, signature_header, signature_secret)
+
+        # Verify header contents
+        self.assertEqual(header["Content-Type"], "application/json")
+        self.assertEqual(header[signature_header], expected_signature)
+
+    @patch("integrations.overwatch.overwatch_auth.requests.post")
+    def test_authenticate_overwatch_app_install_valid(self, mock_post):
+        external_owner_id = "owner"
+        data = {"external_owner_id": external_owner_id}
+        request_data = json.dumps(data).encode("utf-8")
+        key = DummyConfigOutgoing.OVERWATCH_OUTGOING_SIGNATURE_SECRET
+        expected_signature = (
+            "sha256=" + hmac.new(key.encode("utf-8"), request_data, hashlib.sha256).hexdigest()
+        )
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"is_valid": True}
+        mock_post.return_value = mock_resp
+
+        valid = OverwatchAuthentication.authenticate_overwatch_app_install(
+            external_owner_id, config=DummyConfigOutgoing()
+        )
+        self.assertTrue(valid)
+        args, kwargs = mock_post.call_args
+        headers = kwargs.get("headers", {})
+        self.assertEqual(headers.get("HTTP-X-GEN-AI-AUTH-SIGNATURE"), expected_signature)
+
+    @patch("integrations.overwatch.overwatch_auth.requests.post")
+    def test_authenticate_overwatch_app_install_non_200(self, mock_post):
+        external_owner_id = "owner"
+        mock_resp = MagicMock()
+        mock_resp.status_code = 400
+        mock_post.return_value = mock_resp
+
+        valid = OverwatchAuthentication.authenticate_overwatch_app_install(
+            external_owner_id, config=DummyConfigOutgoing()
+        )
+        self.assertFalse(valid)
+
+    @patch("integrations.overwatch.overwatch_auth.requests.post")
+    def test_authenticate_overwatch_app_install_invalid_response(self, mock_post):
+        external_owner_id = "owner"
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"is_valid": False}
+        mock_post.return_value = mock_resp
+
+        valid = OverwatchAuthentication.authenticate_overwatch_app_install(
+            external_owner_id, config=DummyConfigOutgoing()
+        )
+        self.assertFalse(valid)


### PR DESCRIPTION
This will enable AI PR review (and eventually unit test gen) for Sentry Prevent. 

The goal here is to support 2 apps, Codecov AI, and Autofix(Seer by Sentry). `Overwatch`, which is already setup to communicate with seer, will send requests to initiate reviews and unit tests by hitting this endpoint. 

Post migration on Codecov's side, we can remove the `codecov-request` endpoint and use `overwatch-request` for all our needs. A refactoring effort will also be required to change all our variable and class names at that time. 

![Screenshot 2025-05-21 at 10 29 06 AM](https://github.com/user-attachments/assets/62973680-7ce4-4cbe-a55e-1bff29a05499)
