### PR TITLE
feat(autofix): Receive logs from sentry in initial request

### DIFF
--- a/src/seer/automation/autofix/components/root_cause/models.py
+++ b/src/seer/automation/autofix/components/root_cause/models.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, validator
 
 from seer.automation.agent.models import Message
 from seer.automation.component import BaseComponentOutput, BaseComponentRequest
-from seer.automation.models import EventDetails, Profile, TraceTree
+from seer.automation.models import EventDetails, Logs, Profile, TraceTree
 from seer.automation.summarize.issue import IssueSummary
 
 
@@ -77,6 +77,7 @@ class RootCauseAnalysisRequest(BaseComponentRequest):
     initial_memory: list[Message] = []
     profile: Profile | None = None
     trace_tree: TraceTree | None = None
+    logs: Logs | None = None
 
 
 class RootCauseAnalysisOutput(BaseComponentOutput):

--- a/src/seer/automation/autofix/components/solution/models.py
+++ b/src/seer/automation/autofix/components/solution/models.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, ConfigDict, model_validator
 from seer.automation.agent.models import Message
 from seer.automation.autofix.components.root_cause.models import RootCauseAnalysisItem
 from seer.automation.component import BaseComponentOutput, BaseComponentRequest
-from seer.automation.models import EventDetails, Profile, TraceTree
+from seer.automation.models import EventDetails, Logs, Profile, TraceTree
 from seer.automation.summarize.issue import IssueSummary
 
 
@@ -63,6 +63,7 @@ class SolutionRequest(BaseComponentRequest):
     initial_memory: list[Message] = []
     profile: Profile | None = None
     trace_tree: TraceTree | None = None
+    logs: Logs | None = None
 
 
 class SolutionOutput(BaseComponentOutput):

--- a/src/seer/automation/autofix/models.py
+++ b/src/seer/automation/autofix/models.py
@@ -18,6 +18,7 @@ from seer.automation.models import (
     FilePatch,
     IssueDetails,
     Line,
+    Logs,
     Profile,
     RepoDefinition,
     TraceTree,
@@ -340,6 +341,7 @@ class AutofixRequest(BaseModel):
     issue_summary: IssueSummary | None = None
     profile: Profile | None = None
     trace_tree: TraceTree | None = None
+    logs: Logs | None = None
 
     options: AutofixRequestOptions = Field(default_factory=AutofixRequestOptions)
 

--- a/src/seer/automation/autofix/steps/root_cause_step.py
+++ b/src/seer/automation/autofix/steps/root_cause_step.py
@@ -96,6 +96,7 @@ class RootCauseStep(AutofixPipelineStep):
                 initial_memory=self.request.initial_memory,
                 profile=state.request.profile,
                 trace_tree=state.request.trace_tree,
+                logs=state.request.logs,
             )
         )
 

--- a/src/seer/automation/autofix/steps/solution_step.py
+++ b/src/seer/automation/autofix/steps/solution_step.py
@@ -89,6 +89,7 @@ class AutofixSolutionStep(AutofixPipelineStep):
                 initial_memory=self.request.initial_memory,
                 profile=state.request.profile,
                 trace_tree=state.request.trace_tree,
+                logs=state.request.logs,
             )
         )
 

--- a/src/seer/automation/models.py
+++ b/src/seer/automation/models.py
@@ -1005,7 +1005,7 @@ class Logs(BaseModel):
         )
 
         lines = []
-        for log in sorted_logs:
+        for log in sorted_logs[:50]:
             severity = f"[{log.severity}]" if log.severity else ""
             message = log.message or ""
             project = (


### PR DESCRIPTION
Receives logs from `sentry` in the initial Autofix request. Unused for now as I want to make sure it works. Then I'll follow up and include them in the prompt