### PR TITLE
fix(fixability): Train on PR-issue links, more synthetic negatives

### DIFF
--- a/src/seer/automation/summarize/issue.py
+++ b/src/seer/automation/summarize/issue.py
@@ -241,7 +241,7 @@ def run_fixability_score(
 
     with Session() as session:
         issue_summary.scores.fixability_score = fixability_score
-        issue_summary.scores.fixability_score_version = 3
+        issue_summary.scores.fixability_score_version = 4
         issue_summary.scores.is_fixable = is_fixable
         session.merge(issue_summary.to_db_state(request.group_id))
         session.commit()
@@ -261,6 +261,6 @@ def evaluate_autofixability(
         f"Possible cause: {issue_summary.possible_cause}"
     )
     score = autofixability_model.score(issue_summary_input)
-    is_fixable = score > 0.687  # 65th percentile on test set, which is a mix of many orgs' issues
+    is_fixable = score > 0.663  # This flag isn't used. Thresholds are in getsentry/sentry
     sentry_sdk.set_tag("is_fixable", is_fixable)
     return score, is_fixable

--- a/src/seer/inference_models.py
+++ b/src/seer/inference_models.py
@@ -53,7 +53,7 @@ def grouping_lookup() -> GroupingLookup:
 
 @deferred_loading("AUTOFIXABILITY_SCORING_ENABLED")
 def autofixability_model() -> AutofixabilityModel:
-    return AutofixabilityModel(model_path("autofixability_v3/embeddings"))
+    return AutofixabilityModel(model_path("autofixability_v4/embeddings"))
 
 
 @deferred_loading("ANOMALY_DETECTION_ENABLED")

--- a/tests/automation/autofix/test_autofix_context.py
+++ b/tests/automation/autofix/test_autofix_context.py
@@ -120,7 +120,7 @@ class TestAutofixContext(unittest.TestCase):
                     possible_cause_novelty=0.8,
                     is_fixable=True,
                     fixability_score=0.9,
-                    fixability_score_version=3,
+                    fixability_score_version=4,
                 ),
             )
             session.add(original.to_db_state(0))
@@ -141,7 +141,7 @@ class TestAutofixContext(unittest.TestCase):
             self.assertEqual(result.scores.possible_cause_novelty, 0.8)
             self.assertEqual(result.scores.is_fixable, True)
             self.assertEqual(result.scores.fixability_score, 0.9)
-            self.assertEqual(result.scores.fixability_score_version, 3)
+            self.assertEqual(result.scores.fixability_score_version, 4)
 
         with Session() as session:
             invalid_summary_data = {"bad data": "uh oh"}

--- a/tests/automation/summarize/test_issue.py
+++ b/tests/automation/summarize/test_issue.py
@@ -262,7 +262,7 @@ class TestFixabilityScore:
 
     @pytest.fixture
     def autofixability_model(self):
-        return AutofixabilityModel("models/autofixability_v3/embeddings")
+        return AutofixabilityModel("models/autofixability_v4/embeddings")
 
     @patch("seer.automation.summarize.issue.evaluate_autofixability")
     @patch("seer.automation.summarize.issue.Session")
@@ -312,7 +312,7 @@ class TestFixabilityScore:
         assert result.group_id == 123
         assert result.scores is not None
         assert result.scores.fixability_score == 0.75
-        assert result.scores.fixability_score_version == 3
+        assert result.scores.fixability_score_version == 4
         assert result.scores.is_fixable is True
         for score_name, score_value in scores_current.items():
             assert getattr(result.scores, score_name) == score_value
@@ -347,8 +347,7 @@ class TestFixabilityScore:
         assert 0 < score < 1
         assert isinstance(is_fixable, bool)
         if not can_use_model_stubs():
-            assert is_fixable
-            assert score == pytest.approx(0.7751516, abs=1e-5)
+            assert score == pytest.approx(0.60689825, abs=1e-5)
 
     def test_issue_summary_db_conversions(self, sample_issue_summary):
         # Test to_db_state
@@ -363,12 +362,12 @@ class TestFixabilityScore:
         # Update with fixability scores
         sample_issue_summary.scores.fixability_score = 0.85
         sample_issue_summary.scores.is_fixable = True
-        sample_issue_summary.scores.fixability_score_version = 3
+        sample_issue_summary.scores.fixability_score_version = 4
 
         db_state = sample_issue_summary.to_db_state(456)
         assert db_state.fixability_score == 0.85
         assert db_state.is_fixable is True
-        assert db_state.fixability_score_version == 3
+        assert db_state.fixability_score_version == 4
 
         # Test from_db_state
         db_summary = DbIssueSummary(
@@ -376,7 +375,7 @@ class TestFixabilityScore:
             summary=sample_issue_summary.model_dump(mode="json"),
             fixability_score=0.65,
             is_fixable=False,
-            fixability_score_version=3,
+            fixability_score_version=4,
         )
 
         loaded_summary = IssueSummaryWithScores.from_db_state(db_summary)
@@ -384,4 +383,4 @@ class TestFixabilityScore:
         assert loaded_summary.whats_wrong == sample_issue_summary.whats_wrong
         assert loaded_summary.scores.fixability_score == 0.65
         assert loaded_summary.scores.is_fixable is False
-        assert loaded_summary.scores.fixability_score_version == 3
+        assert loaded_summary.scores.fixability_score_version == 4


### PR DESCRIPTION
finetuned model on:
1. issue summaries from issues which had a PR linked to it
2. synthetic negatives from gemini-2.5-pro based on common classes of false positives for the current model, especially tricky string parsing, and errors caused by intentionally not handling a bad request. in its current state, issue summary often doesn't capture the latter well. but the idea is that training the model on them will make it more backwards compatible / less sensitive to what issue summaries look like if better signal comes out. can always retrain but wanted to do this anyway. my next experiment is to get better signal out of issue summary

[updated training notebook](https://github.com/getsentry/data-analysis/blob/main/autofix/issue_summary/autofixability/train.ipynb)