### PR TITLE
Changed the SQL command to avoid timeouts

### DIFF
--- a/src/migrations/versions/4a87188db505_migration.py
+++ b/src/migrations/versions/4a87188db505_migration.py
@@ -31,23 +31,14 @@ def upgrade():
 
     # Update the column with values from the 'value' column or default to current timestamp
     connection = op.get_bind()
-    results = connection.execute(sa.text("SELECT id, value FROM run_state")).fetchall()
-
-    for row in results:
-        id, value = row
-        try:
-            if value:
-                last_triggered_at = value.get("last_triggered_at") or datetime.utcnow()
-                created_at = value.get("created_at") or last_triggered_at
-        except json.JSONDecodeError:
-            logger.error(f"Invalid JSON for run_state {id}: {value}")
-            pass
-
-        # Update the row with new value
-        connection.execute(
-            sa.text("UPDATE run_state SET created_at = :created_at WHERE id = :id"),
-            {"id": id, "created_at": created_at},
+    connection.execute(
+        sa.text(
+            """
+            UPDATE run_state
+            SET created_at = COALESCE(created_at, last_triggered_at, NOW())
+        """
         )
+    )
 
     # Make the column non-nullable
     with op.batch_alter_table("run_state", schema=None) as batch_op:


### PR DESCRIPTION
+ I got this failed deploy in US with the migration failing due to a time out [link](https://deploy.getsentry.net/go/tab/build/detail/deploy-seer-us/575/run-migrations/1/run-migrations)
+ This makes the query more efficient and fixes some buggy logic in the migration script.
+ I am not sure how is succeeded in DE region