### PR TITLE
fix(autofix): Only keep valid files in repo download

### DIFF
--- a/src/seer/automation/codebase/repo_manager.py
+++ b/src/seer/automation/codebase/repo_manager.py
@@ -272,6 +272,7 @@ class RepoManager:
                         if rel_path not in valid_files:
                             try:
                                 os.remove(os.path.join(root, file))
+                                logger.info(f"Removed unsupported file from download: {rel_path}")
                             except Exception as e:
                                 logger.warning(f"Failed to remove file {rel_path}: {e}")
                     # Remove empty directories

--- a/src/seer/automation/codebase/repo_manager.py
+++ b/src/seer/automation/codebase/repo_manager.py
@@ -262,6 +262,25 @@ class RepoManager:
                 # Clean up the temporary extraction directory
                 shutil.rmtree(temp_extract_path)
 
+                # Remove all unsupported files
+                valid_files = self.repo_client.get_valid_file_paths()
+                for root, dirs, files in os.walk(self.repo_path, topdown=False):
+                    for file in files:
+                        # Compute relative path from repo_path
+                        rel_path = os.path.relpath(os.path.join(root, file), self.repo_path)
+                        rel_path = rel_path.replace(os.sep, "/")  # Normalize to forward slashes
+                        if rel_path not in valid_files:
+                            try:
+                                os.remove(os.path.join(root, file))
+                            except Exception as e:
+                                logger.warning(f"Failed to remove file {rel_path}: {e}")
+                    # Remove empty directories
+                    if root != self.repo_path and not os.listdir(root):
+                        try:
+                            os.rmdir(root)
+                        except Exception as e:
+                            logger.warning(f"Failed to remove directory {root}: {e}")
+
             # Clean up the tarball file
             if os.path.exists(tarfile_path):
                 os.unlink(tarfile_path)

--- a/tests/automation/codebase/test_repo_manager.py
+++ b/tests/automation/codebase/test_repo_manager.py
@@ -243,6 +243,8 @@ def test_initialize_tarball_download_success(repo_manager, mock_repo_client):
     fake_tar.__enter__.return_value = fake_tar
     fake_tar.getmembers.return_value = [MagicMock(name="file1.py")]
 
+    setattr(mock_repo_client, "get_valid_file_paths", MagicMock(return_value=["file1.py"]))
+
     with (
         patch("seer.automation.codebase.repo_manager.requests.get", return_value=mock_response),
         patch("seer.automation.codebase.repo_manager.tarfile.open", return_value=fake_tar),


### PR DESCRIPTION
Use `get_valid_file_paths` to remove unreadable files from downloaded repos. Often times the agent would get confused if `ripgrep` or `find` named a file that `expand_document` could not then access