### PR TITLE
chore(dynamic-sampling): parse public key from DSN

### DIFF
--- a/src/seer/bootup.py
+++ b/src/seer/bootup.py
@@ -53,7 +53,7 @@ class CustomTransport(HttpTransport):
     def capture_envelope(self, envelope):
         try:
             # Set public key to seer's public key
-            envelope.headers["trace"]["public_key"] = self.config.SENTRY_SEER_PUBLIC_KEY
+            envelope.headers["trace"]["public_key"] = sentry_sdk.utils.Dsn(self.config.SENTRY_DSN).public_key
         except KeyError:
             pass
 

--- a/src/seer/configuration.py
+++ b/src/seer/configuration.py
@@ -48,9 +48,6 @@ class AppConfig(BaseModel):
     SEER_VERSION_SHA: str = ""
 
     SENTRY_DSN: str = ""
-    SENTRY_SEER_PUBLIC_KEY: str = (
-        "8e99647e94e246f898eaa32eb7cb50e1"  # used to divert origin project from sentry to seer for dynamic sampling
-    )
     SENTRY_ENVIRONMENT: str = "production"
     SENTRY_REGION: str = ""
     SENTRY_PROFILES_SAMPLE_RATE: ParseFloat = 1.0


### PR DESCRIPTION
- sentry_sdk offers utils, including a Dsn class that parses the DSN into its components, so we can access the public key from there instead of putting it into an env variable of its own