### PR TITLE
fix(autofix): Claude use eu-west-4

### DIFF
--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -542,7 +542,7 @@ class AnthropicProvider(BaseLlmProvider):
         supported_models_on_global_endpoint: list[str] = [
             # NOTE: disabling global endpoint while we're on provisioned throughput
             # "claude-3-5-sonnet-v2@20241022",
-            "claude-3-7-sonnet@20250219",
+            # "claude-3-7-sonnet@20250219",
         ]
 
         # Use provided region if available, otherwise fall back to automatic region selection
@@ -556,7 +556,7 @@ class AnthropicProvider(BaseLlmProvider):
             app_config.SENTRY_REGION == "us"
             or self.model_name not in supported_models_on_global_endpoint
         ):
-            selected_region = "us-east5"
+            selected_region = "europe-west4"
         else:
             selected_region = "global"
 


### PR DESCRIPTION
The prior condition was incorrect, revert to original europe-west-4 for sonnet us:

https://github.com/getsentry/seer/blob/30a025c5835d3b96b1fde216ba809380bc8715e4/src/seer/automation/agent/client.py#L556-L564