### PR TITLE
feat(autofix): Switch to claude 4

### DIFF
--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -640,6 +640,15 @@ class AnthropicProvider(BaseLlmProvider):
                 "*": ["global", "us-east5"],
             },
         ),
+        LlmModelDefaultConfig(
+            match="claude-sonnet-4@20250514",
+            defaults=LlmProviderDefaults(temperature=0.0, max_tokens=100000),
+            region_preference={
+                "us": ["global", "us-east5"],
+                "de": ["europe-west1"],
+                "*": ["global", "us-east5"],
+            },
+        ),
     ]
 
     @staticmethod

--- a/src/seer/automation/autofix/components/coding/component.py
+++ b/src/seer/automation/autofix/components/coding/component.py
@@ -170,7 +170,7 @@ class CodingComponent(BaseComponent[CodingRequest, CodingOutput]):
             response = agent.run(
                 RunConfig(
                     system_prompt=CodingPrompts.format_system_msg(),
-                    model=AnthropicProvider.model("claude-3-7-sonnet@20250219"),
+                    model=AnthropicProvider.model("claude-sonnet-4@20250514"),
                     memory_storage_key="code",
                     run_name="Code",
                     max_iterations=64,

--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -98,7 +98,7 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
                 agent.tools = []
                 response = agent.run(
                     run_config=RunConfig(
-                        model=AnthropicProvider.model("claude-3-7-sonnet@20250219"),
+                        model=AnthropicProvider.model("claude-sonnet-4@20250514"),
                         prompt=RootCauseAnalysisPrompts.root_cause_proposal_msg(),
                         system_prompt=RootCauseAnalysisPrompts.format_system_msg(
                             repos_str=repos_str, mode="reasoning"


### PR DESCRIPTION
Upgrades the reasoner in root cause step and the coding step agent to claude 4 from claude 3.7.
Last eval indicated root cause scores went up by 5 points and coding became even more correct

Please double check my region configuration (it works locally)