### PR TITLE
fix(llm-client): Fallbacking should trigger on retryable exceptions

### DIFF
--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -68,7 +68,7 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
-DEFAULT_BACKOFF_MAX_TRIES = 4
+DEFAULT_BACKOFF_MAX_TRIES = 3
 
 
 @dataclass

--- a/src/seer/automation/agent/client.py
+++ b/src/seer/automation/agent/client.py
@@ -1817,6 +1817,10 @@ class LlmClient:
         if isinstance(exception, LlmStreamTimeoutError):
             return True
 
+        if provider.is_completion_exception_retryable(exception):
+            # We fallback on all retryable exceptions
+            return True
+
         if provider.provider_name == LlmProviderType.OPENAI:
             return isinstance(exception, openai.RateLimitError) or (
                 isinstance(exception, openai.APIStatusError) and exception.status_code in [429]

--- a/tests/automation/agent/test_client_fallback.py
+++ b/tests/automation/agent/test_client_fallback.py
@@ -1,7 +1,12 @@
 from unittest.mock import patch
+import json
 
 import pytest
+import anthropic
+import openai
+from google.genai.errors import ClientError, ServerError
 from pydantic import BaseModel
+from requests.exceptions import ChunkedEncodingError
 
 from seer.automation.agent.client import (
     AnthropicProvider,
@@ -12,8 +17,12 @@ from seer.automation.agent.client import (
 from seer.automation.agent.models import (
     LlmGenerateStructuredResponse,
     LlmGenerateTextResponse,
+    LlmNoCompletionTokensError,
     LlmProviderDefaults,
     LlmProviderType,
+    LlmStreamFirstTokenTimeoutError,
+    LlmStreamInactivityTimeoutError,
+    LlmStreamTimeoutError,
 )
 from seer.automation.agent.tools import FunctionTool
 
@@ -675,3 +684,497 @@ class TestEdgeCasesAndErrorHandling:
         assert resolved.temperature == 0.5  # From defaults
         assert resolved.max_tokens == 1000  # From defaults
         assert resolved.seed is None  # No default, remains None
+
+
+class TestFallbackExceptionHandling:
+    """Test the _is_fallback_worthy_exception method comprehensively"""
+
+    def setup_method(self):
+        """Set up test providers for each test"""
+        self.llm_client = LlmClient()
+        self.openai_provider = OpenAiProvider.model("gpt-4")
+        self.anthropic_provider = AnthropicProvider.model("claude-3-5-sonnet@20240620")
+        self.gemini_provider = GeminiProvider.model("gemini-1.5-pro")
+
+    def test_timeout_exceptions_are_fallback_worthy(self):
+        """Test that timeout errors trigger fallback regardless of provider"""
+        timeout_exceptions = [
+            LlmStreamTimeoutError("Timeout occurred"),
+            LlmStreamFirstTokenTimeoutError("First token timeout"),
+            LlmStreamInactivityTimeoutError("Inactivity timeout"),
+        ]
+
+        for exception in timeout_exceptions:
+            for provider in [self.openai_provider, self.anthropic_provider, self.gemini_provider]:
+                assert self.llm_client._is_fallback_worthy_exception(exception, provider) is True
+
+    def test_provider_retryable_exceptions_are_fallback_worthy(self):
+        """Test that provider-specific retryable exceptions trigger fallback"""
+        # Test OpenAI retryable exceptions
+        openai_retryable_exceptions = [
+            openai.InternalServerError("Internal server error"),
+        ]
+
+        for exception in openai_retryable_exceptions:
+            assert (
+                self.llm_client._is_fallback_worthy_exception(exception, self.openai_provider)
+                is True
+            )
+
+        # Test Anthropic retryable exceptions
+        anthropic_retryable_exceptions = [
+            anthropic.AnthropicError("Internal server error"),
+            anthropic.AnthropicError("not_found_error"),
+            anthropic.AnthropicError("404, 'message': 'Publisher Model"),
+            LlmNoCompletionTokensError("No completion tokens"),
+            Exception("incomplete chunked read"),
+        ]
+
+        for exception in anthropic_retryable_exceptions:
+            assert (
+                self.llm_client._is_fallback_worthy_exception(exception, self.anthropic_provider)
+                is True
+            )
+
+        # Test Gemini retryable exceptions
+        gemini_retryable_exceptions = [
+            ServerError("Server error"),
+            ClientError("TLS/SSL connection has been closed"),
+            ClientError("Max retries exceeded with url"),
+            ClientError("Internal error"),
+            ClientError("499 CANCELLED"),
+            LlmNoCompletionTokensError("No completion tokens"),
+            ChunkedEncodingError("Connection broken"),
+            json.JSONDecodeError("Invalid JSON", "", 0),
+            Exception("incomplete chunked read"),
+        ]
+
+        for exception in gemini_retryable_exceptions:
+            assert (
+                self.llm_client._is_fallback_worthy_exception(exception, self.gemini_provider)
+                is True
+            )
+
+    def test_rate_limit_exceptions_are_fallback_worthy(self):
+        """Test that rate limit exceptions trigger fallback"""
+        # OpenAI rate limits
+        openai_rate_limits = [
+            openai.RateLimitError("Rate limit exceeded", response=None, body=None),
+        ]
+
+        # Create a mock APIStatusError for OpenAI 429
+        class MockOpenAIStatusError(openai.APIStatusError):
+            def __init__(self, status_code):
+                self.status_code = status_code
+                super().__init__("Rate limited", response=None, body=None)
+
+        openai_rate_limits.append(MockOpenAIStatusError(429))
+
+        for exception in openai_rate_limits:
+            assert (
+                self.llm_client._is_fallback_worthy_exception(exception, self.openai_provider)
+                is True
+            )
+
+        # Anthropic rate limits
+        anthropic_rate_limits = [
+            anthropic.RateLimitError("Rate limit exceeded", response=None, body=None),
+        ]
+
+        # Create a mock APIStatusError for Anthropic 429
+        class MockAnthropicStatusError(anthropic.APIStatusError):
+            def __init__(self, status_code):
+                self.status_code = status_code
+                super().__init__("Rate limited", response=None, body=None)
+
+        anthropic_rate_limits.append(MockAnthropicStatusError(429))
+
+        for exception in anthropic_rate_limits:
+            assert (
+                self.llm_client._is_fallback_worthy_exception(exception, self.anthropic_provider)
+                is True
+            )
+
+        # Gemini rate limits
+        class MockGeminiClientError(ClientError):
+            def __init__(self, code):
+                self.code = code
+                super().__init__("Rate limited")
+
+        gemini_rate_limits = [
+            MockGeminiClientError(429),
+        ]
+
+        for exception in gemini_rate_limits:
+            assert (
+                self.llm_client._is_fallback_worthy_exception(exception, self.gemini_provider)
+                is True
+            )
+
+    def test_anthropic_specific_fallback_messages(self):
+        """Test Anthropic-specific error messages that trigger fallback"""
+        anthropic_fallback_messages = [
+            "overloaded_error",
+            "Quota exceeded",
+        ]
+
+        for message in anthropic_fallback_messages:
+            exception = Exception(message)
+            assert (
+                self.llm_client._is_fallback_worthy_exception(exception, self.anthropic_provider)
+                is True
+            )
+
+    def test_gemini_specific_fallback_messages(self):
+        """Test Gemini-specific error messages that trigger fallback"""
+        gemini_fallback_messages = [
+            "Resource exhausted. Please try again later.",
+            "429 RESOURCE_EXHAUSTED",
+        ]
+
+        for message in gemini_fallback_messages:
+            exception = Exception(message)
+            assert (
+                self.llm_client._is_fallback_worthy_exception(exception, self.gemini_provider)
+                is True
+            )
+
+    def test_non_fallback_worthy_exceptions(self):
+        """Test that non-retryable exceptions don't trigger fallback"""
+        non_fallback_exceptions = [
+            ValueError("Invalid input"),
+            TypeError("Type error"),
+            RuntimeError("Runtime error"),
+            openai.BadRequestError("Bad request", response=None, body=None),
+            anthropic.BadRequestError("Bad request", response=None, body=None),
+        ]
+
+        for exception in non_fallback_exceptions:
+            for provider in [self.openai_provider, self.anthropic_provider, self.gemini_provider]:
+                assert self.llm_client._is_fallback_worthy_exception(exception, provider) is False
+
+    def test_openai_non_429_status_codes(self):
+        """Test that OpenAI API errors with non-429 status codes don't trigger fallback"""
+
+        class MockOpenAIStatusError(openai.APIStatusError):
+            def __init__(self, status_code):
+                self.status_code = status_code
+                super().__init__("API Error", response=None, body=None)
+
+        non_fallback_status_codes = [400, 401, 403, 404, 500, 502, 503]
+
+        for status_code in non_fallback_status_codes:
+            exception = MockOpenAIStatusError(status_code)
+            assert (
+                self.llm_client._is_fallback_worthy_exception(exception, self.openai_provider)
+                is False
+            )
+
+    def test_anthropic_non_429_status_codes(self):
+        """Test that Anthropic API errors with non-429 status codes don't trigger fallback"""
+
+        class MockAnthropicStatusError(anthropic.APIStatusError):
+            def __init__(self, status_code):
+                self.status_code = status_code
+                super().__init__("API Error", response=None, body=None)
+
+        non_fallback_status_codes = [400, 401, 403, 404, 500, 502, 503]
+
+        for status_code in non_fallback_status_codes:
+            exception = MockAnthropicStatusError(status_code)
+            assert (
+                self.llm_client._is_fallback_worthy_exception(exception, self.anthropic_provider)
+                is False
+            )
+
+    def test_gemini_non_429_status_codes(self):
+        """Test that Gemini API errors with non-429 status codes don't trigger fallback"""
+
+        class MockGeminiClientError(ClientError):
+            def __init__(self, code):
+                self.code = code
+                super().__init__("API Error")
+
+        non_fallback_status_codes = [400, 401, 403, 404, 500, 502, 503]
+
+        for status_code in non_fallback_status_codes:
+            exception = MockGeminiClientError(status_code)
+            assert (
+                self.llm_client._is_fallback_worthy_exception(exception, self.gemini_provider)
+                is False
+            )
+
+    def test_provider_specific_retryable_behavior(self):
+        """Test that provider-specific retryable logic is respected"""
+        # Create a custom exception that only OpenAI considers retryable
+        openai_specific_exception = openai.InternalServerError("OpenAI internal error")
+
+        # Should be fallback-worthy for OpenAI (because is_completion_exception_retryable returns True)
+        assert (
+            self.llm_client._is_fallback_worthy_exception(
+                openai_specific_exception, self.openai_provider
+            )
+            is True
+        )
+
+        # Should not be fallback-worthy for other providers (not their retryable exception types)
+        assert (
+            self.llm_client._is_fallback_worthy_exception(
+                openai_specific_exception, self.anthropic_provider
+            )
+            is False
+        )
+        assert (
+            self.llm_client._is_fallback_worthy_exception(
+                openai_specific_exception, self.gemini_provider
+            )
+            is False
+        )
+
+    def test_cross_provider_timeout_exceptions(self):
+        """Test that timeout exceptions work consistently across all providers"""
+        timeout_exception = LlmStreamTimeoutError("Stream timeout")
+
+        for provider in [self.openai_provider, self.anthropic_provider, self.gemini_provider]:
+            assert (
+                self.llm_client._is_fallback_worthy_exception(timeout_exception, provider) is True
+            )
+
+    def test_mixed_provider_specific_and_general_rules(self):
+        """Test the precedence of general vs provider-specific rules"""
+        # LlmStreamTimeoutError should always be fallback-worthy regardless of provider
+        timeout_error = LlmStreamTimeoutError("Timeout")
+
+        for provider in [self.openai_provider, self.anthropic_provider, self.gemini_provider]:
+            assert self.llm_client._is_fallback_worthy_exception(timeout_error, provider) is True
+
+        # Provider-specific retryable exceptions should also be fallback-worthy
+        with patch.object(
+            self.openai_provider, "is_completion_exception_retryable", return_value=True
+        ):
+            custom_exception = Exception("Custom retryable error")
+            assert (
+                self.llm_client._is_fallback_worthy_exception(
+                    custom_exception, self.openai_provider
+                )
+                is True
+            )
+
+        with patch.object(
+            self.openai_provider, "is_completion_exception_retryable", return_value=False
+        ):
+            custom_exception = Exception("Custom non-retryable error")
+            assert (
+                self.llm_client._is_fallback_worthy_exception(
+                    custom_exception, self.openai_provider
+                )
+                is False
+            )
+
+    def test_edge_case_empty_exception_messages(self):
+        """Test behavior with empty or None exception messages"""
+        empty_exceptions = [
+            Exception(""),
+            Exception(),
+            ValueError(""),
+        ]
+
+        for exception in empty_exceptions:
+            for provider in [self.openai_provider, self.anthropic_provider, self.gemini_provider]:
+                # Should default to False for empty messages (no special fallback text found)
+                assert self.llm_client._is_fallback_worthy_exception(exception, provider) is False
+
+    def test_case_sensitivity_in_error_messages(self):
+        """Test that error message matching is case sensitive"""
+        # Test case sensitivity for Anthropic messages
+        case_sensitive_tests = [
+            ("overloaded_error", True),  # Exact match should work
+            ("OVERLOADED_ERROR", False),  # Different case should not work
+            ("Overloaded_Error", False),  # Mixed case should not work
+            ("quota exceeded", False),  # Different case should not work
+            ("Quota exceeded", True),  # Exact match should work
+        ]
+
+        for message, expected in case_sensitive_tests:
+            exception = Exception(message)
+            result = self.llm_client._is_fallback_worthy_exception(
+                exception, self.anthropic_provider
+            )
+            assert result is expected, f"Message '{message}' should return {expected}"
+
+    def test_partial_message_matching(self):
+        """Test that error messages work with partial string matching"""
+        # Test that messages containing the fallback text work
+        anthropic_partial_tests = [
+            "Server is experiencing overloaded_error right now",
+            "API Quota exceeded for this request",
+            "Multiple errors including overloaded_error occurred",
+        ]
+
+        for message in anthropic_partial_tests:
+            exception = Exception(message)
+            assert (
+                self.llm_client._is_fallback_worthy_exception(exception, self.anthropic_provider)
+                is True
+            )
+
+        gemini_partial_tests = [
+            "Error: Resource exhausted. Please try again later. Code: 429",
+            "API returned: 429 RESOURCE_EXHAUSTED - rate limit hit",
+        ]
+
+        for message in gemini_partial_tests:
+            exception = Exception(message)
+            assert (
+                self.llm_client._is_fallback_worthy_exception(exception, self.gemini_provider)
+                is True
+            )
+
+
+class TestFallbackExceptionIntegration:
+    """Integration tests for fallback behavior with real exceptions"""
+
+    def setup_method(self):
+        """Set up test client and providers"""
+        self.llm_client = LlmClient()
+        self.openai_provider = OpenAiProvider.model("gpt-4")
+        self.anthropic_provider = AnthropicProvider.model("claude-3-5-sonnet@20240620")
+        self.gemini_provider = GeminiProvider.model("gemini-1.5-pro")
+
+    def test_fallback_on_timeout_exception(self):
+        """Test that timeout exceptions trigger fallback to next model"""
+        models = [self.openai_provider, self.anthropic_provider]
+
+        call_count = 0
+
+        def mock_operation(model):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First call fails with timeout
+                raise LlmStreamTimeoutError("First model timed out")
+            else:
+                # Second call succeeds
+                return f"Success with {model.provider_name}"
+
+        result = self.llm_client._execute_with_fallback(
+            models=models, operation_name="Test Operation", operation_func=mock_operation
+        )
+
+        assert result == f"Success with {LlmProviderType.ANTHROPIC}"
+        assert call_count == 2  # Both models were tried
+
+    def test_fallback_on_provider_retryable_exception(self):
+        """Test that provider-specific retryable exceptions trigger fallback"""
+        models = [self.openai_provider, self.anthropic_provider]
+
+        call_count = 0
+
+        def mock_operation(model):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First call fails with OpenAI internal server error (retryable)
+                raise openai.InternalServerError("OpenAI server error")
+            else:
+                # Second call succeeds
+                return f"Success with {model.provider_name}"
+
+        result = self.llm_client._execute_with_fallback(
+            models=models, operation_name="Test Operation", operation_func=mock_operation
+        )
+
+        assert result == f"Success with {LlmProviderType.ANTHROPIC}"
+        assert call_count == 2  # Both models were tried
+
+    def test_no_fallback_on_non_retryable_exception(self):
+        """Test that non-retryable exceptions don't trigger fallback"""
+        models = [self.openai_provider, self.anthropic_provider]
+
+        call_count = 0
+
+        def mock_operation(model):
+            nonlocal call_count
+            call_count += 1
+            # Fail with non-retryable exception
+            raise ValueError("Non-retryable error")
+
+        with pytest.raises(ValueError, match="Non-retryable error"):
+            self.llm_client._execute_with_fallback(
+                models=models, operation_name="Test Operation", operation_func=mock_operation
+            )
+
+        assert call_count == 1  # Only first model was tried
+
+    def test_fallback_on_rate_limit_exception(self):
+        """Test that rate limit exceptions trigger fallback"""
+        models = [self.openai_provider, self.anthropic_provider]
+
+        call_count = 0
+
+        def mock_operation(model):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First call fails with rate limit
+                raise openai.RateLimitError("Rate limit exceeded", response=None, body=None)
+            else:
+                # Second call succeeds
+                return f"Success with {model.provider_name}"
+
+        result = self.llm_client._execute_with_fallback(
+            models=models, operation_name="Test Operation", operation_func=mock_operation
+        )
+
+        assert result == f"Success with {LlmProviderType.ANTHROPIC}"
+        assert call_count == 2  # Both models were tried
+
+    def test_all_models_fail_with_fallback_exceptions(self):
+        """Test behavior when all models fail with fallback-worthy exceptions"""
+        models = [self.openai_provider, self.anthropic_provider]
+
+        call_count = 0
+
+        def mock_operation(model):
+            nonlocal call_count
+            call_count += 1
+            # All calls fail with retryable exceptions
+            if model.provider_name == LlmProviderType.OPENAI:
+                raise openai.RateLimitError("OpenAI rate limit", response=None, body=None)
+            else:
+                raise anthropic.RateLimitError("Anthropic rate limit", response=None, body=None)
+
+        # Should raise the final exception since all models failed
+        with pytest.raises(anthropic.RateLimitError, match="Anthropic rate limit"):
+            self.llm_client._execute_with_fallback(
+                models=models, operation_name="Test Operation", operation_func=mock_operation
+            )
+
+        assert call_count == 2  # Both models were tried
+
+    def test_provider_specific_exception_isolation(self):
+        """Test that provider-specific exceptions only affect the correct provider"""
+        models = [self.openai_provider, self.anthropic_provider, self.gemini_provider]
+
+        call_count = 0
+
+        def mock_operation(model):
+            nonlocal call_count
+            call_count += 1
+
+            if call_count == 1:
+                # OpenAI-specific retryable exception
+                raise openai.InternalServerError("OpenAI error")
+            elif call_count == 2:
+                # Success on second provider
+                return f"Success with {model.provider_name}"
+            else:
+                # Should not reach third provider
+                raise Exception("Should not reach here")
+
+        result = self.llm_client._execute_with_fallback(
+            models=models, operation_name="Test Operation", operation_func=mock_operation
+        )
+
+        assert result == f"Success with {LlmProviderType.ANTHROPIC}"
+        assert call_count == 2  # Only first two models were tried

--- a/tests/automation/agent/test_client_fallback.py
+++ b/tests/automation/agent/test_client_fallback.py
@@ -1,9 +1,9 @@
-from unittest.mock import patch, Mock
 import json
+from unittest.mock import Mock, patch
 
-import pytest
 import anthropic
 import openai
+import pytest
 from google.genai.errors import ClientError, ServerError
 from pydantic import BaseModel
 from requests.exceptions import ChunkedEncodingError


### PR DESCRIPTION
We weren't correctly fallbacking on retryable exceptions. Any exception that's retryable should be fallbackable.