### PR TITLE
chore(autofix): Remove redundant repo downloads

### DIFF
--- a/src/seer/automation/autofix/components/root_cause/component.py
+++ b/src/seer/automation/autofix/components/root_cause/component.py
@@ -31,162 +31,156 @@ class RootCauseAnalysisComponent(BaseComponent[RootCauseAnalysisRequest, RootCau
     def invoke(
         self,
         request: RootCauseAnalysisRequest,
+        tools: BaseTools,
         llm_client: LlmClient = injected,
         config: AppConfig = injected,
     ) -> RootCauseAnalysisOutput:
-        with BaseTools(self.context) as tools:
-            state = self.context.state.get()
+        state = self.context.state.get()
 
-            readable_repos = state.readable_repos
-            unreadable_repos = state.unreadable_repos
+        readable_repos = state.readable_repos
+        unreadable_repos = state.unreadable_repos
 
-            sentry_sdk.set_tag("is_rethinking", len(request.initial_memory) > 0)
+        sentry_sdk.set_tag("is_rethinking", len(request.initial_memory) > 0)
 
-            agent = AutofixAgent(
-                tools=(tools.get_tools(can_access_repos=bool(readable_repos))),
-                config=AgentConfig(
-                    interactive=True,
+        agent = AutofixAgent(
+            tools=(tools.get_tools(can_access_repos=bool(readable_repos))),
+            config=AgentConfig(
+                interactive=True,
+            ),
+            context=self.context,
+            memory=request.initial_memory,
+            name="Root Cause Analysis Agent",
+        )
+
+        repos_str = format_repo_prompt(readable_repos, unreadable_repos)
+
+        try:
+            de_discovery_config = {
+                "model": AnthropicProvider.model("claude-sonnet-4@20250514"),
+                "max_tokens": 8192,
+            }
+            us_discovery_config = {
+                "models": [
+                    GeminiProvider.model(
+                        "gemini-2.5-flash-preview-04-17",
+                        region="us-central1",  # Only try in this region for this model.
+                    ),
+                    GeminiProvider.model("gemini-2.5-flash-preview-05-20"),
+                ],
+                "max_tokens": 32000,
+            }
+
+            response = agent.run(
+                run_config=RunConfig(
+                    prompt=(
+                        RootCauseAnalysisPrompts.format_default_msg(
+                            event=request.event_details.format_event(),
+                            summary=request.summary,
+                            code_map=request.profile,
+                            instruction=request.instruction,
+                            trace_tree=request.trace_tree,
+                            logs=request.logs,
+                        )
+                        if not request.initial_memory
+                        else None
+                    ),
+                    system_prompt=RootCauseAnalysisPrompts.format_system_msg(
+                        repos_str=repos_str, mode="context"
+                    ),
+                    max_iterations=64,
+                    memory_storage_key="root_cause_analysis",
+                    run_name="Root Cause Discovery",
+                    temperature=0.0,
+                    **(
+                        de_discovery_config if config.SENTRY_REGION == "de" else us_discovery_config
+                    ),
                 ),
-                context=self.context,
-                memory=request.initial_memory,
-                name="Root Cause Analysis Agent",
             )
 
-            repos_str = format_repo_prompt(readable_repos, unreadable_repos)
+            if not response:
+                self.context.store_memory("root_cause_analysis", agent.memory)
+                return RootCauseAnalysisOutput(
+                    causes=[],
+                    termination_reason="Something went wrong when Autofix was running.",
+                )
 
-            try:
-                de_discovery_config = {
-                    "model": AnthropicProvider.model("claude-sonnet-4@20250514"),
-                    "max_tokens": 8192,
-                }
-                us_discovery_config = {
-                    "models": [
-                        GeminiProvider.model(
-                            "gemini-2.5-flash-preview-04-17",
-                            region="us-central1",  # Only try in this region for this model.
-                        ),
-                        GeminiProvider.model("gemini-2.5-flash-preview-05-20"),
-                    ],
-                    "max_tokens": 32000,
-                }
+            self.context.event_manager.add_log("Simulating profound thought...")
 
-                response = agent.run(
-                    run_config=RunConfig(
-                        prompt=(
-                            RootCauseAnalysisPrompts.format_default_msg(
-                                event=request.event_details.format_event(),
-                                summary=request.summary,
-                                code_map=request.profile,
-                                instruction=request.instruction,
-                                trace_tree=request.trace_tree,
-                                logs=request.logs,
-                            )
-                            if not request.initial_memory
-                            else None
-                        ),
-                        system_prompt=RootCauseAnalysisPrompts.format_system_msg(
-                            repos_str=repos_str, mode="context"
-                        ),
-                        max_iterations=64,
-                        memory_storage_key="root_cause_analysis",
-                        run_name="Root Cause Discovery",
-                        temperature=0.0,
-                        **(
-                            de_discovery_config
-                            if config.SENTRY_REGION == "de"
-                            else us_discovery_config
-                        ),
+            # reason to propose final root cause
+            agent.tools = []
+            response = agent.run(
+                run_config=RunConfig(
+                    model=AnthropicProvider.model("claude-sonnet-4@20250514"),
+                    prompt=RootCauseAnalysisPrompts.root_cause_proposal_msg(),
+                    system_prompt=RootCauseAnalysisPrompts.format_system_msg(
+                        repos_str=repos_str, mode="reasoning"
                     ),
+                    memory_storage_key="root_cause_analysis",
+                    run_name="Root Cause Proposal",
+                    temperature=1.0,
+                    reasoning_effort="high",
+                    max_tokens=32000,
+                )
+            )
+
+            if not response:
+                self.context.store_memory("root_cause_analysis", agent.memory)
+                return RootCauseAnalysisOutput(
+                    causes=[],
+                    termination_reason="Something went wrong when Autofix was running.",
                 )
 
-                if not response:
-                    self.context.store_memory("root_cause_analysis", agent.memory)
-                    return RootCauseAnalysisOutput(
-                        causes=[],
-                        termination_reason="Something went wrong when Autofix was running.",
-                    )
+            if "<NO_ROOT_CAUSES>" in response:
+                reason = response.split("<NO_ROOT_CAUSES>")[1].strip()
+                if "</NO_ROOT_CAUSES>" in reason:
+                    reason = reason.split("</NO_ROOT_CAUSES>")[0].strip()
+                return RootCauseAnalysisOutput(causes=[], termination_reason=reason)
 
-                self.context.event_manager.add_log("Simulating profound thought...")
+            self.context.event_manager.add_log("Arranging data in a way that looks intentional...")
 
-                # reason to propose final root cause
-                agent.tools = []
-                response = agent.run(
-                    run_config=RunConfig(
-                        model=AnthropicProvider.model("claude-sonnet-4@20250514"),
-                        prompt=RootCauseAnalysisPrompts.root_cause_proposal_msg(),
-                        system_prompt=RootCauseAnalysisPrompts.format_system_msg(
-                            repos_str=repos_str, mode="reasoning"
-                        ),
-                        memory_storage_key="root_cause_analysis",
-                        run_name="Root Cause Proposal",
-                        temperature=1.0,
-                        reasoning_effort="high",
-                        max_tokens=32000,
-                    )
-                )
+            de_formatter_config = {
+                "model": GeminiProvider.model("gemini-2.0-flash-001"),
+                "max_tokens": 8192,
+            }
 
-                if not response:
-                    self.context.store_memory("root_cause_analysis", agent.memory)
-                    return RootCauseAnalysisOutput(
-                        causes=[],
-                        termination_reason="Something went wrong when Autofix was running.",
-                    )
-
-                if "<NO_ROOT_CAUSES>" in response:
-                    reason = response.split("<NO_ROOT_CAUSES>")[1].strip()
-                    if "</NO_ROOT_CAUSES>" in reason:
-                        reason = reason.split("</NO_ROOT_CAUSES>")[0].strip()
-                    return RootCauseAnalysisOutput(causes=[], termination_reason=reason)
-
-                self.context.event_manager.add_log(
-                    "Arranging data in a way that looks intentional..."
-                )
-
-                de_formatter_config = {
-                    "model": GeminiProvider.model("gemini-2.0-flash-001"),
-                    "max_tokens": 8192,
-                }
-
-                us_formatter_config = {
-                    "models": [
-                        GeminiProvider.model(
-                            "gemini-2.5-flash-preview-04-17",
-                            region="us-central1",  # Only try in this region for this model.
-                        ),
-                        GeminiProvider.model("gemini-2.5-flash-preview-05-20"),
-                    ],
-                    "max_tokens": 32000,
-                }
-
-                formatted_response = llm_client.generate_structured(
-                    messages=agent.memory,
-                    prompt=RootCauseAnalysisPrompts.root_cause_formatter_msg(),
-                    response_format=MultipleRootCauseAnalysisOutputPrompt,
-                    run_name="Root Cause Extraction & Formatting",
-                    **(
-                        de_formatter_config if config.SENTRY_REGION == "de" else us_formatter_config
+            us_formatter_config = {
+                "models": [
+                    GeminiProvider.model(
+                        "gemini-2.5-flash-preview-04-17",
+                        region="us-central1",  # Only try in this region for this model.
                     ),
+                    GeminiProvider.model("gemini-2.5-flash-preview-05-20"),
+                ],
+                "max_tokens": 32000,
+            }
+
+            formatted_response = llm_client.generate_structured(
+                messages=agent.memory,
+                prompt=RootCauseAnalysisPrompts.root_cause_formatter_msg(),
+                response_format=MultipleRootCauseAnalysisOutputPrompt,
+                run_name="Root Cause Extraction & Formatting",
+                **(de_formatter_config if config.SENTRY_REGION == "de" else us_formatter_config),
+            )
+
+            if not formatted_response or not getattr(formatted_response, "parsed", None):
+                return RootCauseAnalysisOutput(
+                    causes=[],
+                    termination_reason="Something went wrong when Autofix was running.",
                 )
 
-                if not formatted_response or not getattr(formatted_response, "parsed", None):
-                    return RootCauseAnalysisOutput(
-                        causes=[],
-                        termination_reason="Something went wrong when Autofix was running.",
-                    )
+            parsed = formatted_response.parsed
+            cause = getattr(parsed, "cause", None)
+            if not cause:
+                return RootCauseAnalysisOutput(
+                    causes=[],
+                    termination_reason="Something went wrong when Autofix was running.",
+                )
 
-                parsed = formatted_response.parsed
-                cause = getattr(parsed, "cause", None)
-                if not cause:
-                    return RootCauseAnalysisOutput(
-                        causes=[],
-                        termination_reason="Something went wrong when Autofix was running.",
-                    )
+            cause_model = cause.to_model()
+            cause_model.id = 0
+            causes = [cause_model]
+            return RootCauseAnalysisOutput(causes=causes, termination_reason=None)
 
-                cause_model = cause.to_model()
-                cause_model.id = 0
-                causes = [cause_model]
-                return RootCauseAnalysisOutput(causes=causes, termination_reason=None)
-
-            finally:
-                with self.context.state.update() as cur:
-                    cur.usage += agent.usage
+        finally:
+            with self.context.state.update() as cur:
+                cur.usage += agent.usage

--- a/src/seer/automation/autofix/steps/solution_step.py
+++ b/src/seer/automation/autofix/steps/solution_step.py
@@ -15,6 +15,7 @@ from seer.automation.autofix.config import (
 )
 from seer.automation.autofix.models import AutofixStatus, CommentThread
 from seer.automation.autofix.steps.steps import AutofixPipelineStep
+from seer.automation.autofix.tools.tools import BaseTools
 from seer.automation.models import EventDetails
 from seer.automation.pipeline import PipelineStepTaskRequest
 from seer.automation.utils import make_kill_signal
@@ -52,7 +53,7 @@ class AutofixSolutionStep(AutofixPipelineStep):
 
     @observe(name="Autofix - Solution Step")
     @sentry_sdk.trace
-    def _invoke(self, **kwargs):
+    def _invoke(self, shared_tools: BaseTools | None = None, **kwargs):
         super()._invoke()
 
         self.logger.info("Executing Autofix - Solution Step")
@@ -91,7 +92,8 @@ class AutofixSolutionStep(AutofixPipelineStep):
                 initial_memory=self.request.initial_memory,
                 profile=state.request.profile,
                 trace_tree=state.request.trace_tree,
-            )
+            ),
+            tools=shared_tools,
         )
 
         if solution_output is None:

--- a/src/seer/automation/autofix/tools/tools.py
+++ b/src/seer/automation/autofix/tools/tools.py
@@ -52,6 +52,7 @@ class BaseTools:
         retrieval_top_k: int = 8,
         repo_client_type: RepoClientType = RepoClientType.READ,
     ):
+        print("INITIALIZING TOOLS")
         self.context = context
         self.retrieval_top_k = retrieval_top_k
         self.repo_client_type = repo_client_type
@@ -60,6 +61,7 @@ class BaseTools:
         self._download_repos()
 
     def _download_repos(self):
+        print("DOWNLOADING REPOS")
         repo_names = self._get_repo_names()
         if not repo_names:
             return
@@ -400,6 +402,7 @@ class BaseTools:
     @sentry_sdk.trace
     def cleanup(self):
         """Clean up all repository clients."""
+        print("CLEANING UP TOOLS")
         for repo_name, local_client in list(self.repo_managers.items()):
             try:
                 local_client.cleanup()
@@ -1322,6 +1325,18 @@ class BaseTools:
 
 
 class SemanticSearchTools(BaseTools):
+    def __init__(
+        self,
+        context: AutofixContext | CodegenContext,
+        retrieval_top_k: int = 8,
+        repo_client_type: RepoClientType = RepoClientType.READ,
+    ):
+        print("INITIALIZING SEMANTIC SEARCH TOOLS (no repo downloads)")
+        self.context = context
+        self.retrieval_top_k = retrieval_top_k
+        self.repo_client_type = repo_client_type
+        self.repo_managers = {}
+
     def get_tools(
         self, can_access_repos: bool = True, include_claude_tools: bool = False
     ) -> list[ClaudeTool | FunctionTool]:


### PR DESCRIPTION
- directly invokes the solution step from the root cause step and passes the same instance of `BaseTools` to avoid re-downloading repos and to preserve functools caches
- rethinking still works because it can still create a new `BaseTools` instance when necessary
- remove repo downloads from semantic search agent's tools because they were unused anyway

(a lot of the changes in the diff are just indentation)